### PR TITLE
fix inconsistency in doc: send_keys

### DIFF
--- a/src/libtmux/pane.py
+++ b/src/libtmux/pane.py
@@ -367,7 +367,7 @@ class Pane(Obj):
 
                Default changed from True to False.
         literal : bool, optional
-            Send keys literally, default True.
+            Send keys literally, default False.
 
         Examples
         --------


### PR DESCRIPTION
There is a minor doc inconsistency when I read the `send_keys()` method of `pane`. This fixes it.