### PR TITLE
API Changes - Simplify `EnvironmentMixin`

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -12,6 +12,55 @@ $ pip install --user --upgrade --pre libtmux
 
 - _Insert changes/features/fixes for next release here_
 
+# Breaking changes
+
+- Deprecated individual item lookups ({issue}`390`)
+
+  - Removed key lookups from {meth}`libtmux.common.EnvironmentMixin.show_environment`
+
+    Only `EnvironmentMixin.show_environment()` (without an argument) exists, and
+    it still returns a `dict`.
+
+  - Add key lookups via {meth}`libtmux.common.EnvironmentMixin.getenv`
+
+    ```python
+    # Before
+    server.show_environment('DISPLAY')
+
+    # After
+    server.getenv('DISPLAY')
+
+    # Before
+    session.show_environment('DISPLAY')
+
+    # After
+    session.getenv('DISPLAY')
+    ```
+
+  - Removed key lookups from {meth}`Session.show_options`
+
+    ```python
+    session.show_options()  # still returns dict, without an argument
+
+    # Old
+    session.show_options('DISPLAY')
+
+    # Now
+    session.show_option('DISPLAY')
+    ```
+
+  - Removed key lookups from {meth}`Window.show_window_options`
+
+    ```python
+    window.show_window_options()  # still returns dict, without an argument
+
+    # Old
+    window.show_window_options('DISPLAY')
+
+    # Now
+    window.show_window_option('DISPLAY')
+    ```
+
 ### Development
 
 - Fix incorrect function name `findWhere()` ({issue}`391`)

--- a/libtmux/session.py
+++ b/libtmux/session.py
@@ -421,7 +421,7 @@ class Session(TmuxMappingObject, TmuxRelationalObject, EnvironmentMixin):
         if isinstance(proc.stderr, list) and len(proc.stderr):
             handle_option_error(proc.stderr[0])
 
-    def show_options(self, option=None, _global=False):
+    def show_options(self, _global=False):
         """
         Return a dict of options for the window.
 
@@ -430,9 +430,6 @@ class Session(TmuxMappingObject, TmuxRelationalObject, EnvironmentMixin):
 
         Parameters
         ----------
-        option : str, optional
-            name of option, e.g. 'visual-silence'. Defaults to None, which
-            returns all options.
         _global : bool, optional
             Pass ``-g`` flag for global variable (server-wide)
 
@@ -450,11 +447,8 @@ class Session(TmuxMappingObject, TmuxRelationalObject, EnvironmentMixin):
         if _global:
             tmux_args += ("-g",)
 
-        if option:
-            return self.show_option(option, _global=_global)
-        else:
-            tmux_args += ("show-options",)
-            session_options = self.cmd(*tmux_args).stdout
+        tmux_args += ("show-options",)
+        session_options = self.cmd(*tmux_args).stdout
 
         session_options = [tuple(item.split(" ")) for item in session_options]
 

--- a/libtmux/window.py
+++ b/libtmux/window.py
@@ -193,7 +193,7 @@ class Window(TmuxMappingObject, TmuxRelationalObject):
         if isinstance(cmd.stderr, list) and len(cmd.stderr):
             handle_option_error(cmd.stderr[0])
 
-    def show_window_options(self, option=None, g=False):
+    def show_window_options(self, g=False):
         """
         Return a dict of options for the window.
 
@@ -202,8 +202,6 @@ class Window(TmuxMappingObject, TmuxRelationalObject):
 
         Parameters
         ----------
-        option : str, optional
-            show a single option.
         g : str, optional
             Pass ``-g`` flag for global variable, default False.
 
@@ -217,11 +215,8 @@ class Window(TmuxMappingObject, TmuxRelationalObject):
         if g:
             tmux_args += ("-g",)
 
-        if option:
-            return self.show_window_option(option, g=g)
-        else:
-            tmux_args += ("show-window-options",)
-            cmd = self.cmd(*tmux_args).stdout
+        tmux_args += ("show-window-options",)
+        cmd = self.cmd(*tmux_args).stdout
 
         # The shlex.split function splits the args at spaces, while also
         # retaining quoted sub-strings.

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -63,20 +63,20 @@ def test_show_environment(server):
     assert isinstance(_vars, dict)
 
 
-def test_set_show_environment_single(server, session):
+def test_getenv(server, session):
     """Set environment then Server.show_environment(key)."""
     server.set_environment("FOO", "BAR")
-    assert "BAR" == server.show_environment("FOO")
+    assert "BAR" == server.getenv("FOO")
 
     server.set_environment("FOO", "DAR")
-    assert "DAR" == server.show_environment("FOO")
+    assert "DAR" == server.getenv("FOO")
 
     assert "DAR" == server.show_environment()["FOO"]
 
 
 def test_show_environment_not_set(server):
     """Unset environment variable returns None."""
-    assert server.show_environment("BAR") is None
+    assert server.getenv("BAR") is None
 
 
 def test_new_session(server):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -108,10 +108,10 @@ def test_set_show_options_single(session):
     """Set option then Session.show_options(key)."""
 
     session.set_option("history-limit", 20)
-    assert session.show_options("history-limit") == 20
+    assert session.show_option("history-limit") == 20
 
     session.set_option("history-limit", 40)
-    assert session.show_options("history-limit") == 40
+    assert session.show_option("history-limit") == 40
 
     assert session.show_options()["history-limit"] == 40
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -172,35 +172,35 @@ def test_set_show_environment_single(session):
     """Set environment then Session.show_environment(key)."""
 
     session.set_environment("FOO", "BAR")
-    assert session.show_environment("FOO") == "BAR"
+    assert session.getenv("FOO") == "BAR"
 
     session.set_environment("FOO", "DAR")
-    assert session.show_environment("FOO") == "DAR"
+    assert session.getenv("FOO") == "DAR"
 
     assert session.show_environment()["FOO"] == "DAR"
 
 
 def test_show_environment_not_set(session):
     """Not set environment variable returns None."""
-    assert session.show_environment("BAR") is None
+    assert session.getenv("BAR") is None
 
 
 def test_remove_environment(session):
     """Remove environment variable."""
-    assert session.show_environment("BAM") is None
+    assert session.getenv("BAM") is None
     session.set_environment("BAM", "OK")
-    assert session.show_environment("BAM") == "OK"
+    assert session.getenv("BAM") == "OK"
     session.remove_environment("BAM")
-    assert session.show_environment("BAM") is None
+    assert session.getenv("BAM") is None
 
 
 def test_unset_environment(session):
     """Unset environment variable."""
-    assert session.show_environment("BAM") is None
+    assert session.getenv("BAM") is None
     session.set_environment("BAM", "OK")
-    assert session.show_environment("BAM") == "OK"
+    assert session.getenv("BAM") == "OK"
     session.unset_environment("BAM")
-    assert session.show_environment("BAM") is None
+    assert session.getenv("BAM") is None
 
 
 @pytest.mark.parametrize(

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -184,15 +184,15 @@ def test_set_show_window_options(session):
     window = session.new_window(window_name="test_window")
 
     window.set_window_option("main-pane-height", 20)
-    assert window.show_window_options("main-pane-height") == 20
+    assert window.show_window_option("main-pane-height") == 20
 
     window.set_window_option("main-pane-height", 40)
-    assert window.show_window_options("main-pane-height") == 40
+    assert window.show_window_option("main-pane-height") == 40
     assert window.show_window_options()["main-pane-height"] == 40
 
     if has_gte_version("2.3"):
         window.set_window_option("pane-border-format", " #P ")
-        assert window.show_window_options("pane-border-format") == " #P "
+        assert window.show_window_option("pane-border-format") == " #P "
 
 
 def test_empty_window_option_returns_None(session):


### PR DESCRIPTION
Via #389 


- Removed key lookups from {meth}`libtmux.common.EnvironmentMixin.show_environment`

  Only `EnvironmentMixin.show_environment()` (without an argument) exists, and
  it still returns a `dict`.

- Add key lookups via {meth}`libtmux.common.EnvironmentMixin.getenv`

  ```python
  # Before
  server.show_environment('DISPLAY')

  # After
  server.getenv('DISPLAY')

  # Before
  session.show_environment('DISPLAY')

  # After
  session.getenv('DISPLAY')
  ```

- Removed key lookups from {meth}`Session.show_options`

  ```python
  session.show_options()  # still returns dict, without an argument

  # Old
  session.show_options('DISPLAY')

  # Now
  session.show_option('DISPLAY')
  ```

- Removed key lookups from {meth}`Window.show_window_options`

  ```python
  window.show_window_options()  # still returns dict, without an argument

  # Old
  window.show_window_options('DISPLAY')

  # Now
  window.show_window_option('DISPLAY')
  ```