### PR TITLE
some bug fixes

### DIFF
--- a/libtmux/pane.py
+++ b/libtmux/pane.py
@@ -121,6 +121,17 @@ class Pane(TmuxMappingObject, TmuxRelationalObject):
         if enter:
             self.enter()
 
+    def send_control_key(self, key):
+        """
+        ``$ tmux send-keys C-key`` to the pane.
+
+        Parameters
+        ----------
+        key : str
+            Control key to send to the pane. E.g. "c" to kill a process.
+        """
+        self.send_keys("C-"+key, enter=False, suppress_history=False)
+
     def display_message(self, cmd, get_text=False):
         """
         ``$ tmux display-message`` to the pane.

--- a/libtmux/server.py
+++ b/libtmux/server.py
@@ -78,11 +78,9 @@ class Server(TmuxRelationalObject, EnvironmentMixin):
         socket_path=None,
         config_file=None,
         colors=None,
-        split='\t',
         **kwargs
     ):
         EnvironmentMixin.__init__(self, '-g')
-        self._split = split
         self._windows = []
         self._panes = []
 
@@ -147,7 +145,7 @@ class Server(TmuxRelationalObject, EnvironmentMixin):
         sformats = formats.SESSION_FORMATS
         tmux_formats = ['#{%s}' % f for f in sformats]
 
-        tmux_args = ('-F%s' % self._split.join(tmux_formats),)  # output
+        tmux_args = ('-F%s' % '\t'.join(tmux_formats),)  # output
 
         proc = self.cmd('list-sessions', *tmux_args)
 
@@ -159,7 +157,7 @@ class Server(TmuxRelationalObject, EnvironmentMixin):
         sessions = proc.stdout
 
         # combine format keys with values returned from ``tmux list-sessions``
-        sessions = [dict(zip(sformats, session.split(self._split))) for session in sessions]
+        sessions = [dict(zip(sformats, session.split('\t'))) for session in sessions]
 
         # clear up empty dict
         sessions = [
@@ -212,7 +210,7 @@ class Server(TmuxRelationalObject, EnvironmentMixin):
         proc = self.cmd(
             'list-windows',  # ``tmux list-windows``
             '-a',
-            '-F%s' % self._split.join(tmux_formats),  # output
+            '-F%s' % '\t'.join(tmux_formats),  # output
         )
 
         if proc.stderr:
@@ -223,7 +221,7 @@ class Server(TmuxRelationalObject, EnvironmentMixin):
         wformats = ['session_name', 'session_id'] + formats.WINDOW_FORMATS
 
         # combine format keys with values returned from ``tmux list-windows``
-        windows = [dict(zip(wformats, window.split(self._split))) for window in windows]
+        windows = [dict(zip(wformats, window.split('\t'))) for window in windows]
 
         # clear up empty dict
         windows = [dict((k, v) for k, v in window.items() if v is not None) for window in windows]
@@ -272,7 +270,7 @@ class Server(TmuxRelationalObject, EnvironmentMixin):
             'window_id',
             'window_name',
         ] + formats.PANE_FORMATS
-        tmux_formats = [('#{%s}'+self._split) % f for f in pformats]
+        tmux_formats = [('#{%s}'+'\t') % f for f in pformats]
 
         proc = self.cmd('list-panes', '-a', '-F%s' % ''.join(tmux_formats))  # output
 
@@ -290,7 +288,7 @@ class Server(TmuxRelationalObject, EnvironmentMixin):
         ] + formats.PANE_FORMATS
 
         # combine format keys with values returned from ``tmux list-panes``
-        panes = [dict(zip(pformats, window.split(self._split))) for window in panes]
+        panes = [dict(zip(pformats, window.split('\t'))) for window in panes]
 
         # clear up empty dict
         panes = [
@@ -533,7 +531,7 @@ class Server(TmuxRelationalObject, EnvironmentMixin):
         tmux_args = (
             '-s%s' % session_name,
             '-P',
-            '-F%s' % self._split.join(tmux_formats),  # output
+            '-F%s' % '\t'.join(tmux_formats),  # output
         )
 
         if not attach:
@@ -564,7 +562,7 @@ class Server(TmuxRelationalObject, EnvironmentMixin):
             os.environ['TMUX'] = env
 
         # combine format keys with values returned from ``tmux list-windows``
-        session = dict(zip(sformats, session.split(self._split)))
+        session = dict(zip(sformats, session.split('\t')))
 
         # clear up empty dict
         session = dict((k, v) for k, v in session.items() if v is not None)

--- a/libtmux/session.py
+++ b/libtmux/session.py
@@ -221,7 +221,7 @@ class Session(TmuxMappingObject, TmuxRelationalObject, EnvironmentMixin):
             start_directory = os.path.expanduser(start_directory)
             window_args += ('-c%s' % start_directory,)
 
-        window_args += ('-F"%s"' % self.server._split.join(tmux_formats),)  # output
+        window_args += ('-F"%s"' % '\t'.join(tmux_formats),)  # output
         if window_name:
             window_args += ('-n%s' % window_name,)
 
@@ -241,7 +241,7 @@ class Session(TmuxMappingObject, TmuxRelationalObject, EnvironmentMixin):
 
         window = proc.stdout[0]
 
-        window = dict(zip(wformats, window.split(self.server._split)))
+        window = dict(zip(wformats, window.split('\t')))
 
         # clear up empty dict
         window = dict((k, v) for k, v in window.items() if v is not None)

--- a/libtmux/window.py
+++ b/libtmux/window.py
@@ -429,7 +429,7 @@ class Window(TmuxMappingObject, TmuxRelationalObject):
             'window_index',
             'window_id',
         ] + formats.PANE_FORMATS
-        tmux_formats = ['#{%s}\t' % f for f in pformats]
+        tmux_formats = [('#{%s}\t') % f for f in pformats]
 
         # '-t%s' % self.attached_pane.get('pane_id'),
         # 2013-10-18 LOOK AT THIS, rm'd it..

--- a/libtmux/window.py
+++ b/libtmux/window.py
@@ -44,8 +44,7 @@ class Window(TmuxMappingObject, TmuxRelationalObject):
     formatter_prefix = 'window_'
 
     def __init__(self, session=None, **kwargs):
-
-        if not session:
+        if session is None:
             raise ValueError('Window requires a Session, session=Session')
 
         self.session = session
@@ -59,7 +58,7 @@ class Window(TmuxMappingObject, TmuxRelationalObject):
     def __repr__(self):
         return "%s(%s %s:%s, %s)" % (
             self.__class__.__name__,
-            self.id,
+            self._window_id,
             self.index,
             self.name,
             self.session,
@@ -107,7 +106,7 @@ class Window(TmuxMappingObject, TmuxRelationalObject):
             Renamed from ``.tmux`` to ``.cmd``.
         """
         if not any(arg.startswith('-t') for arg in args):
-            args = ('-t', self.id) + args
+            args = ('-t', self._window_id) + args
 
         return self.server.cmd(cmd, *args, **kwargs)
 
@@ -178,7 +177,7 @@ class Window(TmuxMappingObject, TmuxRelationalObject):
         cmd = self.cmd(
             'set-window-option',
             '-t%s:%s' % (self.get('session_id'), self.index),
-            # '-t%s' % self.id,
+            # '-t%s' % self._window_id,
             option,
             value,
         )
@@ -304,7 +303,7 @@ class Window(TmuxMappingObject, TmuxRelationalObject):
 
         proc = self.cmd(
             'kill-window',
-            # '-t:%s' % self.id
+            # '-t:%s' % self._window_id
             '-t%s:%s' % (self.get('session_id'), self.index),
         )
 
@@ -368,7 +367,7 @@ class Window(TmuxMappingObject, TmuxRelationalObject):
         """
 
         if target_pane in ['-l', '-U', '-D', '-L', '-R']:
-            proc = self.cmd('select-pane', '-t%s' % self.id, target_pane)
+            proc = self.cmd('select-pane', '-t%s' % self._window_id, target_pane)
         else:
             proc = self.cmd('select-pane', '-t%s' % target_pane)
 
@@ -474,7 +473,7 @@ class Window(TmuxMappingObject, TmuxRelationalObject):
             pane = dict(zip(pformats, pane.split('\t')))
 
             # clear up empty dict
-            pane = dict((k, v) for k, v in pane.items() if v)
+            pane = dict((k, v) for k, v in pane.items() if v is not None)
 
         return Pane(window=self, **pane)
 
@@ -501,7 +500,7 @@ class Window(TmuxMappingObject, TmuxRelationalObject):
         panes = self.server._update_panes()._panes
 
         panes = [p for p in panes if p['session_id'] == self.get('session_id')]
-        panes = [p for p in panes if p['window_id'] == self.id]
+        panes = [p for p in panes if p['window_id'] == self._window_id]
         return panes
 
     @property


### PR DESCRIPTION
1. While clearing up certain dicts, there was a "if v" to remove any key-value pairs where the value is "false". This resulted in certain sessions or windows with the name "0" to cause errors. So I replaced all occurences with "if v" to "if v is None".

2. In my python installation self._info doesn't work properly. So I renamed lines like "self.id" to "self._session_id".

3. Even though the code specifies in the tmux format strings to use \t as separator, in my installation (ubuntu 16.04) tmux always returned strings with _ as separator. I added the split character to the Server constructor, which is by default \t.