### PR TITLE
Fix select_window() by providing the session ID as argument to -t

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -17,6 +17,8 @@ Python 2.7 support dropped.
 - :issue:`312`: ci: Add tmux 3.2a to CI
 - chore: Update black to `21.6b0
   <https://github.com/psf/black/blob/21.6b0/CHANGES.md#216b0>`_
+- :issue:`271`: Fix select_window() by providing the session ID as
+  argument to -t.
 
 libtmux 0.8.5 (2020-10-25)
 --------------------------

--- a/libtmux/session.py
+++ b/libtmux/session.py
@@ -353,7 +353,10 @@ class Session(TmuxMappingObject, TmuxRelationalObject, EnvironmentMixin):
             assure ``-l``, ``-n``, ``-p`` work.
         """
 
-        target = '-t%s' % target_window
+        # Note that we also provide the session ID here, since cmd()
+        # will not automatically add it as there is already a '-t'
+        # argument provided.
+        target = '-t%s:%s' % (self._session_id, target_window)
 
         proc = self.cmd('select-window', target)
 


### PR DESCRIPTION
Previosly select_window() would not work in nested tmux scenarios, as
there was no tmux session ID in the final tmux command. This is because
select_window() already adds the '-t' argument, hence the check in
cmd() does not add the session ID.

Thanks to Fabian Lesniak and Andreas Fried for pointing this out.

Fixes #161