### PR TITLE
Modify retry() to take a callable and enforce the timeout

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,7 +8,7 @@ To install the unreleased libtmux version, see [developmental releases](https://
 $ pip install --user --upgrade --pre libtmux
 ```
 
-## libtmux current (unreleased)
+## libtmux 0.12.x (unreleased)
 
 - _Insert changes/features/fixes for next release here_
 
@@ -21,6 +21,11 @@ $ pip install --user --upgrade --pre libtmux
 ### Documentation
 
 - Try out sphinx-autoapi for its table of contents generation ({issue}`367`)
+
+### Testing
+
+- `retry()`: Add deprecation warning. This will be removed in 0.13.x ({issue}`368`, {issue}`372`)
+- New function `retry_until()`: Polls a callback function for a set period of time until it returns `True` or times out. By default it will raise {exc}`libtmux.exc.WaitTimeout`, with `raises=False` it will return `False`. Thank you @categulario! ({issue}`368`, {issue}`372`)
 
 ## libtmux 0.11.0 (2022-03-10)
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -171,6 +171,10 @@ versions.
 ```
 
 ```{eval-rst}
+.. automethod:: libtmux.test.retry_until
+```
+
+```{eval-rst}
 .. automethod:: libtmux.test.get_test_session_name
 ```
 

--- a/libtmux/exc.py
+++ b/libtmux/exc.py
@@ -49,3 +49,8 @@ class InvalidOption(OptionError):
 class AmbiguousOption(OptionError):
 
     """Option that could potentially match more than one."""
+
+
+class WaitTimeout(LibTmuxException):
+
+    """Function timed out without meeting condition"""

--- a/libtmux/test.py
+++ b/libtmux/test.py
@@ -5,7 +5,7 @@ import os
 import tempfile
 import time
 import warnings
-from typing import Optional
+from typing import Callable, Optional
 
 from .exc import WaitTimeout
 
@@ -57,12 +57,12 @@ def retry(seconds: Optional[float] = RETRY_TIMEOUT_SECONDS) -> bool:
 
 
 def retry_until(
-    fun,
-    seconds=RETRY_TIMEOUT_SECONDS,
+    fun: Callable,
+    seconds: float = RETRY_TIMEOUT_SECONDS,
     *,
-    interval=RETRY_INTERVAL_SECONDS,
-    raises=True,
-):
+    interval: Optional[float] = RETRY_INTERVAL_SECONDS,
+    raises: Optional[bool] = True,
+) -> bool:
     """
     Retry a function until a condition meets or the specified time passes.
 
@@ -71,7 +71,7 @@ def retry_until(
     fun : callable
         A function that will be called repeatedly until it returns ``True``  or
         the specified time passes.
-    seconds : int
+    seconds : float
         Seconds to retry. Defaults to ``8``, which is configurable via
         ``RETRY_TIMEOUT_SECONDS`` environment variables.
     interval : float

--- a/libtmux/test.py
+++ b/libtmux/test.py
@@ -79,6 +79,10 @@ def retry_until(
     ...     return p.current_path == pane_path
     ...
     ... retry(f)
+
+    In pytest:
+
+    >>> assert retry(f, raises=False)
     """
     ini = time.time()
 
@@ -88,8 +92,9 @@ def retry_until(
             if raises:
                 raise WaitTimeout()
             else:
-                break
+                return False
         time.sleep(interval)
+    return True
 
 
 def get_test_session_name(server, prefix=TEST_SESSION_PREFIX):

--- a/libtmux/test.py
+++ b/libtmux/test.py
@@ -4,6 +4,7 @@ import logging
 import os
 import tempfile
 import time
+import warnings
 from typing import Optional
 
 from .exc import WaitTimeout
@@ -23,6 +24,10 @@ fixtures_dir = os.path.realpath(os.path.join(current_dir, "fixtures"))
 def retry(seconds: Optional[float] = RETRY_TIMEOUT_SECONDS) -> bool:
     """
     Retry a block of code until a time limit or ``break``.
+
+    .. deprecated:: 0.12.0
+          `retry` doesn't work, it will be removed in libtmux 0.13.0, it is replaced by
+          `retry_until`, more info: https://github.com/tmux-python/libtmux/issues/368.
 
     Parameters
     ----------
@@ -44,6 +49,10 @@ def retry(seconds: Optional[float] = RETRY_TIMEOUT_SECONDS) -> bool:
     ...     if p.current_path == pane_path:
     ...         break
     """
+    warnings.warn(
+        "retry() is being deprecated and will soon be replaced by retry_until()",
+        DeprecationWarning,
+    )
     return (lambda: time.time() < time.time() + seconds)()
 
 

--- a/libtmux/test.py
+++ b/libtmux/test.py
@@ -4,6 +4,7 @@ import logging
 import os
 import tempfile
 import time
+from typing import Optional
 
 from .exc import WaitTimeout
 
@@ -19,13 +20,13 @@ example_dir = os.path.abspath(os.path.join(current_dir, "..", "examples"))
 fixtures_dir = os.path.realpath(os.path.join(current_dir, "fixtures"))
 
 
-def retry(seconds=RETRY_TIMEOUT_SECONDS):
+def retry(seconds: Optional[float] = RETRY_TIMEOUT_SECONDS) -> bool:
     """
     Retry a block of code until a time limit or ``break``.
 
     Parameters
     ----------
-    seconds : int
+    seconds : float
         Seconds to retry, defaults to ``RETRY_TIMEOUT_SECONDS``, which is
         configurable via environmental variables.
 

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -51,3 +51,37 @@ def test_function_times_out_no_rise():
     end = time()
 
     assert abs((end - ini) - 1.0) < 0.01
+
+
+def test_function_times_out_no_raise_assert():
+    ini = time()
+
+    def never_true():
+        return False
+
+    assert not retry_until(never_true, 1, raises=False)
+
+    end = time()
+
+    assert abs((end - ini) - 1.0) < 0.01
+
+
+def test_retry_three_times_no_raise_assert():
+    ini = time()
+    value = 0
+
+    def call_me_three_times():
+        nonlocal value
+
+        if value == 2:
+            return True
+
+        value += 1
+
+        return False
+
+    assert retry_until(call_me_three_times, 1, raises=False)
+
+    end = time()
+
+    assert abs((end - ini) - 0.1) < 0.01

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -1,0 +1,53 @@
+from time import time
+
+import pytest
+
+from libtmux.test import WaitTimeout, retry_until
+
+
+def test_retry_three_times():
+    ini = time()
+    value = 0
+
+    def call_me_three_times():
+        nonlocal value
+
+        if value == 2:
+            return True
+
+        value += 1
+
+        return False
+
+    retry_until(call_me_three_times, 1)
+
+    end = time()
+
+    assert abs((end - ini) - 0.1) < 0.01
+
+
+def test_function_times_out():
+    ini = time()
+
+    def never_true():
+        return False
+
+    with pytest.raises(WaitTimeout):
+        retry_until(never_true, 1)
+
+    end = time()
+
+    assert abs((end - ini) - 1.0) < 0.01
+
+
+def test_function_times_out_no_rise():
+    ini = time()
+
+    def never_true():
+        return False
+
+    retry_until(never_true, 1, raises=False)
+
+    end = time()
+
+    assert abs((end - ini) - 1.0) < 0.01


### PR DESCRIPTION
Previous implementation is equivalent to `return True`. This implementation, while API incompatible, is easy to use (I would modify the corresponding code in tmuxp myself) and enforces the timeout via an exception, which would help debugging since it provide the specific cause.

API docs updated accordingly. Environment variable preserved.

fixes #368 and addresses https://github.com/tmux-python/tmuxp/issues/704#issuecomment-1128288348 , it would also help with https://github.com/tmux-python/tmuxp/issues/620