### PR TITLE
Add method `display_message` to `Pane`

### DIFF
--- a/libtmux/pane.py
+++ b/libtmux/pane.py
@@ -116,6 +116,30 @@ class Pane(TmuxMappingObject, TmuxRelationalObject):
         if enter:
             self.enter()
 
+    def display_message(self, cmd, get_text=False):
+        """
+        ``$ tmux display-message`` to the pane.
+
+        Displays a message in target-client status line.
+
+        Parameters
+        ----------
+        cmd : str
+            Special parameters to request from pane.
+        get_text : bool, optional
+            Returns only text without displaying a message in
+            target-client status line.
+
+        Returns
+        -------
+        :class:`list`
+        :class:`None`
+        """
+        if get_text:
+            return self.cmd('display-message', '-p', cmd).stdout
+        else:
+            self.cmd('display-message', cmd)
+
     def clear(self):
         """Clear pane."""
         self.send_keys('reset')


### PR DESCRIPTION
Useful for displaying messages in a tmux session and doing stuff like:
```python
>>> pane.display_message('#T', get_text=True)
'server.py (~/Downloads/libtmux/libtmux) - NVIM'
```

Here is a complete example:
```python
# First create a Tmux session by yourself
# before running this example
# `$ tmux`

>>> import libtmux
>>> server = libtmux.Server()
>>> session = server.list_sessions()[0]
>>> pane = session.attached_pane
# Display a message "Hallo World!" in the tmux session
>>> pane.display_message('Hallo World!')
# Get current terminal title
>>> pane.display_message('#T', get_text=True)
['server.py (~/Downloads/libtmux/libtmux) - NVIM']