### PR TITLE
Fix for unicode commands in Python 2

### DIFF
--- a/libtmux/_compat.py
+++ b/libtmux/_compat.py
@@ -92,3 +92,9 @@ else:
 
 
 number_types = integer_types + (float,)
+
+def str_from_console(s):
+    try:
+        return text_type(s)
+    except UnicodeDecodeError:
+        return text_type(s, encoding='utf_8')

--- a/libtmux/common.py
+++ b/libtmux/common.py
@@ -14,7 +14,7 @@ import sys
 from distutils.version import LooseVersion
 
 from . import exc
-from ._compat import console_to_str
+from ._compat import console_to_str, text_type
 
 logger = logging.getLogger(__name__)
 
@@ -196,7 +196,7 @@ class tmux_cmd(object):
 
         cmd = [tmux_bin]
         cmd += args  # add the command arguments to cmd
-        cmd = [str(c) for c in cmd]
+        cmd = [text_type(c, encoding='utf_8') for c in cmd]
 
         self.cmd = cmd
 

--- a/libtmux/common.py
+++ b/libtmux/common.py
@@ -14,7 +14,7 @@ import sys
 from distutils.version import LooseVersion
 
 from . import exc
-from ._compat import console_to_str, text_type
+from ._compat import console_to_str, str_from_console
 
 logger = logging.getLogger(__name__)
 
@@ -196,7 +196,7 @@ class tmux_cmd(object):
 
         cmd = [tmux_bin]
         cmd += args  # add the command arguments to cmd
-        cmd = [text_type(c, encoding='utf_8') for c in cmd]
+        cmd = [str_from_console(c) for c in cmd]
 
         self.cmd = cmd
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -164,7 +164,7 @@ def test_tmux_cmd_raises_on_not_found():
 
 
 def test_tmux_cmd_unicode():
-    tmux_cmd('has-session', 'юникод')
+    tmux_cmd('new-window', '-t', 3, '-n', 'юникод', '-F', u'Ελληνικά')
 
 
 @pytest.mark.parametrize(

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -163,6 +163,10 @@ def test_tmux_cmd_raises_on_not_found():
     tmux_cmd('-V')
 
 
+def test_tmux_cmd_unicode():
+    tmux_cmd('has-session', 'юникод')
+
+
 @pytest.mark.parametrize(
     "session_name,raises,exc_msg_regex",
     [


### PR DESCRIPTION
Before this PR, if a command was passed into `tmux_command` that had unicode characters in it, such as in the name of a session, format string, or window, a unicode error would be thrown when tmuxp was run with Python 2. The provided unit test shows an example failing test case of this behavior—the real-world use-case is `config.yml` files for tmuxp that contain unicode characters in their names.

This PR resolves the issue by using a python-version-independent conversion inside the `tmux_command` constructor (instead of `str`), assuming that unicode data being sent in Python 2 is encoded as `utf_8`, which is consistent with other places in the code that assumption is made.

Happy to answer any questions, an thanks for making this!