### PR TITLE
Replacement for `distutils.version.LooseVersion`, fix warning

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -14,6 +14,27 @@ $ pip install --user --upgrade --pre libtmux
 
 <!-- Maintainers and contributors: Insert change notes for the next release above -->
 
+### Breaking changes
+
+- Fix `distutils` warning, vendorize `LegacyVersion` (#351)
+
+  Removal of reliancy on `distutils.version.LooseVersion`, which does not
+  support `tmux(1)` versions like `3.1a`.
+
+  Fixes warning:
+  
+  > DeprecationWarning: distutils Version classes are deprecated. Use
+  > packaging.version instead.
+
+  The temporary workaround, before 0.16.0 (assuming _setup.cfg_):
+
+  ```ini
+  [tool:pytest]
+  filterwarnings =
+      ignore:.* Use packaging.version.*:DeprecationWarning::
+      ignore:The frontend.Option(Parser)? class.*:DeprecationWarning::
+  ```
+
 ### Features
 
 - `Window.split_window()` and `Session.new_window()` now support an optional

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,6 @@ line_length = 88
 
 [tool:pytest]
 filterwarnings =
-    ignore:.* Use packaging.version.*:DeprecationWarning::
     ignore:The frontend.Option(Parser)? class.*:DeprecationWarning::
 addopts = --tb=short --no-header --showlocals --doctest-docutils-modules --reruns 2 -p no:doctest
 doctest_optionflags = ELLIPSIS NORMALIZE_WHITESPACE

--- a/src/libtmux/_compat.py
+++ b/src/libtmux/_compat.py
@@ -1,4 +1,5 @@
 # flake8: NOQA
+import functools
 import sys
 import types
 import typing as t
@@ -31,3 +32,106 @@ def str_from_console(s: t.Union[str, bytes]) -> str:
         return str(s)
     except UnicodeDecodeError:
         return str(s, encoding="utf_8") if isinstance(s, bytes) else s
+
+
+import re
+from typing import Iterator, List, Tuple
+
+from packaging.version import Version
+
+###
+### Legacy support for LooseVersion / LegacyVersion, e.g. 2.4-openbsd
+### https://github.com/pypa/packaging/blob/21.3/packaging/version.py#L106-L115
+### License: BSD, Accessed: Jan 14th, 2022
+###
+
+LegacyCmpKey = Tuple[int, Tuple[str, ...]]
+
+_legacy_version_component_re = re.compile(r"(\d+ | [a-z]+ | \.| -)", re.VERBOSE)
+_legacy_version_replacement_map = {
+    "pre": "c",
+    "preview": "c",
+    "-": "final-",
+    "rc": "c",
+    "dev": "@",
+}
+
+
+def _parse_version_parts(s: str) -> Iterator[str]:
+    for part in _legacy_version_component_re.split(s):
+        part = _legacy_version_replacement_map.get(part, part)
+
+        if not part or part == ".":
+            continue
+
+        if part[:1] in "0123456789":
+            # pad for numeric comparison
+            yield part.zfill(8)
+        else:
+            yield "*" + part
+
+    # ensure that alpha/beta/candidate are before final
+    yield "*final"
+
+
+def _legacy_cmpkey(version: str) -> LegacyCmpKey:
+    # We hardcode an epoch of -1 here. A PEP 440 version can only have a epoch
+    # greater than or equal to 0. This will effectively put the LegacyVersion,
+    # which uses the defacto standard originally implemented by setuptools,
+    # as before all PEP 440 versions.
+    epoch = -1
+
+    # This scheme is taken from pkg_resources.parse_version setuptools prior to
+    # it's adoption of the packaging library.
+    parts: List[str] = []
+    for part in _parse_version_parts(version.lower()):
+        if part.startswith("*"):
+            # remove "-" before a prerelease tag
+            if part < "*final":
+                while parts and parts[-1] == "*final-":
+                    parts.pop()
+
+            # remove trailing zeros from each series of numeric parts
+            while parts and parts[-1] == "00000000":
+                parts.pop()
+
+        parts.append(part)
+
+    return epoch, tuple(parts)
+
+
+@functools.total_ordering
+class LegacyVersion:
+    _key: LegacyCmpKey
+
+    def __hash__(self) -> int:
+        return hash(self._key)
+
+    def __init__(self, version: object) -> None:
+        self._version = str(version)
+        self._key = _legacy_cmpkey(self._version)
+
+    def __str__(self) -> str:
+        return self._version
+
+    def __lt__(self, other: object) -> bool:
+        if isinstance(other, str):
+            other = LegacyVersion(other)
+        if not isinstance(other, LegacyVersion):
+            return NotImplemented
+
+        return self._key < other._key
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, str):
+            other = LegacyVersion(other)
+        if not isinstance(other, LegacyVersion):
+            return NotImplemented
+
+        return self._key == other._key
+
+    def __repr__(self) -> str:
+        return "<LegacyVersion({0})>".format(repr(str(self)))
+
+
+LooseVersion = LegacyVersion

--- a/src/libtmux/common.py
+++ b/src/libtmux/common.py
@@ -11,11 +11,10 @@ import shutil
 import subprocess
 import sys
 import typing as t
-from distutils.version import LooseVersion
 from typing import Dict, Generic, KeysView, List, Optional, TypeVar, Union, overload
 
 from . import exc
-from ._compat import console_to_str, str_from_console
+from ._compat import LooseVersion, console_to_str, str_from_console
 
 if t.TYPE_CHECKING:
     from typing_extensions import Literal

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -3,12 +3,12 @@
 import re
 import sys
 import typing as t
-from distutils.version import LooseVersion
 from typing import Optional
 
 import pytest
 
 import libtmux
+from libtmux._compat import LooseVersion
 from libtmux.common import (
     TMUX_MAX_VERSION,
     TMUX_MIN_VERSION,

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,43 @@
+import operator
+from contextlib import nullcontext as does_not_raise
+
+import pytest
+
+from libtmux._compat import LooseVersion
+
+
+@pytest.mark.parametrize(
+    "version",
+    [
+        "1",
+        "1.0",
+        "1.0.0",
+        "1.0.0b",
+        "1.0.0b1",
+        "1.0.0b-openbsd",
+        "1.0.0-next",
+        "1.0.0-next.1",
+    ],
+)
+def test_version(version):
+    assert LooseVersion(version)
+
+
+@pytest.mark.parametrize(
+    "version,op,versionb,raises",
+    [
+        ["1", operator.eq, "1", False],
+        ["1", operator.eq, "1.0", False],
+        ["1", operator.eq, "1.0.0", False],
+        ["1", operator.gt, "1.0.0a", False],
+        ["1", operator.gt, "1.0.0b", False],
+        ["1", operator.lt, "1.0.0p1", False],
+        ["1", operator.lt, "1.0.0-openbsd", False],
+        ["1", operator.lt, "1", AssertionError],
+        ["1", operator.lt, "1", AssertionError],
+    ],
+)
+def test_version_compare(version, op, versionb, raises):
+    raises_ctx = pytest.raises(raises) if raises else does_not_raise()
+    with raises_ctx:
+        assert op(LooseVersion(version), LooseVersion(versionb))


### PR DESCRIPTION
`distutils` is deprecation `Version`

The new version will no longer select tmux versions like `3.1` vs `3.1a` vs `3.1b`.

We will backport `LegacyVersion` in a typesafe way to tmuxp.