### PR TITLE
Handle next-X.Y versions

### DIFF
--- a/libtmux/common.py
+++ b/libtmux/common.py
@@ -471,7 +471,7 @@ def get_version():
     if version == 'master':
         return LooseVersion('%s-master' % TMUX_MAX_VERSION)
 
-    version = re.sub(r'[a-z]', '', version)
+    version = re.sub(r'[a-z-]', '', version)
 
     return LooseVersion(version)
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -45,6 +45,24 @@ def test_allows_master_version(monkeypatch):
     ), "Is the latest supported version with -master appended"
 
 
+def test_allows_next_version(monkeypatch):
+    def mock_tmux_cmd(param):
+        class Hi(object):
+            stdout = ['tmux next-2.9']
+            stderr = None
+
+        return Hi()
+
+    monkeypatch.setattr(libtmux.common, 'tmux_cmd', mock_tmux_cmd)
+
+    assert has_minimum_version()
+    assert has_gte_version(TMUX_MIN_VERSION)
+    assert has_gt_version(TMUX_MAX_VERSION), "Greater than the max-supported version"
+    assert (
+        '2.9' == get_version()
+    )
+
+
 def test_get_version_openbsd(monkeypatch):
     def mock_tmux_cmd(param):
         class Hi(object):


### PR DESCRIPTION
tmuxp currently crashes when used with
tmux next-2.9 (the latest Homebrew release).

```
TypeError: '<' not supported between instances of 'str' and 'int'
```

This patch avoids the error by making `get_version()`
strip the "next-" part of the version.

closes tmux-python/tmuxp#449