### PR TITLE
chore(tests): Increase time bias limit to 0.02

### DIFF
--- a/tests/legacy_api/test_test.py
+++ b/tests/legacy_api/test_test.py
@@ -26,7 +26,7 @@ def test_retry_three_times() -> None:
 
     end = time()
 
-    assert abs((end - ini) - 0.1) < 0.01
+    assert abs((end - ini) - 0.1) < 0.02
 
 
 def test_function_times_out() -> None:
@@ -41,7 +41,7 @@ def test_function_times_out() -> None:
 
     end = time()
 
-    assert abs((end - ini) - 1.0) < 0.01
+    assert abs((end - ini) - 1.0) < 0.02
 
 
 def test_function_times_out_no_raise() -> None:
@@ -55,7 +55,7 @@ def test_function_times_out_no_raise() -> None:
 
     end = time()
 
-    assert abs((end - ini) - 1.0) < 0.01
+    assert abs((end - ini) - 1.0) < 0.02
 
 
 def test_function_times_out_no_raise_assert() -> None:
@@ -69,7 +69,7 @@ def test_function_times_out_no_raise_assert() -> None:
 
     end = time()
 
-    assert abs((end - ini) - 1.0) < 0.01
+    assert abs((end - ini) - 1.0) < 0.02
 
 
 def test_retry_three_times_no_raise_assert() -> None:
@@ -91,4 +91,4 @@ def test_retry_three_times_no_raise_assert() -> None:
 
     end = time()
 
-    assert abs((end - ini) - 0.1) < 0.01
+    assert abs((end - ini) - 0.1) < 0.02

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -26,7 +26,7 @@ def test_retry_three_times() -> None:
 
     end = time()
 
-    assert abs((end - ini) - 0.1) < 0.01
+    assert abs((end - ini) - 0.1) < 0.02
 
 
 def test_function_times_out() -> None:
@@ -41,7 +41,7 @@ def test_function_times_out() -> None:
 
     end = time()
 
-    assert abs((end - ini) - 1.0) < 0.01
+    assert abs((end - ini) - 1.0) < 0.02
 
 
 def test_function_times_out_no_raise() -> None:
@@ -55,7 +55,7 @@ def test_function_times_out_no_raise() -> None:
 
     end = time()
 
-    assert abs((end - ini) - 1.0) < 0.01
+    assert abs((end - ini) - 1.0) < 0.02
 
 
 def test_function_times_out_no_raise_assert() -> None:
@@ -69,7 +69,7 @@ def test_function_times_out_no_raise_assert() -> None:
 
     end = time()
 
-    assert abs((end - ini) - 1.0) < 0.01
+    assert abs((end - ini) - 1.0) < 0.02
 
 
 def test_retry_three_times_no_raise_assert() -> None:
@@ -91,4 +91,4 @@ def test_retry_three_times_no_raise_assert() -> None:
 
     end = time()
 
-    assert abs((end - ini) - 0.1) < 0.01
+    assert abs((end - ini) - 0.1) < 0.02


### PR DESCRIPTION
On my RISC-V board, it would be a little more than 0.01, such as 0.012354135513305664.

```text
=================================== FAILURES ===================================
___________________________ test_function_times_out ____________________________

    def test_function_times_out() -> None:
        """Test time outs with retry_until()."""
        ini = time()
    
        def never_true() -> bool:
            return False
    
        with pytest.raises(WaitTimeout):
            retry_until(never_true, 1)
    
        end = time()
    
>       assert abs((end - ini) - 1.0) < 0.01
E       assert 0.01162266731262207 < 0.01
E        +  where 0.01162266731262207 = abs(((1708230824.4211185 - 1708230823.4094958) - 1.0))

tests/test_test.py:44: AssertionError
___________________ test_function_times_out_no_raise_assert ____________________

    def test_function_times_out_no_raise_assert() -> None:
        """Tests retry_until() with exception raising disabled, returning False."""
        ini = time()
    
        def never_true() -> bool:
            return False
    
        assert not retry_until(never_true, 1, raises=False)
    
        end = time()
    
>       assert abs((end - ini) - 1.0) < 0.01
E       assert 0.011825084686279297 < 0.01
E        +  where 0.011825084686279297 = abs(((1708230826.5377028 - 1708230825.5258777) - 1.0))

tests/test_test.py:72: AssertionError
_______________________ test_function_times_out_no_raise _______________________

    def test_function_times_out_no_raise() -> None:
        """Tests retry_until() with exception raising disabled."""
        ini = time()
    
        def never_true() -> bool:
            return False
    
        retry_until(never_true, 1, raises=False)
    
        end = time()
    
>       assert abs((end - ini) - 1.0) < 0.01
E       assert 0.012354135513305664 < 0.01
E        +  where 0.012354135513305664 = abs(((1708230865.1922984 - 1708230864.1799443) - 1.0))

tests/legacy_api/test_test.py:58: AssertionError
___________________ test_function_times_out_no_raise_assert ____________________

    def test_function_times_out_no_raise_assert() -> None:
        """Tests retry_until() with exception raising disabled, returning False."""
        ini = time()
    
        def never_true() -> bool:
            return False
    
        assert not retry_until(never_true, 1, raises=False)
    
        end = time()
    
>       assert abs((end - ini) - 1.0) < 0.01
E       assert 0.010137319564819336 < 0.01
E        +  where 0.010137319564819336 = abs(((1708230866.2246602 - 1708230865.2145228) - 1.0))

tests/legacy_api/test_test.py:72: AssertionError
=========================== short test summary info ============================
FAILED tests/test_test.py::test_function_times_out - assert 0.011622667312622...
FAILED tests/test_test.py::test_function_times_out_no_raise_assert - assert 0...
FAILED tests/legacy_api/test_test.py::test_function_times_out_no_raise - asse...
FAILED tests/legacy_api/test_test.py::test_function_times_out_no_raise_assert
```