### PR TITLE
fix: use `|` instead of `\t` for format sepatator

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.x"]
+        python-version: ["3.9"]
     steps:
       - uses: actions/checkout@v1
       - name: Configure git

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -99,7 +99,6 @@ jobs:
 
       - name: Build documentation
         if: env.PUBLISH == 'true'
-        if: env.PUBLISH == 'true'
         run: |
           pushd docs; make SPHINXBUILD='poetry run sphinx-build' html; popd
 

--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,9 @@ Here you can find the recent changes to libtmux
 ## current
 
 - _Insert changes/features/fixes for next release here_
+
+## libtmux 0.10.2 (2021-10-30)
+
 - #324: Update poetry to 1.1
   - CI: Use poetry 1.1.7 and `install-poetry.py` installer
   - Relock poetry.lock at 1.1 (w/ 1.1.7's fix)
@@ -12,7 +15,7 @@ Here you can find the recent changes to libtmux
 - #341 #342: `Server.attached_sessions()` now supports multiple attached sessions.
 
   Remove attached sessions limitation to not detect multiple attached clients,
-  thank you @Timoses
+  thank you @timoses
 
 ## libtmux 0.10.1 (2021-06-16)
 - Update `Window.select_window()` for #271

--- a/CHANGES
+++ b/CHANGES
@@ -12,6 +12,7 @@ Here you can find the recent changes to libtmux
   - CI: Use poetry 1.1.7 and `install-poetry.py` installer
   - Relock poetry.lock at 1.1 (w/ 1.1.7's fix)
 - #339 (CI): Lock python at 3.9 to avoid poetry issue with `dataclasses`
+- ci: Fix publishing docs (similar to #339)
 - #341 #342: `Server.attached_sessions()` now supports multiple attached sessions.
 
   Remove attached sessions limitation to not detect multiple attached clients,

--- a/libtmux/__about__.py
+++ b/libtmux/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'libtmux'
 __package_name__ = 'libtmux'
-__version__ = '0.10.1'
+__version__ = '0.10.2'
 __description__ = 'scripting library / orm for tmux'
 __email__ = 'tony@git-pull.com'
 __author__ = 'Tony Narlock'

--- a/libtmux/formats.py
+++ b/libtmux/formats.py
@@ -7,6 +7,10 @@ For reference: https://github.com/tmux/tmux/blob/master/format.c
 
 """
 
+from __future__ import absolute_import, unicode_literals, with_statement
+
+FORMAT_SEPERATOR = "|"
+
 SESSION_FORMATS = [
     'session_name',
     'session_windows',

--- a/libtmux/server.py
+++ b/libtmux/server.py
@@ -142,7 +142,9 @@ class Server(TmuxRelationalObject, EnvironmentMixin):
         sformats = formats.SESSION_FORMATS
         tmux_formats = ['#{%s}' % f for f in sformats]
 
-        tmux_args = ('-F%s' % '\t'.join(tmux_formats),)  # output
+        tmux_args = (
+            '-F%s' % formats.FORMAT_SEPERATOR.join(tmux_formats),
+        )  # output
 
         proc = self.cmd('list-sessions', *tmux_args)
 
@@ -154,7 +156,17 @@ class Server(TmuxRelationalObject, EnvironmentMixin):
         sessions = proc.stdout
 
         # combine format keys with values returned from ``tmux list-sessions``
-        sessions = [dict(zip(sformats, session.split('\t'))) for session in sessions]
+        sessions = [
+            dict(
+                zip(
+                    sformats,
+                    session.split(
+                        formats.FORMAT_SEPERATOR
+                    )
+                )
+            )
+            for session in sessions
+        ]
 
         # clear up empty dict
         sessions = [
@@ -207,7 +219,9 @@ class Server(TmuxRelationalObject, EnvironmentMixin):
         proc = self.cmd(
             'list-windows',  # ``tmux list-windows``
             '-a',
-            '-F%s' % '\t'.join(tmux_formats),  # output
+            '-F%s' % formats.FORMAT_SEPERATOR.join(
+                tmux_formats
+            ),  # output
         )
 
         if proc.stderr:
@@ -218,7 +232,17 @@ class Server(TmuxRelationalObject, EnvironmentMixin):
         wformats = ['session_name', 'session_id'] + formats.WINDOW_FORMATS
 
         # combine format keys with values returned from ``tmux list-windows``
-        windows = [dict(zip(wformats, window.split('\t'))) for window in windows]
+        windows = [
+            dict(
+                zip(
+                    wformats,
+                    window.split(
+                        formats.FORMAT_SEPERATOR
+                    )
+                )
+            )
+            for window in windows
+        ]
 
         # clear up empty dict
         windows = [dict((k, v) for k, v in window.items() if v) for window in windows]
@@ -267,7 +291,10 @@ class Server(TmuxRelationalObject, EnvironmentMixin):
             'window_id',
             'window_name',
         ] + formats.PANE_FORMATS
-        tmux_formats = ['#{%s}\t' % f for f in pformats]
+        tmux_formats = [
+            ('#{%%s}%s' % formats.FORMAT_SEPERATOR) % f
+            for f in pformats
+        ]
 
         proc = self.cmd('list-panes', '-a', '-F%s' % ''.join(tmux_formats))  # output
 
@@ -285,7 +312,17 @@ class Server(TmuxRelationalObject, EnvironmentMixin):
         ] + formats.PANE_FORMATS
 
         # combine format keys with values returned from ``tmux list-panes``
-        panes = [dict(zip(pformats, window.split('\t'))) for window in panes]
+        panes = [
+            dict(
+                zip(
+                    pformats,
+                    window.split(
+                        formats.FORMAT_SEPERATOR
+                    )
+                )
+            )
+            for window in panes
+        ]
 
         # clear up empty dict
         panes = [
@@ -526,7 +563,7 @@ class Server(TmuxRelationalObject, EnvironmentMixin):
         tmux_args = (
             '-s%s' % session_name,
             '-P',
-            '-F%s' % '\t'.join(tmux_formats),  # output
+            '-F%s' % formats.FORMAT_SEPERATOR.join(tmux_formats),  # output
         )
 
         if not attach:
@@ -557,7 +594,7 @@ class Server(TmuxRelationalObject, EnvironmentMixin):
             os.environ['TMUX'] = env
 
         # combine format keys with values returned from ``tmux list-windows``
-        session = dict(zip(sformats, session.split('\t')))
+        session = dict(zip(sformats, session.split(formats.FORMAT_SEPERATOR)))
 
         # clear up empty dict
         session = dict((k, v) for k, v in session.items() if v)

--- a/libtmux/session.py
+++ b/libtmux/session.py
@@ -217,7 +217,9 @@ class Session(TmuxMappingObject, TmuxRelationalObject, EnvironmentMixin):
             start_directory = os.path.expanduser(start_directory)
             window_args += ('-c%s' % start_directory,)
 
-        window_args += ('-F"%s"' % '\t'.join(tmux_formats),)  # output
+        window_args += (
+            '-F"%s"' % formats.FORMAT_SEPERATOR.join(tmux_formats),
+        )  # output
         if window_name:
             window_args += ('-n%s' % window_name,)
 
@@ -237,7 +239,14 @@ class Session(TmuxMappingObject, TmuxRelationalObject, EnvironmentMixin):
 
         window = proc.stdout[0]
 
-        window = dict(zip(wformats, window.split('\t')))
+        window = dict(
+            zip(
+                wformats,
+                window.split(
+                    formats.FORMAT_SEPERATOR
+                )
+            )
+        )
 
         # clear up empty dict
         window = dict((k, v) for k, v in window.items() if v)

--- a/libtmux/window.py
+++ b/libtmux/window.py
@@ -434,7 +434,10 @@ class Window(TmuxMappingObject, TmuxRelationalObject):
             'window_index',
             'window_id',
         ] + formats.PANE_FORMATS
-        tmux_formats = ['#{%s}\t' % f for f in pformats]
+        tmux_formats = [
+            ('#{%%s}%s' % formats.FORMAT_SEPERATOR) % f
+            for f in pformats
+        ]
 
         # '-t%s' % self.attached_pane.get('pane_id'),
         # 2013-10-18 LOOK AT THIS, rm'd it..
@@ -478,7 +481,7 @@ class Window(TmuxMappingObject, TmuxRelationalObject):
         else:
             pane = pane.stdout[0]
 
-            pane = dict(zip(pformats, pane.split('\t')))
+            pane = dict(zip(pformats, pane.split(formats.FORMAT_SEPERATOR)))
 
             # clear up empty dict
             pane = dict((k, v) for k, v in pane.items() if v)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ skip-string-normalization = true
 
 [tool.poetry]
 name = "libtmux"
-version = "0.10.1"
+version = "0.10.2"
 description = "scripting library / orm for tmux"
 license = "MIT"
 authors = ["Tony Narlock <tony@git-pull.com>"]


### PR DESCRIPTION
- for some reason on my arch install tmux does not print back tabs

I'm not sure if it affects other but just puttin this out there