### PR TITLE
Import MutableMapping from collections.abc instead of collections

### DIFF
--- a/libtmux/common.py
+++ b/libtmux/common.py
@@ -6,7 +6,7 @@ libtmux.common
 ~~~~~~~~~~~~~~
 
 """
-import collections
+import collections.abc
 import logging
 import os
 import re
@@ -231,9 +231,9 @@ class tmux_cmd(object):
         logger.debug('self.stdout for %s: \n%s' % (' '.join(cmd), self.stdout))
 
 
-class TmuxMappingObject(collections.MutableMapping):
+class TmuxMappingObject(collections.abc.MutableMapping):
 
-    """Base: :py:class:`collections.MutableMapping`.
+    """Base: :py:class:`collections.abc.MutableMapping`.
 
     Convenience container. Base class for :class:`Pane`, :class:`Window`,
     :class:`Session` and :class:`Server`.


### PR DESCRIPTION
Importing MutableMapping from collections is deprecated since Python
3.3 and will stop working in 3.9. See the following deprecation notice:

libtmux/common.py:233: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working

Hence we now import from collections.abc.