### PR TITLE
Remove attached sessions limitation to not detect multiple attached clients

### DIFF
--- a/libtmux/server.py
+++ b/libtmux/server.py
@@ -330,13 +330,13 @@ class Server(TmuxRelationalObject, EnvironmentMixin):
         attached_sessions = list()
 
         for session in sessions:
-            if 'session_attached' in session:
-                # for now session_active is a unicode
-                if session.attached == '1':
-                    logger.debug('session %s attached', session.name)
-                    attached_sessions.append(session)
-                else:
-                    continue
+            attached = session.get('session_attached')
+            # for now session_active is a unicode
+            if attached == '1':
+                logger.debug('session %s attached', session.get('name'))
+                attached_sessions.append(session)
+            else:
+                continue
 
         return [Session(server=self, **s) for s in attached_sessions] or None
 

--- a/libtmux/server.py
+++ b/libtmux/server.py
@@ -319,8 +319,6 @@ class Server(TmuxRelationalObject, EnvironmentMixin):
         """
         Return active :class:`Session` objects.
 
-        This will not work where multiple tmux sessions are attached.
-
         Returns
         -------
         list of :class:`Session`
@@ -332,7 +330,7 @@ class Server(TmuxRelationalObject, EnvironmentMixin):
         for session in sessions:
             attached = session.get('session_attached')
             # for now session_active is a unicode
-            if attached == '1':
+            if attached != '0':
                 logger.debug('session %s attached', session.get('name'))
                 attached_sessions.append(session)
             else:


### PR DESCRIPTION
Technically this is a breaking change. Previously one could expect to detect that only **one** client is attached to the sessions via this property.

However, since previously `Server.attached_sessions` was broken (see #180 and PR to fix #341) I do not expect anybody to use the property currently.

Builds on https://github.com/tmux-python/libtmux/pull/341/files (<- Merge first)