### PR TITLE
fix(`pytest_plugin`): `Pytester` import, use public APIs from pytest

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -19,6 +19,11 @@ $ pip install --user --upgrade --pre libtmux
 - Use stable `pytest` API imports where possible to fix issues in downstream
   packaging on Arch (#441, via #442)
 
+### Packaging
+
+- Add `.tmuxp-before-script.sh` (used by `.tmuxp.yaml`) and `conftest.py` to
+  source distributoins (#441, via #442)
+
 ## libtmux 0.15.3 (2022-09-20)
 
 ### Tests / docs

--- a/CHANGES
+++ b/CHANGES
@@ -12,6 +12,13 @@ $ pip install --user --upgrade --pre libtmux
 
 - _Insert changes/features/fixes for next release here_
 
+## libtmux 0.15.4 (unreleased)
+
+### Bug fixes
+
+- Use stable `pytest` API imports where possible to fix issues in downstream
+  packaging on Arch (#441, via #442)
+
 ## libtmux 0.15.3 (2022-09-20)
 
 ### Tests / docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ packages = [
 include = [
   { path = "CHANGES", format = "sdist" },
   { path = ".tmuxp.yaml", format = "sdist" },
+  { path = ".tmuxp-before-script.sh", format = "sdist" },
   { path = "tests", format = "sdist" },
   { path = "docs", format = "sdist" },
   { path = "conftest.py", format = "sdist" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ include = [
   { path = ".tmuxp.yaml", format = "sdist" },
   { path = "tests", format = "sdist" },
   { path = "docs", format = "sdist" },
+  { path = "conftest.py", format = "sdist" },
 ]
 
 [tool.poetry.urls]

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -8,8 +8,6 @@ from typing import Optional
 
 import pytest
 
-from _pytest.monkeypatch import MonkeyPatch
-
 import libtmux
 from libtmux.common import (
     TMUX_MAX_VERSION,
@@ -31,7 +29,7 @@ from libtmux.session import Session
 version_regex = re.compile(r"([0-9]\.[0-9])|(master)")
 
 
-def test_allows_master_version(monkeypatch: MonkeyPatch) -> None:
+def test_allows_master_version(monkeypatch: pytest.MonkeyPatch) -> None:
     class Hi:
         stdout = ["tmux master"]
         stderr = None
@@ -49,7 +47,7 @@ def test_allows_master_version(monkeypatch: MonkeyPatch) -> None:
     ), "Is the latest supported version with -master appended"
 
 
-def test_allows_next_version(monkeypatch: MonkeyPatch) -> None:
+def test_allows_next_version(monkeypatch: pytest.MonkeyPatch) -> None:
     TMUX_NEXT_VERSION = str(float(TMUX_MAX_VERSION) + 0.1)
 
     class Hi:
@@ -67,7 +65,7 @@ def test_allows_next_version(monkeypatch: MonkeyPatch) -> None:
     assert TMUX_NEXT_VERSION == get_version()
 
 
-def test_get_version_openbsd(monkeypatch: MonkeyPatch) -> None:
+def test_get_version_openbsd(monkeypatch: pytest.MonkeyPatch) -> None:
     class Hi:
         stderr = ["tmux: unknown option -- V"]
 
@@ -84,7 +82,7 @@ def test_get_version_openbsd(monkeypatch: MonkeyPatch) -> None:
     ), "Is the latest supported version with -openbsd appended"
 
 
-def test_get_version_too_low(monkeypatch: MonkeyPatch) -> None:
+def test_get_version_too_low(monkeypatch: pytest.MonkeyPatch) -> None:
     class Hi:
         stderr = ["tmux: unknown option -- V"]
 
@@ -97,7 +95,7 @@ def test_get_version_too_low(monkeypatch: MonkeyPatch) -> None:
     exc_info.match("is running tmux 1.3 or earlier")
 
 
-def test_ignores_letter_versions(monkeypatch: MonkeyPatch) -> None:
+def test_ignores_letter_versions(monkeypatch: pytest.MonkeyPatch) -> None:
     """Ignore letters such as 1.8b.
 
     See ticket https://github.com/tmux-python/tmuxp/issues/55.
@@ -120,7 +118,7 @@ def test_ignores_letter_versions(monkeypatch: MonkeyPatch) -> None:
     assert type(has_version("1.9a")) is bool
 
 
-def test_error_version_less_1_7(monkeypatch: MonkeyPatch) -> None:
+def test_error_version_less_1_7(monkeypatch: pytest.MonkeyPatch) -> None:
     def mock_get_version() -> LooseVersion:
         return LooseVersion("1.7")
 

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -2,11 +2,9 @@ import textwrap
 
 import pytest
 
-import _pytest.pytester
-
 
 def test_plugin(
-    pytester: _pytest.pytester.Pytester,
+    pytester: pytest.Pytester,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     # Initialize variables


### PR DESCRIPTION
Fixes (#441)

Avoid using internal pytest APIs for typing:
- [x] `_pytest.pytester.Pytester` -> `pytest.Pytester`
- [x] `_pytest.monkeypatch.MonkeyPatcher` -> `pytest.MonkeyPatch`
- [ ] `_pytest.doctest.DoctestItem` -> ??? (see https://github.com/pytest-dev/pytest/issues/10312)
- [x] add `conftest.py` to sdist