### PR TITLE
fix(test_capture_pane): use of double `env`

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -14,6 +14,11 @@ $ pip install --user --upgrade --pre libtmux
 
 <!-- Maintainers and contributors: Insert change notes for the next release above -->
 
+### Tests
+
+- Compatibility improvement for `test_capture_pane` and `env` (#452), credit:
+  @zappolowski!
+
 ## libtmux 0.15.9 (2022-10-30)
 
 ### Bug fix

--- a/tests/test_pane.py
+++ b/tests/test_pane.py
@@ -1,5 +1,6 @@
 """Tests for libtmux Pane object."""
 import logging
+import shutil
 
 from libtmux.session import Session
 
@@ -66,10 +67,13 @@ def test_set_width(session: Session) -> None:
 
 
 def test_capture_pane(session: Session) -> None:
+    env = shutil.which("env")
+    assert env is not None, "Cannot find usable `env` in PATH."
+
     session.new_window(
         attach=True,
         window_name="capture_pane",
-        window_shell='env -i PS1="$ " /usr/bin/env bash --norc --noprofile',
+        window_shell=f"{env} PS1='$ ' bash --norc --noprofile",
     )
     pane = session.attached_window.attached_pane
     assert pane is not None


### PR DESCRIPTION
This makes the test fail (at least for me) as it still won't start bash but my login-shell (which is not bash).