### PR TITLE
[docs] Sphinx v8 compatibility: configure a non-empty inventory name for Python Intersphinx mapping.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -133,7 +133,7 @@ ogp_image = "_static/img/icons/icon-192x192.png"
 ogp_site_name = about["__title__"]
 
 intersphinx_mapping = {
-    "": ("https://docs.python.org/", None),
+    "python": ("https://docs.python.org/", None),
     "pytest": ("https://docs.pytest.org/en/stable/", None),
 }
 


### PR DESCRIPTION
From [Sphinx](https://github.com/sphinx-doc/sphinx/) version 8.0 onwards, some legacy behaviours of the `intersphinx_mapping` configuration setting will be dropped, and validation of Intersphinx mapping names is being tightened to require non-empty mapping names.

Based on a [code search on GitHub](https://github.com/search?q=path%3Aconf.py+intersphinx_mapping+%2F%5E%5B+%5D*%5B%27%22%5D%5B%27%22%5D%3A+%5C%28%2F&type=code) I discovered your project as one that is recently-maintained and has an `intersphinx_mapping` configuration containing an empty-string name entry.  Because only a small number of source repositories are affected, I'm opening pull requests to offer corresponding configuration updates.

Note: I'm unfamiliar with the details of the `libtmux` documentation, so the extent of my testing has been:

  * Install a minimal set of dependencies for the project.
  * Disable the `linkify_issues` Sphinx extension since I couldn't initially find the origin for it.
  * Build the project as HTML using Sphinx v7.4.7 (the latest and perhaps last pre-v8.x release).
  * Confirmed that the documentation build succeeded.