### PR TITLE
fix(tmux_cmd): remove only trailing new lines in stdout

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -12,6 +12,12 @@ $ pip install --user --upgrade --pre libtmux
 
 - _Insert changes/features/fixes for next release here_
 
+### Breaking changes
+
+- Fixes #402: {func}`common.tmux_cmd` will only strip _trailing_ empty lines. Before this change,
+  all empty lines were filtered out. This will lead to a more accurate behavior when using
+  {meth}`Pane.capture_pane`. Credit: @rockandska, via #405.
+
 ### Documentation
 
 - Move to sphinx-autoissues, #406

--- a/libtmux/common.py
+++ b/libtmux/common.py
@@ -270,16 +270,21 @@ class tmux_cmd:
 
         stdout_str = console_to_str(stdout)
         stdout_split = stdout_str.split("\n")
-        stdout_filtered = list(filter(None, stdout_split))  # filter empty values
+        # remove trailing newlines from stdout
+        for v in reversed(stdout_split):
+            if v == '':
+                stdout_split.pop()
+            else:
+                break
 
         stderr_str = console_to_str(stderr)
         stderr_split = stderr_str.split("\n")
         self.stderr = list(filter(None, stderr_split))  # filter empty values
 
-        if "has-session" in cmd and len(self.stderr) and not stdout_filtered:
+        if "has-session" in cmd and len(self.stderr) and not stdout_split:
             self.stdout = [self.stderr[0]]
         else:
-            self.stdout = stdout_filtered
+            self.stdout = stdout_split
 
         logger.debug("self.stdout for {}: \n{}".format(" ".join(cmd), self.stdout))
 

--- a/libtmux/common.py
+++ b/libtmux/common.py
@@ -271,11 +271,8 @@ class tmux_cmd:
         stdout_str = console_to_str(stdout)
         stdout_split = stdout_str.split("\n")
         # remove trailing newlines from stdout
-        for v in reversed(stdout_split):
-            if v == '':
-                stdout_split.pop()
-            else:
-                break
+        while stdout_split and stdout_split[-1] == "":
+            stdout_split.pop()
 
         stderr_str = console_to_str(stderr)
         stderr_split = stderr_str.split("\n")

--- a/libtmux/session.py
+++ b/libtmux/session.py
@@ -201,7 +201,7 @@ class Session(
         start_directory: None = None,
         attach: bool = True,
         window_index: str = "",
-        window_shell: None = None,
+        window_shell: t.Optional[str] = None,
     ) -> Window:
         """
         Return :class:`Window` from ``$ tmux new-window``.
@@ -219,7 +219,7 @@ class Session(
         window_index : str
             create the new window at the given index position. Default is empty
             string which will create the window in the next available position.
-        window_shell : str
+        window_shell : str, optional
             execute a command on starting the window.  The window will close
             when the command exits.
 

--- a/tests/test_pane.py
+++ b/tests/test_pane.py
@@ -63,3 +63,24 @@ def test_set_width(session: Session) -> None:
     assert int(pane1["pane_width"]) == 10
 
     pane1.reset()
+
+
+def test_capture_pane(session: Session) -> None:
+    session.new_window(
+        attach=True,
+        window_name="capture_pane",
+        window_shell='env -i PS1="$ " /usr/bin/env bash --norc --noprofile'
+    )
+    pane = session.attached_window.attached_pane
+    assert pane is not None
+    pane_contents = "\n".join(pane.capture_pane())
+    assert pane_contents == '$'
+    pane.send_keys(
+        r'printf "\n%s\n" "Hello World !"',
+        literal=True,
+        suppress_history=False
+    )
+    pane_contents = "\n".join(pane.capture_pane())
+    assert pane_contents == r'$ printf "\n%s\n" "Hello World !"{}'.format(
+        '\n\nHello World !\n$'
+    )


### PR DESCRIPTION
Close #402

Seems the branch v0.8x did not exist anymore to backport this change.