### PR TITLE
Fix typo, sting -> string

### DIFF
--- a/MIGRATION
+++ b/MIGRATION
@@ -12,7 +12,7 @@ well.
 
    API changes can be painful.
 
-   If we can do something to draw the sting, we'll do it. We're taking a balanced approach. That's why these notes are here!
+   If we can do something to draw the string, we'll do it. We're taking a balanced approach. That's why these notes are here!
 
    (Please pin the package. 🙏)
 


### PR DESCRIPTION
Found via `codespell -H`