### PR TITLE
chore!(test): Remove retry(), deprecated in 0.13

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -12,6 +12,14 @@ $ pip install --user --upgrade --pre libtmux
 
 - _Insert changes/features/fixes for next release here_
 
+## What's new
+
+- **Improved typings**
+
+  Now [`mypy --strict`] compliant ({issue}`383`)
+
+  [`mypy --strict`]: https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-strict
+
 ### Breaking changes
 
 - Deprecated individual item lookups ({issue}`390`)
@@ -62,14 +70,6 @@ $ pip install --user --upgrade --pre libtmux
     ```
 
 - Remove `libtmux.test.retry()`, deprecated since 0.12.x ({issue}`393`)
-
-## What's new
-
-- **Improved typings**
-
-  Now [`mypy --strict`] compliant ({issue}`383`)
-
-  [`mypy --strict`]: https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-strict
 
 ### Development
 

--- a/CHANGES
+++ b/CHANGES
@@ -61,6 +61,8 @@ $ pip install --user --upgrade --pre libtmux
     window.show_window_option('DISPLAY')
     ```
 
+- Remove `libtmux.test.retry()`, deprecated since 0.12.x ({issue}`393`)
+
 ## What's new
 
 - **Improved typings**

--- a/libtmux/test.py
+++ b/libtmux/test.py
@@ -6,7 +6,6 @@ import random
 import time
 import types
 import typing as t
-import warnings
 from typing import Callable, Optional
 
 from libtmux.server import Server
@@ -40,41 +39,6 @@ namer = RandomStrSequence()
 current_dir = os.path.abspath(os.path.dirname(__file__))
 example_dir = os.path.abspath(os.path.join(current_dir, "..", "examples"))
 fixtures_dir = os.path.realpath(os.path.join(current_dir, "fixtures"))
-
-
-def retry(seconds: float = RETRY_TIMEOUT_SECONDS) -> bool:
-    """
-    Retry a block of code until a time limit or ``break``.
-
-    .. deprecated:: 0.12.0
-          `retry` doesn't work, it will be removed in libtmux 0.13.0, it is replaced by
-          `retry_until`, more info: https://github.com/tmux-python/libtmux/issues/368.
-
-    Parameters
-    ----------
-    seconds : float
-        Seconds to retry, defaults to ``RETRY_TIMEOUT_SECONDS``, which is
-        configurable via environmental variables.
-
-    Returns
-    -------
-    bool
-        True if time passed since retry() invoked less than seconds param.
-
-    Examples
-    --------
-
-    >>> while retry():
-    ...     p = w.attached_pane
-    ...     p.server._update_panes()
-    ...     if p.current_path == pane_path:
-    ...         break
-    """
-    warnings.warn(
-        "retry() is being deprecated and will soon be replaced by retry_until()",
-        DeprecationWarning,
-    )
-    return (lambda: time.time() < time.time() + seconds)()
 
 
 def retry_until(


### PR DESCRIPTION
This function didn't work, see #368