### PR TITLE
Add percent arg to split window

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,7 @@ Here you can find the recent changes to libtmux
 
 current
 -------
+- :issue:`234`: ``Window.split_window``: Allow passing ``percent``
 - :issue:`289`: Fix warning due to invalid escape sequences
 - :issue:`295`: Publish docs via our own action
 - :issue:`295`: Move more packaging over to poetry, though we'll keep

--- a/libtmux/pane.py
+++ b/libtmux/pane.py
@@ -155,7 +155,7 @@ class Pane(TmuxMappingObject, TmuxRelationalObject):
 
         self.cmd('send-keys', r'-R \; clear-history')
 
-    def split_window(self, attach=False, vertical=True, start_directory=None):
+    def split_window(self, attach=False, vertical=True, start_directory=None, percent=None):
         """
         Split window at pane and return newly created :class:`Pane`.
 
@@ -167,6 +167,8 @@ class Pane(TmuxMappingObject, TmuxRelationalObject):
             split vertically
         start_directory : str, optional
             specifies the working directory in which the new pane is created.
+        percent: int, optional
+            percentage to occupy with respect to current pane
 
         Returns
         -------
@@ -177,6 +179,7 @@ class Pane(TmuxMappingObject, TmuxRelationalObject):
             start_directory=start_directory,
             attach=attach,
             vertical=vertical,
+            percent=percent,
         )
 
     def set_width(self, width):

--- a/libtmux/window.py
+++ b/libtmux/window.py
@@ -382,7 +382,8 @@ class Window(TmuxMappingObject, TmuxRelationalObject):
         return self.select_pane('-l')
 
     def split_window(
-        self, target=None, start_directory=None, attach=True, vertical=True, shell=None
+        self, target=None, start_directory=None, attach=True, vertical=True,
+        shell=None, percent=None
     ):
         """
         Split window and return the created :class:`Pane`.
@@ -407,6 +408,8 @@ class Window(TmuxMappingObject, TmuxRelationalObject):
             NOTE: When this command exits the pane will close.  This feature
             is useful for long-running processes where the closing of the
             window upon completion is desired.
+        percent: int, optional
+            percentage to occupy with respect to current window
 
         Returns
         -------
@@ -445,6 +448,9 @@ class Window(TmuxMappingObject, TmuxRelationalObject):
             tmux_args += ('-v',)
         else:
             tmux_args += ('-h',)
+
+        if percent:
+            tmux_args += ('-p %d' % percent,)
 
         tmux_args += ('-P', '-F%s' % ''.join(tmux_formats))  # output
 

--- a/libtmux/window.py
+++ b/libtmux/window.py
@@ -454,7 +454,7 @@ class Window(TmuxMappingObject, TmuxRelationalObject):
         else:
             tmux_args += ('-h',)
 
-        if percent:
+        if percent is not None:
             tmux_args += ('-p %d' % percent,)
 
         tmux_args += ('-P', '-F%s' % ''.join(tmux_formats))  # output

--- a/libtmux/window.py
+++ b/libtmux/window.py
@@ -382,8 +382,13 @@ class Window(TmuxMappingObject, TmuxRelationalObject):
         return self.select_pane('-l')
 
     def split_window(
-        self, target=None, start_directory=None, attach=True, vertical=True,
-        shell=None, percent=None
+        self,
+        target=None,
+        start_directory=None,
+        attach=True,
+        vertical=True,
+        shell=None,
+        percent=None,
     ):
         """
         Split window and return the created :class:`Pane`.


### PR DESCRIPTION
While spliting window tmux supports '-p' to specify the amount (in
percentage) that the newly created pane will occupy with respect to
current pane. So let's expose the same functionality by an extra
argument percent to split_window function.

Signed-off-by: Jinank Jain <jinankj@amazon.de>