### PR TITLE
build(build-system): Remove setuptools build dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,5 +130,5 @@ exclude_lines = [
 ]
 
 [build-system]
-requires = ["poetry_core>=1.0.0", "setuptools>50"]
+requires = ["poetry_core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
This was added in https://github.com/tmux-python/libtmux/commit/3bc03fbcaa0c9d7719d9c537645d299b016f8d36 to support `pip install -e .` but I noticed that (per https://github.com/python-poetry/poetry/issues/34#issuecomment-1193722065), this is fixed in `pip` >= 21.3.

For context, I am working on this package in [nixpkgs](https://github.com/NixOS/nixpkgs) and investigating if `setuptools` is really needed as a build dependency.