### PR TITLE
split on a special wildcard instead of tab

### DIFF
--- a/libtmux/server.py
+++ b/libtmux/server.py
@@ -142,7 +142,7 @@ class Server(TmuxRelationalObject, EnvironmentMixin):
         sformats = formats.SESSION_FORMATS
         tmux_formats = ['#{%s}' % f for f in sformats]
 
-        tmux_args = ('-F%s' % '\t'.join(tmux_formats),)  # output
+        tmux_args = ('-F%s' % '$@$'.join(tmux_formats),)  # output
 
         proc = self.cmd('list-sessions', *tmux_args)
 
@@ -154,7 +154,7 @@ class Server(TmuxRelationalObject, EnvironmentMixin):
         sessions = proc.stdout
 
         # combine format keys with values returned from ``tmux list-sessions``
-        sessions = [dict(zip(sformats, session.split('\t'))) for session in sessions]
+        sessions = [dict(zip(sformats, session.split('$@$'))) for session in sessions]
 
         # clear up empty dict
         sessions = [
@@ -203,11 +203,12 @@ class Server(TmuxRelationalObject, EnvironmentMixin):
 
         wformats = ['session_name', 'session_id'] + formats.WINDOW_FORMATS
         tmux_formats = ['#{%s}' % format for format in wformats]
+        print()
 
         proc = self.cmd(
             'list-windows',  # ``tmux list-windows``
             '-a',
-            '-F%s' % '\t'.join(tmux_formats),  # output
+            '-F%s' % '$@$'.join(tmux_formats),  # output
         )
 
         if proc.stderr:
@@ -218,7 +219,7 @@ class Server(TmuxRelationalObject, EnvironmentMixin):
         wformats = ['session_name', 'session_id'] + formats.WINDOW_FORMATS
 
         # combine format keys with values returned from ``tmux list-windows``
-        windows = [dict(zip(wformats, window.split('\t'))) for window in windows]
+        windows = [dict(zip(wformats, window.split('$@$'))) for window in windows]
 
         # clear up empty dict
         windows = [dict((k, v) for k, v in window.items() if v) for window in windows]
@@ -267,7 +268,7 @@ class Server(TmuxRelationalObject, EnvironmentMixin):
             'window_id',
             'window_name',
         ] + formats.PANE_FORMATS
-        tmux_formats = ['#{%s}\t' % f for f in pformats]
+        tmux_formats = ['#{%s}$@$' % f for f in pformats]
 
         proc = self.cmd('list-panes', '-a', '-F%s' % ''.join(tmux_formats))  # output
 
@@ -285,7 +286,7 @@ class Server(TmuxRelationalObject, EnvironmentMixin):
         ] + formats.PANE_FORMATS
 
         # combine format keys with values returned from ``tmux list-panes``
-        panes = [dict(zip(pformats, window.split('\t'))) for window in panes]
+        panes = [dict(zip(pformats, window.split('$@$'))) for window in panes]
 
         # clear up empty dict
         panes = [
@@ -526,7 +527,7 @@ class Server(TmuxRelationalObject, EnvironmentMixin):
         tmux_args = (
             '-s%s' % session_name,
             '-P',
-            '-F%s' % '\t'.join(tmux_formats),  # output
+            '-F%s' % '$@$'.join(tmux_formats),  # output
         )
 
         if not attach:
@@ -557,7 +558,7 @@ class Server(TmuxRelationalObject, EnvironmentMixin):
             os.environ['TMUX'] = env
 
         # combine format keys with values returned from ``tmux list-windows``
-        session = dict(zip(sformats, session.split('\t')))
+        session = dict(zip(sformats, session.split('$@$')))
 
         # clear up empty dict
         session = dict((k, v) for k, v in session.items() if v)

--- a/libtmux/session.py
+++ b/libtmux/session.py
@@ -217,7 +217,7 @@ class Session(TmuxMappingObject, TmuxRelationalObject, EnvironmentMixin):
             start_directory = os.path.expanduser(start_directory)
             window_args += ('-c%s' % start_directory,)
 
-        window_args += ('-F"%s"' % '\t'.join(tmux_formats),)  # output
+        window_args += ('-F"%s"' % '$@$'.join(tmux_formats),)  # output
         if window_name:
             window_args += ('-n%s' % window_name,)
 
@@ -237,7 +237,7 @@ class Session(TmuxMappingObject, TmuxRelationalObject, EnvironmentMixin):
 
         window = proc.stdout[0]
 
-        window = dict(zip(wformats, window.split('\t')))
+        window = dict(zip(wformats, window.split('$@$')))
 
         # clear up empty dict
         window = dict((k, v) for k, v in window.items() if v)

--- a/libtmux/window.py
+++ b/libtmux/window.py
@@ -434,7 +434,7 @@ class Window(TmuxMappingObject, TmuxRelationalObject):
             'window_index',
             'window_id',
         ] + formats.PANE_FORMATS
-        tmux_formats = ['#{%s}\t' % f for f in pformats]
+        tmux_formats = ['#{%s}$@$' % f for f in pformats]
 
         # '-t%s' % self.attached_pane.get('pane_id'),
         # 2013-10-18 LOOK AT THIS, rm'd it..
@@ -478,7 +478,7 @@ class Window(TmuxMappingObject, TmuxRelationalObject):
         else:
             pane = pane.stdout[0]
 
-            pane = dict(zip(pformats, pane.split('\t')))
+            pane = dict(zip(pformats, pane.split('$@$')))
 
             # clear up empty dict
             pane = dict((k, v) for k, v in pane.items() if v)


### PR DESCRIPTION
Several APIs in libtmux fail with Tmux 3.1 installed but worked with Tmux 3.0/3.0a.
It appears that the format string used by the library to communicate with Tmux will ignore tabs and return lowercases instead. I switch the tab to a wildcard (e.g. `$@$`) but this could be any kind of string assuming it's sufficiently rare to not collide with desired user input.