### PR TITLE
Fix docstring for `color` parameter

### DIFF
--- a/src/libtmux/server.py
+++ b/src/libtmux/server.py
@@ -96,7 +96,7 @@ class Server(EnvironmentMixin):
     config_file = None
     """Passthrough to ``[-f file]``"""
     colors = None
-    """``-2`` or ``-8``"""
+    """``256`` or ``88``"""
     child_id_attribute = "session_id"
     """Unique child ID used by :class:`~libtmux.common.TmuxRelationalObject`"""
     formatter_prefix = "server_"


### PR DESCRIPTION
This PR fixes an incorrect docstring.

For the `color` parameter, the API for libtmux actually expects either `256` or `88`. See this place in code: https://github.com/tmux-python/libtmux/blob/master/src/libtmux/server.py#L238