### PR TITLE
refactor(typing): Narrow t.Any to specific types across codebase

### DIFF
--- a/src/libtmux/exc.py
+++ b/src/libtmux/exc.py
@@ -351,7 +351,7 @@ class WaitTimeout(LibTmuxException):
 class VariableUnpackingError(LibTmuxException):
     """Error unpacking variable."""
 
-    def __init__(self, variable: t.Any | None = None, *args: object) -> None:
+    def __init__(self, variable: object | None = None, *args: object) -> None:
         return super().__init__(f"Unexpected variable: {variable!s}")
 
 

--- a/src/libtmux/hooks.py
+++ b/src/libtmux/hooks.py
@@ -50,7 +50,7 @@ from libtmux.options import handle_option_error
 if t.TYPE_CHECKING:
     from typing_extensions import Self
 
-HookDict = dict[str, t.Any]
+HookDict = dict[str, int | str]
 HookValues = dict[int, str] | SparseArray[str] | list[str]
 
 logger = logging.getLogger(__name__)

--- a/src/libtmux/pane.py
+++ b/src/libtmux/pane.py
@@ -2781,7 +2781,7 @@ class Pane(
             version="0.33.0",
         )
 
-    def get(self, key: str, default: t.Any | None = None) -> t.Any:
+    def get(self, key: str, default: object | None = None) -> object:
         """Return key-based lookup. Deprecated by attributes.
 
         .. deprecated:: 0.17
@@ -2796,7 +2796,7 @@ class Pane(
             version="0.17.0",
         )
 
-    def __getitem__(self, key: str) -> t.Any:
+    def __getitem__(self, key: str) -> object:
         """Return item lookup by key. Deprecated in favor of attributes.
 
         .. deprecated:: 0.17

--- a/src/libtmux/pytest_plugin.py
+++ b/src/libtmux/pytest_plugin.py
@@ -59,6 +59,19 @@ def _reap_test_server(socket_name: str | None) -> None:
         socket_path.unlink(missing_ok=True)
 
 
+class SessionParams(t.TypedDict, total=False):
+    """Keyword arguments for :meth:`libtmux.Server.new_session` in tests."""
+
+    kill_session: bool
+    attach: bool
+    start_directory: os.PathLike[str] | str | None
+    window_name: str | None
+    window_command: str | None
+    x: int | t.Literal["-"] | None
+    y: int | t.Literal["-"] | None
+    environment: dict[str, str] | None
+
+
 @pytest.fixture(scope="session")
 def home_path(tmp_path_factory: pytest.TempPathFactory) -> pathlib.Path:
     """Temporary `/home/` path."""
@@ -183,7 +196,7 @@ def server(
 
 
 @pytest.fixture
-def session_params() -> dict[str, t.Any]:
+def session_params() -> SessionParams:
     """Return default session creation parameters.
 
     >>> import pytest
@@ -223,7 +236,7 @@ def session_params() -> dict[str, t.Any]:
 @pytest.fixture
 def session(
     request: pytest.FixtureRequest,
-    session_params: dict[str, t.Any],
+    session_params: SessionParams,
     server: Server,
 ) -> Session:
     """Return new, temporary :class:`libtmux.Session`.

--- a/src/libtmux/server.py
+++ b/src/libtmux/server.py
@@ -2763,7 +2763,7 @@ class Server(
             version="0.16.0",
         )
 
-    def where(self, kwargs: dict[str, t.Any]) -> list[Session]:
+    def where(self, kwargs: dict[str, object]) -> list[Session]:
         """Filter through sessions, return list of :class:`Session`.
 
         .. deprecated:: 0.17
@@ -2777,7 +2777,7 @@ class Server(
             version="0.17.0",
         )
 
-    def find_where(self, kwargs: dict[str, t.Any]) -> Session | None:
+    def find_where(self, kwargs: dict[str, object]) -> Session | None:
         """Filter through sessions, return first :class:`Session`.
 
         .. deprecated:: 0.17

--- a/src/libtmux/session.py
+++ b/src/libtmux/session.py
@@ -1082,7 +1082,7 @@ class Session(
             version="0.30.0",
         )
 
-    def get(self, key: str, default: t.Any | None = None) -> t.Any:
+    def get(self, key: str, default: object | None = None) -> object:
         """Return key-based lookup. Deprecated by attributes.
 
         .. deprecated:: 0.17
@@ -1097,7 +1097,7 @@ class Session(
             version="0.17.0",
         )
 
-    def __getitem__(self, key: str) -> t.Any:
+    def __getitem__(self, key: str) -> object:
         """Return item lookup by key. Deprecated in favor of attributes.
 
         .. deprecated:: 0.17
@@ -1126,7 +1126,7 @@ class Session(
             version="0.16.0",
         )
 
-    def where(self, kwargs: dict[str, t.Any]) -> list[Window]:
+    def where(self, kwargs: dict[str, object]) -> list[Window]:
         """Filter through windows, return list of :class:`Window`.
 
         .. deprecated:: 0.17
@@ -1140,7 +1140,7 @@ class Session(
             version="0.17.0",
         )
 
-    def find_where(self, kwargs: dict[str, t.Any]) -> Window | None:
+    def find_where(self, kwargs: dict[str, object]) -> Window | None:
         """Filter through windows, return first :class:`Window`.
 
         .. deprecated:: 0.17

--- a/src/libtmux/test/temporary.py
+++ b/src/libtmux/test/temporary.py
@@ -24,7 +24,7 @@ def temp_session(
     server: Server,
     *args: t.Any,
     **kwargs: t.Any,
-) -> Generator[Session, t.Any, t.Any]:
+) -> Generator[Session, None, None]:
     """
     Return a context manager with a temporary session.
 
@@ -75,7 +75,7 @@ def temp_window(
     session: Session,
     *args: t.Any,
     **kwargs: t.Any,
-) -> Generator[Window, t.Any, t.Any]:
+) -> Generator[Window, None, None]:
     """
     Return a context manager with a temporary window.
 

--- a/src/libtmux/test/temporary.py
+++ b/src/libtmux/test/temporary.py
@@ -9,8 +9,11 @@ from libtmux.test.random import get_test_session_name, get_test_window_name
 
 if t.TYPE_CHECKING:
     import sys
-    from collections.abc import Generator
 
+    from typing_extensions import Unpack
+
+    from libtmux._internal.types import StrPath
+    from libtmux.constants import WindowDirection
     from libtmux.server import Server
     from libtmux.session import Session
     from libtmux.window import Window
@@ -19,12 +22,73 @@ if t.TYPE_CHECKING:
         pass
 
 
+class TempSessionParams(t.TypedDict, total=False):
+    """Keyword arguments for :func:`temp_session`."""
+
+    session_name: str | None
+    kill_session: bool
+    attach: bool
+    start_directory: StrPath | None
+    window_name: str | None
+    window_command: str | None
+    x: int | t.Literal["-"] | None
+    y: int | t.Literal["-"] | None
+    environment: dict[str, str] | None
+
+
+class TempWindowParams(t.TypedDict, total=False):
+    """Keyword arguments for :func:`temp_window`."""
+
+    window_name: str | None
+    start_directory: StrPath | None
+    attach: bool
+    window_index: str
+    window_shell: str | None
+    environment: dict[str, str] | None
+    direction: WindowDirection | None
+    target_window: str | None
+
+
 @contextlib.contextmanager
+def _temp_session(
+    server: Server,
+    *args: t.Any,
+    **kwargs: t.Any,
+) -> t.Iterator[Session]:
+    if "session_name" in kwargs:
+        session_name = kwargs.pop("session_name")
+    else:
+        session_name = get_test_session_name(server)
+
+    session = server.new_session(session_name, *args, **kwargs)
+
+    try:
+        yield session
+    finally:
+        if server.has_session(session_name):
+            session.kill()
+
+
+@t.overload
+def temp_session(
+    server: Server,
+    **kwargs: Unpack[TempSessionParams],
+) -> contextlib.AbstractContextManager[Session]: ...
+
+
+@t.overload
 def temp_session(
     server: Server,
     *args: t.Any,
     **kwargs: t.Any,
-) -> Generator[Session, None, None]:
+) -> contextlib.AbstractContextManager[Session]: ...
+
+
+def temp_session(
+    server: Server,
+    *args: t.Any,
+    **kwargs: t.Any,
+) -> contextlib.AbstractContextManager[Session]:
     """
     Return a context manager with a temporary session.
 
@@ -55,27 +119,54 @@ def temp_session(
     ...     session.new_window(window_name='my window')
     Window(@3 2:my window, Session($... ...))
     """
-    if "session_name" in kwargs:
-        session_name = kwargs.pop("session_name")
-    else:
-        session_name = get_test_session_name(server)
-
-    session = server.new_session(session_name, *args, **kwargs)
-
-    try:
-        yield session
-    finally:
-        if server.has_session(session_name):
-            session.kill()
-    return
+    return _temp_session(server, *args, **kwargs)
 
 
 @contextlib.contextmanager
+def _temp_window(
+    session: Session,
+    *args: t.Any,
+    **kwargs: t.Any,
+) -> t.Iterator[Window]:
+    if "window_name" not in kwargs:
+        window_name = get_test_window_name(session)
+    else:
+        window_name = kwargs.pop("window_name")
+
+    window = session.new_window(window_name, *args, **kwargs)
+
+    # Get ``window_id`` before returning it, it may be killed within context.
+    window_id = window.window_id
+    assert window_id is not None
+    assert isinstance(window_id, str)
+
+    try:
+        yield window
+    finally:
+        if len(session.windows.filter(window_id=window_id)) > 0:
+            window.kill()
+
+
+@t.overload
+def temp_window(
+    session: Session,
+    **kwargs: Unpack[TempWindowParams],
+) -> contextlib.AbstractContextManager[Window]: ...
+
+
+@t.overload
 def temp_window(
     session: Session,
     *args: t.Any,
     **kwargs: t.Any,
-) -> Generator[Window, None, None]:
+) -> contextlib.AbstractContextManager[Window]: ...
+
+
+def temp_window(
+    session: Session,
+    *args: t.Any,
+    **kwargs: t.Any,
+) -> contextlib.AbstractContextManager[Window]:
     """
     Return a context manager with a temporary window.
 
@@ -112,21 +203,4 @@ def temp_window(
     ...     window.split()
     Pane(%4 Window(@3 2:libtmux_..., Session($1 libtmux_...)))
     """
-    if "window_name" not in kwargs:
-        window_name = get_test_window_name(session)
-    else:
-        window_name = kwargs.pop("window_name")
-
-    window = session.new_window(window_name, *args, **kwargs)
-
-    # Get ``window_id`` before returning it, it may be killed within context.
-    window_id = window.window_id
-    assert window_id is not None
-    assert isinstance(window_id, str)
-
-    try:
-        yield window
-    finally:
-        if len(session.windows.filter(window_id=window_id)) > 0:
-            window.kill()
-    return
+    return _temp_window(session, *args, **kwargs)

--- a/src/libtmux/test/temporary.py
+++ b/src/libtmux/test/temporary.py
@@ -36,6 +36,19 @@ class TempSessionParams(t.TypedDict, total=False):
     environment: dict[str, str] | None
 
 
+class TempSessionKwargs(t.TypedDict, total=False):
+    """Keyword arguments forwarded to :meth:`Server.new_session`."""
+
+    kill_session: bool
+    attach: bool
+    start_directory: StrPath | None
+    window_name: str | None
+    window_command: str | None
+    x: int | t.Literal["-"] | None
+    y: int | t.Literal["-"] | None
+    environment: dict[str, str] | None
+
+
 class TempWindowParams(t.TypedDict, total=False):
     """Keyword arguments for :func:`temp_window`."""
 
@@ -49,23 +62,44 @@ class TempWindowParams(t.TypedDict, total=False):
     target_window: str | None
 
 
+class TempWindowKwargs(t.TypedDict, total=False):
+    """Keyword arguments forwarded to :meth:`Session.new_window`."""
+
+    start_directory: StrPath | None
+    attach: bool
+    window_index: str
+    window_shell: str | None
+    environment: dict[str, str] | None
+    direction: WindowDirection | None
+    target_window: str | None
+
+
 @contextlib.contextmanager
 def _temp_session(
     server: Server,
     *args: t.Any,
-    **kwargs: t.Any,
+    **kwargs: object,
 ) -> t.Iterator[Session]:
-    if "session_name" in kwargs:
-        session_name = kwargs.pop("session_name")
+    kwargs_typed = t.cast("TempSessionParams", dict(kwargs))
+    if "session_name" in kwargs_typed:
+        session_name = kwargs_typed["session_name"]
     else:
         session_name = get_test_session_name(server)
+    kwargs_no_name = t.cast(
+        "TempSessionKwargs",
+        {k: v for k, v in kwargs_typed.items() if k != "session_name"},
+    )
 
-    session = server.new_session(session_name, *args, **kwargs)
+    session = server.new_session(
+        session_name,
+        *args,
+        **kwargs_no_name,
+    )
 
     try:
         yield session
     finally:
-        if server.has_session(session_name):
+        if isinstance(session_name, str) and server.has_session(session_name):
             session.kill()
 
 
@@ -80,14 +114,14 @@ def temp_session(
 def temp_session(
     server: Server,
     *args: t.Any,
-    **kwargs: t.Any,
+    **kwargs: object,
 ) -> contextlib.AbstractContextManager[Session]: ...
 
 
 def temp_session(
     server: Server,
     *args: t.Any,
-    **kwargs: t.Any,
+    **kwargs: object,
 ) -> contextlib.AbstractContextManager[Session]:
     """
     Return a context manager with a temporary session.
@@ -126,14 +160,23 @@ def temp_session(
 def _temp_window(
     session: Session,
     *args: t.Any,
-    **kwargs: t.Any,
+    **kwargs: object,
 ) -> t.Iterator[Window]:
-    if "window_name" not in kwargs:
-        window_name = get_test_window_name(session)
+    kwargs_typed = t.cast("TempWindowParams", dict(kwargs))
+    if "window_name" in kwargs_typed:
+        window_name = kwargs_typed["window_name"]
     else:
-        window_name = kwargs.pop("window_name")
+        window_name = get_test_window_name(session)
+    kwargs_no_name = t.cast(
+        "TempWindowKwargs",
+        {k: v for k, v in kwargs_typed.items() if k != "window_name"},
+    )
 
-    window = session.new_window(window_name, *args, **kwargs)
+    window = session.new_window(
+        window_name,
+        *args,
+        **kwargs_no_name,
+    )
 
     # Get ``window_id`` before returning it, it may be killed within context.
     window_id = window.window_id
@@ -158,14 +201,14 @@ def temp_window(
 def temp_window(
     session: Session,
     *args: t.Any,
-    **kwargs: t.Any,
+    **kwargs: object,
 ) -> contextlib.AbstractContextManager[Window]: ...
 
 
 def temp_window(
     session: Session,
     *args: t.Any,
-    **kwargs: t.Any,
+    **kwargs: object,
 ) -> contextlib.AbstractContextManager[Window]:
     """
     Return a context manager with a temporary window.

--- a/src/libtmux/window.py
+++ b/src/libtmux/window.py
@@ -1849,7 +1849,7 @@ class Window(
             global_=g,
         )
 
-    def get(self, key: str, default: t.Any | None = None) -> t.Any:
+    def get(self, key: str, default: object | None = None) -> object:
         """Return key-based lookup. Deprecated by attributes.
 
         .. deprecated:: 0.17
@@ -1864,7 +1864,7 @@ class Window(
             version="0.17.0",
         )
 
-    def __getitem__(self, key: str) -> t.Any:
+    def __getitem__(self, key: str) -> object:
         """Return item lookup by key. Deprecated in favor of attributes.
 
         .. deprecated:: 0.17
@@ -1893,7 +1893,7 @@ class Window(
             version="0.16.0",
         )
 
-    def where(self, kwargs: dict[str, t.Any]) -> list[Pane]:
+    def where(self, kwargs: dict[str, object]) -> list[Pane]:
         """Filter through panes, return list of :class:`Pane`.
 
         .. deprecated:: 0.17
@@ -1907,7 +1907,7 @@ class Window(
             version="0.17.0",
         )
 
-    def find_where(self, kwargs: dict[str, t.Any]) -> Pane | None:
+    def find_where(self, kwargs: dict[str, object]) -> Pane | None:
         """Filter through panes, return first :class:`Pane`.
 
         .. deprecated:: 0.17

--- a/tests/_internal/test_query_list.py
+++ b/tests/_internal/test_query_list.py
@@ -12,7 +12,11 @@ from libtmux._internal.query_list import (
 )
 
 if t.TYPE_CHECKING:
-    from collections.abc import Callable
+    pass
+
+
+FilterExpr: t.TypeAlias = t.Callable[[object], bool] | object | None
+ExpectedResult: t.TypeAlias = QueryList[object] | list[object]
 
 
 @dataclasses.dataclass
@@ -256,9 +260,9 @@ class Obj:
     ],
 )
 def test_filter(
-    items: list[dict[str, t.Any]],
-    filter_expr: Callable[[t.Any], bool] | t.Any | None,
-    expected_result: QueryList[t.Any] | list[dict[str, t.Any]],
+    items: list[object],
+    filter_expr: FilterExpr,
+    expected_result: ExpectedResult,
 ) -> None:
     qs = QueryList(items)
     if filter_expr is not None:

--- a/tests/legacy_api/test_common.py
+++ b/tests/legacy_api/test_common.py
@@ -43,7 +43,7 @@ def test_allows_master_version(monkeypatch: pytest.MonkeyPatch) -> None:
         stdout: t.ClassVar = ["tmux master"]
         stderr = None
 
-    def mock_tmux_cmd(*args: t.Any, **kwargs: t.Any) -> Hi:
+    def mock_tmux_cmd(*args: object, **kwargs: object) -> Hi:
         return Hi()
 
     monkeypatch.setattr(libtmux.common, "tmux_cmd", mock_tmux_cmd)
@@ -64,7 +64,7 @@ def test_allows_next_version(monkeypatch: pytest.MonkeyPatch) -> None:
         stdout: t.ClassVar = [f"tmux next-{TMUX_NEXT_VERSION}"]
         stderr = None
 
-    def mock_tmux_cmd(*args: t.Any, **kwargs: t.Any) -> Hi:
+    def mock_tmux_cmd(*args: object, **kwargs: object) -> Hi:
         return Hi()
 
     monkeypatch.setattr(libtmux.common, "tmux_cmd", mock_tmux_cmd)
@@ -81,7 +81,7 @@ def test_get_version_openbsd(monkeypatch: pytest.MonkeyPatch) -> None:
     class Hi:
         stderr: t.ClassVar = ["tmux: unknown option -- V"]
 
-    def mock_tmux_cmd(*args: t.Any, **kwargs: t.Any) -> Hi:
+    def mock_tmux_cmd(*args: object, **kwargs: object) -> Hi:
         return Hi()
 
     monkeypatch.setattr(libtmux.common, "tmux_cmd", mock_tmux_cmd)
@@ -100,7 +100,7 @@ def test_get_version_too_low(monkeypatch: pytest.MonkeyPatch) -> None:
     class Hi:
         stderr: t.ClassVar = ["tmux: unknown option -- V"]
 
-    def mock_tmux_cmd(*args: t.Any, **kwargs: t.Any) -> Hi:
+    def mock_tmux_cmd(*args: object, **kwargs: object) -> Hi:
         return Hi()
 
     monkeypatch.setattr(libtmux.common, "tmux_cmd", mock_tmux_cmd)

--- a/tests/legacy_api/test_version.py
+++ b/tests/legacy_api/test_version.py
@@ -22,7 +22,7 @@ if t.TYPE_CHECKING:
         RaisesExc: TypeAlias = RaisesContext[Exception]  # type: ignore[no-redef]
 
     VersionCompareOp: TypeAlias = Callable[
-        [t.Any, t.Any],
+        [LooseVersion, LooseVersion],
         bool,
     ]
 
@@ -48,9 +48,9 @@ def test_version(version: str) -> None:
 class VersionCompareFixture(t.NamedTuple):
     """Test fixture for version comparison."""
 
-    a: object
+    a: str
     op: VersionCompareOp
-    b: object
+    b: str
     raises: type[Exception] | bool
 
 

--- a/tests/test/test_sparse_array.py
+++ b/tests/test/test_sparse_array.py
@@ -7,13 +7,14 @@ import typing as t
 import pytest
 
 from libtmux._internal.sparse_array import SparseArray, is_sparse_array_list
+from libtmux.options import ExplodedComplexUntypedOptionsDict
 
 
 class IsSparseArrayListTestCase(t.NamedTuple):
     """Test case for is_sparse_array_list TypeGuard function."""
 
     test_id: str
-    input_dict: dict[str, t.Any]
+    input_dict: ExplodedComplexUntypedOptionsDict
     expected: bool
 
 
@@ -39,12 +40,12 @@ IS_SPARSE_ARRAY_LIST_TEST_CASES: list[IsSparseArrayListTestCase] = [
     IsSparseArrayListTestCase("empty_dict", {}, True),
     IsSparseArrayListTestCase(
         "sparse_arrays_only",
-        {"hook1": SparseArray(), "hook2": SparseArray()},
+        {"hook1": SparseArray[str | int](), "hook2": SparseArray[str | int]()},
         True,
     ),
     IsSparseArrayListTestCase(
         "mixed_values",
-        {"hook1": SparseArray(), "opt": "string"},
+        {"hook1": SparseArray[str | int](), "opt": "string"},
         False,
     ),
     IsSparseArrayListTestCase(

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -474,7 +474,7 @@ def test_version_parsing(
         stdout = mock_stdout
         stderr = mock_stderr
 
-    def mock_tmux_cmd(*args: t.Any, **kwargs: t.Any) -> MockTmuxOutput:
+    def mock_tmux_cmd(*args: object, **kwargs: object) -> MockTmuxOutput:
         return MockTmuxOutput()
 
     monkeypatch.setattr(libtmux.common, "tmux_cmd", mock_tmux_cmd)

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -25,7 +25,7 @@ if t.TYPE_CHECKING:
     ListExtraArgs = tuple[str] | None
 
 
-OutputRaw = dict[str, t.Any]
+OutputRaw = dict[str, str]
 OutputsRaw = list[OutputRaw]
 
 

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -11,6 +11,8 @@ from libtmux._internal.sparse_array import SparseArray
 from libtmux.common import has_gte_version
 
 if t.TYPE_CHECKING:
+    from _pytest.mark.structures import ParameterSet
+
     from libtmux.server import Server
 
 
@@ -420,11 +422,11 @@ ALL_HOOK_TEST_CASES: list[HookTestCase] = (
 )
 
 
-def _build_hook_params() -> list[t.Any]:
+def _build_hook_params() -> list[ParameterSet]:
     """Build pytest params with appropriate marks."""
     params = []
     for tc in ALL_HOOK_TEST_CASES:
-        marks: list[t.Any] = []
+        marks: list[pytest.MarkDecorator] = []
         if tc.xfail_reason:
             marks.append(pytest.mark.xfail(reason=tc.xfail_reason))
         params.append(pytest.param(tc, id=tc.test_id, marks=marks))
@@ -521,9 +523,16 @@ class SetHooksTestCase(t.NamedTuple):
     test_id: str
     hook: str  # Hook name to test
     setup_hooks: dict[int, str]  # Initial hooks to set (index -> value)
-    operation_args: dict[str, t.Any]  # Args for set_hooks
+    operation_args: SetHooksOperationArgs
     expected_indices: list[int]  # Expected indices after operation
     expected_contains: list[str] | None = None  # Strings expected in values
+
+
+class SetHooksOperationArgs(t.TypedDict, total=False):
+    """Keyword arguments for set_hooks."""
+
+    values: dict[int, str] | SparseArray[str] | list[str]
+    clear_existing: bool
 
 
 SET_HOOKS_TESTS: list[SetHooksTestCase] = [
@@ -565,7 +574,7 @@ SET_HOOKS_TESTS: list[SetHooksTestCase] = [
 ]
 
 
-def _build_set_hooks_params() -> list[t.Any]:
+def _build_set_hooks_params() -> list[ParameterSet]:
     """Build pytest params for set_hooks tests."""
     return [pytest.param(tc, id=tc.test_id) for tc in SET_HOOKS_TESTS]
 
@@ -816,7 +825,7 @@ SHOW_HOOKS_TEST_CASES: list[ShowHooksTestCase] = [
 ]
 
 
-def _build_show_hooks_params() -> list[t.Any]:
+def _build_show_hooks_params() -> list[ParameterSet]:
     """Build pytest params for show_hooks tests."""
     return [pytest.param(tc, id=tc.test_id) for tc in SHOW_HOOKS_TEST_CASES]
 
@@ -877,9 +886,17 @@ class SetHookFlagTestCase(t.NamedTuple):
     """Test case for set_hook flag combinations."""
 
     test_id: str
-    flag_kwargs: dict[str, t.Any]
+    flag_kwargs: SetHookFlagArgs
     expected_behavior: str  # "sets_hook", "runs_immediately", "appends", "global"
     min_version: str = "3.2"
+
+
+class SetHookFlagArgs(t.TypedDict, total=False):
+    """Keyword arguments for set_hook flags."""
+
+    append: bool
+    global_: bool
+    run: bool
 
 
 SET_HOOK_FLAG_TEST_CASES: list[SetHookFlagTestCase] = [

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -443,7 +443,7 @@ class OptionDataclassTestFixture(t.NamedTuple):
     tmux_option: str  # e.g. terminal-features
 
     # results
-    expected: t.Any  # e.g. 50, TerminalFeatures({}), etc.
+    expected: dict[str, str | list[str]]
     dataclass_attribute: str  # e.g. terminal_features
 
 
@@ -503,7 +503,7 @@ def test_mocked_cmd_stdoutclass_fixture(
     test_id: str,
     mocked_cmd_stdout: list[str],
     tmux_option: str,
-    expected: t.Any,
+    expected: dict[str, str | list[str]],
     dataclass_attribute: str,
     server: Server,
 ) -> None:
@@ -528,7 +528,7 @@ def test_show_option_pane_fixture(
     test_id: str,
     mocked_cmd_stdout: list[str],
     tmux_option: str,
-    expected: t.Any,
+    expected: dict[str, str | list[str]],
     dataclass_attribute: str,
     server: Server,
 ) -> None:

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -23,6 +23,7 @@ from libtmux.options import TerminalOverrides, convert_values, explode_arrays
 from libtmux.pane import Pane
 
 if t.TYPE_CHECKING:
+    from _pytest.mark.structures import ParameterSet
     from typing_extensions import LiteralString
 
     from libtmux.server import Server
@@ -802,7 +803,7 @@ class OptionTestCase(t.NamedTuple):
     test_id: str
     option: str  # tmux option name (hyphenated)
     scope: OptionScope
-    test_value: t.Any  # Value to set
+    test_value: str | int  # Value to set
     expected_type: type  # Expected Python type after retrieval
     min_version: str | None = None  # Minimum tmux version required
     xfail_reason: str | None = None  # Mark as expected failure with reason
@@ -1281,11 +1282,11 @@ ALL_OPTION_TEST_CASES: list[OptionTestCase] = (
 )
 
 
-def _build_option_params() -> list[t.Any]:
+def _build_option_params() -> list[ParameterSet]:
     """Build pytest params with appropriate marks."""
     params = []
     for tc in ALL_OPTION_TEST_CASES:
-        marks: list[t.Any] = []
+        marks: list[pytest.MarkDecorator] = []
         if tc.xfail_reason:
             marks.append(pytest.mark.xfail(reason=tc.xfail_reason))
         params.append(pytest.param(tc, id=tc.test_id, marks=marks))
@@ -1394,7 +1395,7 @@ SHOW_OPTIONS_TEST_CASES: list[ShowOptionsTestCase] = [
 ]
 
 
-def _build_show_options_params() -> list[t.Any]:
+def _build_show_options_params() -> list[ParameterSet]:
     """Build pytest params for show_options tests."""
     return [pytest.param(tc, id=tc.test_id) for tc in SHOW_OPTIONS_TEST_CASES]
 
@@ -1445,7 +1446,7 @@ class ConvertValuesSparseTestCase(t.NamedTuple):
 
     test_id: str
     initial_values: dict[int, str]  # index -> value
-    expected_converted: dict[int, t.Any]  # index -> converted value
+    expected_converted: dict[int, bool | int | str]
 
 
 CONVERT_SPARSE_TEST_CASES: list[ConvertValuesSparseTestCase] = [

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -558,7 +558,11 @@ def test_session_attach_does_not_fail_if_session_killed_during_attach(
             self.stderr: list[str] = []
             self.cmd: list[str] = ["tmux", "attach-session"]
 
-    def patched_cmd(cmd_name: str, *args: t.Any, **kwargs: t.Any) -> tmux_cmd:
+    def patched_cmd(
+        cmd_name: str,
+        *args: object,
+        **kwargs: str | int | None,
+    ) -> tmux_cmd:
         """Patched cmd that kills session after attach-session."""
         if cmd_name == "attach-session":
             # Simulate: attach-session succeeded, user worked, then killed session

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -22,7 +22,7 @@ if t.TYPE_CHECKING:
         RaisesExc: TypeAlias = RaisesContext[Exception]  # type: ignore[no-redef]
 
     VersionCompareOp: TypeAlias = Callable[
-        [t.Any, t.Any],
+        [LooseVersion, LooseVersion],
         bool,
     ]
 
@@ -60,9 +60,9 @@ class VersionCompareFixture(t.NamedTuple):
     """Test fixture for version comparison."""
 
     test_id: str
-    a: object
+    a: str
     op: VersionCompareOp
-    b: object
+    b: str
     raises: type[Exception] | bool
 
 

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -23,6 +23,8 @@ from libtmux.server import Server
 from libtmux.window import Window
 
 if t.TYPE_CHECKING:
+    from _pytest.mark.structures import ParameterSet
+
     from libtmux._internal.types import StrPath
     from libtmux.session import Session
 
@@ -813,8 +815,8 @@ class DeprecatedMethodTestCase(t.NamedTuple):
 
     test_id: str
     method_name: str  # Name of deprecated method to call
-    args: tuple[t.Any, ...]  # Positional args
-    kwargs: dict[str, t.Any]  # Keyword args
+    args: tuple[str | int | bool, ...]  # Positional args
+    kwargs: dict[str, str | int | bool]  # Keyword args
     expected_error_match: str  # Regex pattern to match error message
 
 
@@ -844,7 +846,7 @@ DEPRECATED_WARNING_WINDOW_METHOD_TEST_CASES: list[DeprecatedMethodTestCase] = [
 ]
 
 
-def _build_deprecated_warning_method_params() -> list[t.Any]:
+def _build_deprecated_warning_method_params() -> list[ParameterSet]:
     """Build pytest params for deprecated method warning tests."""
     return [
         pytest.param(tc, id=tc.test_id)


### PR DESCRIPTION
## Summary
- Replace `t.Any` with narrower types (`object`, `int | str`, etc.) throughout the codebase
- Add `TypedDict` definitions for structured keyword argument patterns
- Use function overloads for better type inference in temp helpers

## Changes by area

### Core library
- **exc.py**: Narrow `VariableUnpackingError.variable` from `t.Any` to `object`
- **hooks.py**: Narrow `HookDict` values from `t.Any` to `int | str`
- **pane.py, session.py, window.py, server.py**: Narrow deprecated lookup methods (`get`, `__getitem__`, `where`, `find_where`) to use `object` instead of `t.Any`

### Test utilities
- **pytest_plugin.py**: Add `SessionParams` TypedDict for typed fixture parameters
- **test/temporary.py**: Add TypedDicts (`TempSessionParams`, `TempWindowParams`, etc.) and use overloads for `temp_session`/`temp_window` functions

### Tests
- Narrow test fixture types throughout (`ParameterSet`, specific union types)
- Tighten mock function signatures
- Replace generic `dict[str, t.Any]` with specific TypedDicts

## Test plan
- [x] All 872 tests pass
- [x] mypy passes with no issues
- [x] ruff linting clean