### PR TITLE
Address inconsistent type self.colors returned by Click generating exception in cmd

### DIFF
--- a/libtmux/server.py
+++ b/libtmux/server.py
@@ -119,6 +119,8 @@ class Server(TmuxRelationalObject, EnvironmentMixin):
         if self.config_file:
             args.insert(0, '-f{0}'.format(self.config_file))
         if self.colors:
+            # Resolve inconsistent type returned by Click
+            self.colors=int(self.colors)
             if self.colors == 256:
                 args.insert(0, '-2')
             elif self.colors == 88:


### PR DESCRIPTION
Noted in the [tmuxp](https://github.com/tmux-python/tmuxp/issues/649) project, libtmux returns an error with the most recent versions of the Click library, where `self.colors` is a `str` not an `int`, leading to the error _ValueError: Server.colors must equal 88 or 256_. This PR casts the `self.colors` to an `int` to accommodate the inconsistency in Click.

CC: @mtrajano 