### PR TITLE
Fix docstring ordering in pane.split_window

### DIFF
--- a/src/libtmux/pane.py
+++ b/src/libtmux/pane.py
@@ -506,6 +506,8 @@ class Pane(Obj):
             split vertically
         percent: int, optional
             percentage to occupy with respect to current pane
+        environment: dict, optional
+            Environmental variables for new pane. tmux 3.0+ only. Passthrough to ``-e``.
 
         Notes
         -----

--- a/src/libtmux/pane.py
+++ b/src/libtmux/pane.py
@@ -500,10 +500,10 @@ class Pane(Obj):
         ----------
         attach : bool, optional
             Attach / select pane after creation.
-        vertical : bool, optional
-            split vertically
         start_directory : str, optional
             specifies the working directory in which the new pane is created.
+        vertical : bool, optional
+            split vertically
         percent: int, optional
             percentage to occupy with respect to current pane
 


### PR DESCRIPTION
It seems in 0.29->0.30 pane.split_window() argument order was modified, but the corresponding docstring was not change.
This changes argument ordering in the docstring