### PR TITLE
fix: server.attached_sessions

### DIFF
--- a/src/libtmux/server.py
+++ b/src/libtmux/server.py
@@ -260,7 +260,7 @@ class Server(EnvironmentMixin):
         -------
         list of :class:`Session`
         """
-        return self.sessions.filter(session_attached="1")
+        return [s for s in self.sessions if s.session_attached != "0"]
 
     def has_session(self, target_session: str, exact: bool = True) -> bool:
         """Return True if session exists.


### PR DESCRIPTION
The current implementation of `server.attached_sessions` excludes sessions that have more than one client attached.