### PR TITLE
Fix passing both window command and environment

### DIFF
--- a/src/libtmux/server.py
+++ b/src/libtmux/server.py
@@ -499,9 +499,6 @@ class Server(EnvironmentMixin):
         if y is not None:
             tmux_args += ("-y", y)
 
-        if window_command:
-            tmux_args += (window_command,)
-
         if environment:
             if has_gte_version("3.2"):
                 for k, v in environment.items():
@@ -510,6 +507,9 @@ class Server(EnvironmentMixin):
                 logger.warning(
                     "Environment flag ignored, tmux 3.2 or newer required.",
                 )
+
+        if window_command:
+            tmux_args += (window_command,)
 
         proc = self.cmd("new-session", *tmux_args)
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,7 +1,9 @@
 """Test for libtmux Server object."""
 
 import logging
+import os
 import subprocess
+import time
 
 import pytest
 
@@ -121,6 +123,28 @@ def test_new_session_shell(server: Server) -> None:
     pane = window.panes[0]
     assert mysession.session_name == "test_new_session"
     assert server.has_session("test_new_session")
+
+    pane_start_command = pane.pane_start_command
+    assert pane_start_command is not None
+
+    if has_gte_version("3.2"):
+        assert pane_start_command.replace('"', "") == cmd
+    else:
+        assert pane_start_command == cmd
+
+
+def test_new_session_shell_env(server: Server) -> None:
+    """Verify ``Server.new_session`` creates valid session running w/ command."""
+    cmd = "sleep 1m"
+    env = dict(os.environ)
+    mysession = server.new_session(
+        "test_new_session_env", window_command=cmd, environment=env
+    )
+    time.sleep(0.1)
+    window = mysession.windows[0]
+    pane = window.panes[0]
+    assert mysession.session_name == "test_new_session_env"
+    assert server.has_session("test_new_session_env")
 
     pane_start_command = pane.pane_start_command
     assert pane_start_command is not None


### PR DESCRIPTION
If the `-e this=that` options are passed after a window command, tmux (correctly, IMHO) interprets them as options to be passed to the command itself, does not change the environment, and passes them through to the command, which does not usually expect to get a whole lot of `-e this=that -e other=something` options.

For a demonstration, see https://gitlab.com/-/snippets/4782141