### PR TITLE
`FORMAT_SEPARATOR`: Change to a character less likely to collide with buffers

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -14,6 +14,13 @@ $ pip install --user --upgrade --pre libtmux
 
 <!-- Maintainers and contributors: Insert change notes for the next release above -->
 
+### Breaking internal change
+
+- Default format separator (`LIBTMUX_TMUX_FORMAT_SEPARATOR`): `|` -> `␞` (#475,
+  in re: #471, #472)
+
+  Fixes `buffer_sample` with pipes causing `fetch_objs()`-powered listings to fail unexpectedly.
+
 ## libtmux 0.20.0 (2023-01-15)
 
 ### What's new

--- a/src/libtmux/formats.py
+++ b/src/libtmux/formats.py
@@ -8,7 +8,7 @@ For reference: https://github.com/tmux/tmux/blob/master/format.c
 """
 import os
 
-FORMAT_SEPARATOR = os.environ.get("LIBTMUX_TMUX_FORMAT_SEPARATOR", "|")
+FORMAT_SEPARATOR = os.environ.get("LIBTMUX_TMUX_FORMAT_SEPARATOR", "␞")
 
 SESSION_FORMATS = [
     "session_name",


### PR DESCRIPTION
See also https://github.com/tmux-python/libtmux/issues/472 and issue https://github.com/tmux-python/libtmux/issues/471 and PR https://github.com/tmux-python/libtmux/pull/473 from @hongwen000