### PR TITLE
fix(Window.set_window_option): Remove .refresh()

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -14,6 +14,12 @@ $ pip install --user --upgrade --pre libtmux
 
 <!-- Maintainers and contributors: Insert change notes for the next release above -->
 
+### Fixes
+
+- `Window.set_window_option()`: Remove `.refresh()` (#467)
+
+  See also: https://github.com/tmux-python/tmuxp/issues/860
+
 ## libtmux 0.19.0 (2022-01-07)
 
 ### New features

--- a/src/libtmux/window.py
+++ b/src/libtmux/window.py
@@ -342,9 +342,6 @@ class Window(Obj):
         :exc:`exc.OptionError`, :exc:`exc.UnknownOption`,
         :exc:`exc.InvalidOption`, :exc:`exc.AmbiguousOption`
         """
-
-        self.refresh()
-
         if isinstance(value, bool) and value:
             value = "on"
         elif isinstance(value, bool) and not value:


### PR DESCRIPTION
This causes builder to break
https://github.com/tmux-python/tmuxp/issues/860