### PR TITLE
Add method `capture_pane` to`Pane`

### DIFF
--- a/libtmux/pane.py
+++ b/libtmux/pane.py
@@ -217,6 +217,18 @@ class Pane(TmuxMappingObject, TmuxRelationalObject):
         """
         self.cmd('send-keys', 'Enter')
 
+    def capture_pane(self):
+        """
+        Capture text from pane.
+
+        ``$ tmux capture-pane`` to pane.
+
+        Returns
+        -------
+        :class:`list`
+        """
+        return self.cmd('capture-pane', '-p').stdout
+
     def select_pane(self):
         """
         Select pane. Return ``self``.


### PR DESCRIPTION
This new method `Pane.capture_pane` will be very handy for capturing text from a tmux pane.

```python
>>> pane.capture_pane()
['lots and...',
 '..lots of..',
 '.cute text.']
```
So kawaii. :D