### PR TITLE
Strict detection of tmux version via regex

### DIFF
--- a/libtmux/common.py
+++ b/libtmux/common.py
@@ -552,7 +552,7 @@ def get_version() -> LooseVersion:
             )
         raise exc.VersionTooLow(proc.stderr)
 
-    version = proc.stdout[0].split("tmux ")[1]
+    version = re.search('[0-9]{1}.[0-9]', proc.stdout[0]).group(0)
 
     # Allow latest tmux HEAD
     if version == "master":


### PR DESCRIPTION
See: #396 

This change uses a more precise regex method to grab the tmux version string, taking into account the many variations of tmux versions:

```
# tmux 3.3a · tmux 3.3 · tmux 3.2a · tmux 3.2 · tmux 3.1c · tmux 3.1b · tmux tmux.org 2.8
```

I tested my change locally with tmuxp as well:

```
[dev-dsk-deguzim-1a-fa82568b DeGuzim-Config]$ tmuxp freeze --force -f yaml --yes --quiet
Save to: /home/deguzim/.tmuxp/work.yaml [/home/deguzim/.tmuxp/work.yaml]: 
[dev-dsk-deguzim-1a-fa82568b DeGuzim-Config]$ cat ~/.tmuxp/work.yaml 
session_name: work
windows:
- focus: 'true'
  layout: 61a9,231x42,0,0[231x16,0,0{150x16,0,0,0,80x16,151,0,2},231x25,0,17,1]
  options: {}
  panes:
  - shell_command:
    - cd /local/home/deguzim/src/libtmux
    - zsh
  - shell_command:
    - cd /local/home/deguzim/src/tmuxp
    - zsh
  - focus: 'true'
    shell_command:
    - cd /local/home/deguzim/src/DeGuzim-Config
    - python3
  window_name: zsh
```

Testing with python3:
```
>>> ver = "tmux 1.8"
>>> import re
>>> re.search('[0-9]{1}.[0-9]', ver).group(0)
'2.8'

>>> ver = "tmux 2.3"
>>> re.search('[0-9]{1}.[0-9]', ver).group(0)
'2.3'
```
Regex 101 test: https://regex101.com/r/y7jsSJ/1