### PR TITLE
Split init / exec of tmux_cmd for debuggability

### DIFF
--- a/libtmux/common.py
+++ b/libtmux/common.py
@@ -165,7 +165,12 @@ class tmux_cmd:
 
     .. code-block:: python
 
-        proc = tmux_cmd('new-session', '-s%' % 'my session')
+        c = tmux_cmd('new-session', '-s%' % 'my session')
+
+        # You can actually see the command in the .cmd attribute
+        print(c.cmd)
+
+        proc = c.execute()
 
         if proc.stderr:
             raise exc.LibTmuxException(
@@ -205,6 +210,8 @@ class tmux_cmd:
 
         self.cmd = cmd
 
+    def execute(self):
+        cmd = self.cmd
         try:
             self.process = subprocess.Popen(
                 cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE
@@ -229,6 +236,7 @@ class tmux_cmd:
                 self.stdout = self.stderr[0]
 
         logger.debug("self.stdout for {}: \n{}".format(" ".join(cmd), self.stdout))
+        return self
 
 
 class TmuxMappingObject(MutableMapping):
@@ -462,7 +470,7 @@ def get_version() -> LooseVersion:
     :class:`distutils.version.LooseVersion`
         tmux version according to :func:`libtmux.common.which`'s tmux
     """
-    proc = tmux_cmd("-V")
+    proc = tmux_cmd("-V").execute()
     if proc.stderr:
         if proc.stderr[0] == "tmux: unknown option -- V":
             if sys.platform.startswith("openbsd"):  # openbsd has no tmux -V

--- a/libtmux/server.py
+++ b/libtmux/server.py
@@ -127,7 +127,7 @@ class Server(TmuxRelationalObject, EnvironmentMixin):
             else:
                 raise ValueError("Server.colors must equal 88 or 256")
 
-        return tmux_cmd(*args, **kwargs)
+        return tmux_cmd(*args, **kwargs).execute()
 
     def _list_sessions(self) -> t.List[SessionDict]:
         """

--- a/libtmux/server.py
+++ b/libtmux/server.py
@@ -13,11 +13,11 @@ from .common import (
     EnvironmentMixin,
     PaneDict,
     SessionDict,
+    TmuxCommand,
     TmuxRelationalObject,
     WindowDict,
     has_gte_version,
     session_check_name,
-    tmux_cmd,
 )
 from .session import Session
 
@@ -127,7 +127,7 @@ class Server(TmuxRelationalObject, EnvironmentMixin):
             else:
                 raise ValueError("Server.colors must equal 88 or 256")
 
-        return tmux_cmd(*args, **kwargs).execute()
+        return TmuxCommand(*args, **kwargs).execute()
 
     def _list_sessions(self) -> t.List[SessionDict]:
         """
@@ -136,7 +136,7 @@ class Server(TmuxRelationalObject, EnvironmentMixin):
         Retrieved from ``$ tmux(1) list-sessions`` stdout.
 
         The :py:obj:`list` is derived from ``stdout`` in
-        :class:`common.tmux_cmd` which wraps :py:class:`subprocess.Popen`.
+        :class:`common.TmuxCommand` which wraps :py:class:`subprocess.Popen`.
 
         Returns
         -------
@@ -199,7 +199,7 @@ class Server(TmuxRelationalObject, EnvironmentMixin):
         Retrieved from ``$ tmux(1) list-windows`` stdout.
 
         The :py:obj:`list` is derived from ``stdout`` in
-        :class:`common.tmux_cmd` which wraps :py:class:`subprocess.Popen`.
+        :class:`common.TmuxCommand` which wraps :py:class:`subprocess.Popen`.
 
         Returns
         -------
@@ -261,7 +261,7 @@ class Server(TmuxRelationalObject, EnvironmentMixin):
         Retrieved from ``$ tmux(1) list-panes`` stdout.
 
         The :py:obj:`list` is derived from ``stdout`` in
-        :class:`util.tmux_cmd` which wraps :py:class:`subprocess.Popen`.
+        :class:`util.TmuxCommand` which wraps :py:class:`subprocess.Popen`.
 
         Returns
         -------

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -33,6 +33,9 @@ def test_allows_master_version(monkeypatch):
             stdout = ["tmux master"]
             stderr = None
 
+            def execute(self):
+                return self
+
         return Hi()
 
     monkeypatch.setattr(libtmux.common, "tmux_cmd", mock_tmux_cmd)
@@ -51,6 +54,9 @@ def test_allows_next_version(monkeypatch):
             stdout = ["tmux next-2.9"]
             stderr = None
 
+            def execute(self):
+                return self
+
         return Hi()
 
     monkeypatch.setattr(libtmux.common, "tmux_cmd", mock_tmux_cmd)
@@ -65,6 +71,9 @@ def test_get_version_openbsd(monkeypatch):
     def mock_tmux_cmd(param):
         class Hi:
             stderr = ["tmux: unknown option -- V"]
+
+            def execute(self):
+                return self
 
         return Hi()
 
@@ -82,6 +91,9 @@ def test_get_version_too_low(monkeypatch):
     def mock_tmux_cmd(param):
         class Hi:
             stderr = ["tmux: unknown option -- V"]
+
+            def execute(self):
+                return self
 
         return Hi()
 
@@ -181,6 +193,12 @@ def test_tmux_cmd_raises_on_not_found():
 
 def test_tmux_cmd_unicode(session):
     session.cmd("new-window", "-t", 3, "-n", "юникод", "-F", "Ελληνικά")
+
+
+def test_tmux_cmd_makes_cmd_available():
+    """tmux_cmd objects should make .cmd attribute available."""
+    command = tmux_cmd("-V")
+    assert hasattr(command, "cmd")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
_Edit 2022-08-14 by @tony : This is very similar to [`SubprocessCommand`](https://libvcs.git-pull.com/internals/subprocess.html#libvcs._internal.subprocess.SubprocessCommand) ([source](https://github.com/vcs-python/libvcs/blob/v0.14.0/libvcs/_internal/subprocess.py))_

tmux_cmd initialization composes the command

the command will be available in the instance attribute `.cmd`

`.execute()` instance method will run tmux_cmd

See `Server.cmd` for example of new usage

Related #77