### PR TITLE
Better interaction with subprocess std[in|out|err]

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,7 +6,7 @@ Here you can find the recent changes to libtmux
 
 current
 -------
-- :issue:`251`: Enchance subprocess interaction stdin/out/err. Needed for interact with big buffer
+- :issue:`251`: Enchance subprocess interaction std[in|out|err]. Needed for interact with big buffer
 - :issue:`295`: Publish docs via our own action
 - :issue:`295`: Move more packaging over to poetry, though we'll keep
   setup.py for the moment to ensure compatibility package maintainers.

--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,7 @@ Here you can find the recent changes to libtmux
 
 current
 -------
+- :issue:`251`: Enchance subprocess interaction stdin/out/err. Needed for interact with big buffer
 - :issue:`295`: Publish docs via our own action
 - :issue:`295`: Move more packaging over to poetry, though we'll keep
   setup.py for the moment to ensure compatibility package maintainers.

--- a/libtmux/common.py
+++ b/libtmux/common.py
@@ -205,11 +205,7 @@ class tmux_cmd(object):
             self.process = subprocess.Popen(
                 cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE
             )
-            self.process.wait()
-            stdout = self.process.stdout.read()
-            self.process.stdout.close()
-            stderr = self.process.stderr.read()
-            self.process.stderr.close()
+            stdout, stderr = self.process.communicate()
             returncode = self.process.returncode
         except Exception as e:
             logger.error('Exception for %s: \n%s' % (subprocess.list2cmdline(cmd), e))


### PR DESCRIPTION
Needed for interact with big buffer.

Thanks to communicate method ~implemented with python > 3.~
~I don't know how to deal with it with python2 ?~

https://docs.python.org/3.5/library/subprocess.html#subprocess.Popen.communicate

#251

Official docs:

    Warning
    Use communicate() rather than .stdin.write, .stdout.read or .stderr.read to avoid deadlocks due to any of the other OS   pipe buffers filling up and blocking the child process. 
