### PR TITLE
Refactor: Cleaning up 

### DIFF
--- a/libtmux/_compat.py
+++ b/libtmux/_compat.py
@@ -1,7 +1,6 @@
 # flake8: NOQA
 import sys
 import typing as t
-from collections.abc import MutableMapping
 
 console_encoding = sys.__stdout__.encoding
 

--- a/libtmux/common.py
+++ b/libtmux/common.py
@@ -349,7 +349,7 @@ class TmuxRelationalObject:
         target_children = list(filter(by, self.children))
         if first:
             return target_children[0]
-        return return target_children
+        return target_children
 
     def get_by_id(self, id):
         """

--- a/libtmux/common.py
+++ b/libtmux/common.py
@@ -11,10 +11,11 @@ import re
 import subprocess
 import sys
 import typing as t
+from collections.abc import MutableMapping
 from distutils.version import LooseVersion
 
 from . import exc
-from ._compat import MutableMapping, console_to_str, str_from_console
+from ._compat import console_to_str, str_from_console
 
 logger = logging.getLogger(__name__)
 

--- a/libtmux/common.py
+++ b/libtmux/common.py
@@ -62,7 +62,7 @@ class EnvironmentMixin:
         proc = self.cmd(*args)
 
         if proc.stderr:
-            if isinstance(proc.stderr, list) and len(proc.stderr) == int(1):
+            if isinstance(proc.stderr, list) and len(proc.stderr) == 1:
                 proc.stderr = proc.stderr[0]
             raise ValueError("tmux set-environment stderr: %s" % proc.stderr)
 
@@ -83,7 +83,7 @@ class EnvironmentMixin:
         proc = self.cmd(*args)
 
         if proc.stderr:
-            if isinstance(proc.stderr, list) and len(proc.stderr) == int(1):
+            if isinstance(proc.stderr, list) and len(proc.stderr) == 1:
                 proc.stderr = proc.stderr[0]
             raise ValueError("tmux set-environment stderr: %s" % proc.stderr)
 
@@ -103,7 +103,7 @@ class EnvironmentMixin:
         proc = self.cmd(*args)
 
         if proc.stderr:
-            if isinstance(proc.stderr, list) and len(proc.stderr) == int(1):
+            if isinstance(proc.stderr, list) and len(proc.stderr) == 1:
                 proc.stderr = proc.stderr[0]
             raise ValueError("tmux set-environment stderr: %s" % proc.stderr)
 

--- a/libtmux/common.py
+++ b/libtmux/common.py
@@ -336,19 +336,20 @@ class TmuxRelationalObject:
         """
 
         # from https://github.com/serkanyersen/underscore.py
-        def by(val, *args):
-            for key, value in attrs.items():
+        def by(val) -> bool:
+            for key in attrs.keys():
                 try:
                     if attrs[key] != val[key]:
                         return False
                 except KeyError:
                     return False
-                return True
+            return True
 
+        # TODO add type hint
+        target_children = list(filter(by, self.children))
         if first:
-            return list(filter(by, self.children))[0]
-        else:
-            return list(filter(by, self.children))
+            return target_children[0]
+        return return target_children
 
     def get_by_id(self, id):
         """

--- a/libtmux/pane.py
+++ b/libtmux/pane.py
@@ -63,7 +63,7 @@ class Pane(TmuxMappingObject, TmuxRelationalObject):
         attrs = {"pane_id": self._pane_id}
 
         # from https://github.com/serkanyersen/underscore.py
-        def by(val):
+        def by(val) -> bool:
             for key in attrs.keys():
                 try:
                     if attrs[key] != val[key]:

--- a/libtmux/pane.py
+++ b/libtmux/pane.py
@@ -58,21 +58,23 @@ class Pane(TmuxMappingObject, TmuxRelationalObject):
         self.server._update_panes()
 
     @property
-    def _info(self, *args):
+    def _info(self):
 
         attrs = {"pane_id": self._pane_id}
 
         # from https://github.com/serkanyersen/underscore.py
-        def by(val, *args):
-            for key, value in attrs.items():
+        def by(val):
+            for key in attrs.keys():
                 try:
                     if attrs[key] != val[key]:
                         return False
                 except KeyError:
                     return False
-                return True
+            return True
 
-        return list(filter(by, self.server._panes))[0]
+        # TODO add type hint
+        target_panes = list(filter(by, self.server._panes))
+        return target_panes[0]
 
     def cmd(self, cmd, *args, **kwargs):
         """Return :meth:`Server.cmd` defaulting to ``target_pane`` as target.

--- a/libtmux/session.py
+++ b/libtmux/session.py
@@ -318,12 +318,9 @@ class Session(TmuxMappingObject, TmuxRelationalObject, EnvironmentMixin):
         """
         active_windows = []
         for window in self._windows:
-            if "window_active" in window:
-                # for now window_active is a unicode
-                if window.get("window_active") == "1":
-                    active_windows.append(Window(session=self, **window))
-                else:
-                    continue
+            # for now window_active is a unicode
+            if "window_active" in window and window.get("window_active") == "1":
+                active_windows.append(Window(session=self, **window))
 
         if len(active_windows) == int(1):
             return active_windows[0]

--- a/libtmux/session.py
+++ b/libtmux/session.py
@@ -322,14 +322,14 @@ class Session(TmuxMappingObject, TmuxRelationalObject, EnvironmentMixin):
             if "window_active" in window and window.get("window_active") == "1":
                 active_windows.append(Window(session=self, **window))
 
-        if len(active_windows) == int(1):
+        if len(active_windows) == 1:
             return active_windows[0]
         else:
             raise exc.LibTmuxException(
                 "multiple active windows found. %s" % active_windows
             )
 
-        if len(self._windows) == int(0):
+        if len(self._windows) == 0:
             raise exc.LibTmuxException("No Windows")
 
     def select_window(self, target_window: str) -> Window:

--- a/libtmux/session.py
+++ b/libtmux/session.py
@@ -66,16 +66,18 @@ class Session(TmuxMappingObject, TmuxRelationalObject, EnvironmentMixin):
         attrs = {"session_id": str(self._session_id)}
 
         def by(val):
-            for key, value in attrs.items():
+            for key in attrs.keys():
                 try:
                     if attrs[key] != val[key]:
                         return False
                 except KeyError:
                     return False
-                return True
+            return True
 
+        # TODO add type hint
+        target_sessions = list(filter(by, self.server._sessions))
         try:
-            return list(filter(by, self.server._sessions))[0]
+            return target_sessions[0]
         except IndexError as e:
             logger.error(e)
 

--- a/libtmux/session.py
+++ b/libtmux/session.py
@@ -65,7 +65,7 @@ class Session(TmuxMappingObject, TmuxRelationalObject, EnvironmentMixin):
 
         attrs = {"session_id": str(self._session_id)}
 
-        def by(val):
+        def by(val) -> bool:
             for key in attrs.keys():
                 try:
                     if attrs[key] != val[key]:

--- a/libtmux/window.py
+++ b/libtmux/window.py
@@ -74,7 +74,7 @@ class Window(TmuxMappingObject, TmuxRelationalObject):
         attrs = {"window_id": self._window_id}
 
         # from https://github.com/serkanyersen/underscore.py
-        def by(val):
+        def by(val) -> bool:
             for key in attrs.keys():
                 try:
                     if attrs[key] != val[key]:

--- a/libtmux/window.py
+++ b/libtmux/window.py
@@ -74,22 +74,23 @@ class Window(TmuxMappingObject, TmuxRelationalObject):
         attrs = {"window_id": self._window_id}
 
         # from https://github.com/serkanyersen/underscore.py
-        def by(val, *args):
-            for key, value in attrs.items():
+        def by(val):
+            for key in attrs.keys():
                 try:
                     if attrs[key] != val[key]:
                         return False
                 except KeyError:
                     return False
-                return True
+            return True
 
-        ret = list(filter(by, self.server._windows))
+        # TODO add type hint
+        target_windows = list(filter(by, self.server._windows))
         # If a window_shell option was configured which results in
         # a short-lived process, the window id is @0.  Use that instead of
         # self._window_id
-        if len(ret) == 0 and self.server._windows[0]["window_id"] == "@0":
-            ret = self.server._windows
-        return ret[0]
+        if len(target_windows) == 0 and self.server._windows[0]["window_id"] == "@0":
+            target_windows = self.server._windows
+        return target_windows[0]
 
     def cmd(self, cmd, *args, **kwargs):
         """Return :meth:`Server.cmd` defaulting ``target_window`` as target.

--- a/libtmux/window.py
+++ b/libtmux/window.py
@@ -502,10 +502,9 @@ class Window(TmuxMappingObject, TmuxRelationalObject):
         :class:`Pane`
         """
         for pane in self._panes:
-            if "pane_active" in pane:
-                # for now pane_active is a unicode
-                if pane.get("pane_active") == "1":
-                    return Pane(window=self, **pane)
+            # for now pane_active is a unicode
+            if "pane_active" in pane and pane.get("pane_active") == "1":
+                return Pane(window=self, **pane)
 
     def _list_panes(self) -> t.List[PaneDict]:
         panes = self.server._update_panes()._panes


### PR DESCRIPTION
* Fixed incorrectly indented `return True` line in `by` filter method in `_info` class methods
* Created intermediate filtered list variables for `_info` class methods to more explicitly define the return type
* Reduced nesting of `if` statements within class `attached` methods
* Removed redundant `int` casts
* Moved `MutableMapping` import statement from `_compat` to `common`