### PR TITLE
fix(Server.session_name): Handle empty session names better

### DIFF
--- a/libtmux/server.py
+++ b/libtmux/server.py
@@ -558,10 +558,12 @@ class Server(TmuxRelationalObject["Session", "SessionDict"], EnvironmentMixin):
             del os.environ["TMUX"]
 
         tmux_args: t.Tuple[t.Union[str, int], ...] = (
-            "-s%s" % session_name,
             "-P",
             "-F%s" % formats.FORMAT_SEPARATOR.join(tmux_formats),  # output
         )
+
+        if session_name is not None:
+            tmux_args += (f"-s{session_name}",)
 
         if not attach:
             tmux_args += ("-d",)

--- a/libtmux/server.py
+++ b/libtmux/server.py
@@ -534,6 +534,20 @@ class Server(TmuxRelationalObject["Session", "SessionDict"], EnvironmentMixin):
         Raises
         ------
         :exc:`exc.BadSessionName`
+
+        Examples
+        --------
+        Sessions can be created without a session name (0.14.2+):
+        >>> server.new_session()
+        Session($2 2)
+
+        Creating them in succession will enumerate IDs (via tmux):
+        >>> server.new_session()
+        Session($3 3)
+
+        With a `session_name`:
+        >>> server.new_session(session_name='my session')
+        Session($4 my session)
         """
         if session_name is not None:
             session_check_name(session_name)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -91,10 +91,19 @@ def test_new_session(server: Server) -> None:
 
 def test_new_session_no_name(server: Server) -> None:
     """Server.new_session works with no name"""
-    mysession = server.new_session()
-    session_name = mysession.get("session_name")
-    assert session_name is not None
-    assert server.has_session(session_name)
+    first_session = server.new_session()
+    first_session_name = first_session.get("session_name")
+    assert first_session_name is not None
+    assert server.has_session(first_session_name)
+
+    expected_session_name = str(int(first_session_name) + 1)
+
+    # When a new session is created, it should enumerate
+    second_session = server.new_session()
+    second_session_name = second_session.get("session_name")
+    assert expected_session_name == second_session_name
+    assert second_session_name is not None
+    assert server.has_session(second_session_name)
 
 
 def test_new_session_shell(server: Server) -> None:


### PR DESCRIPTION
Avoid passing `-s session_name` when no `session_name` passed

Follow up to #400 for #399