### PR TITLE
fix(temp_window): Remove non-functional *args parameter

### DIFF
--- a/src/libtmux/test/temporary.py
+++ b/src/libtmux/test/temporary.py
@@ -73,7 +73,6 @@ def temp_session(
 @contextlib.contextmanager
 def temp_window(
     session: Session,
-    *args: t.Any,
     **kwargs: t.Any,
 ) -> Generator[Window, t.Any, t.Any]:
     """
@@ -91,8 +90,6 @@ def temp_window(
 
     Other Parameters
     ----------------
-    args : list
-        Arguments passed into :meth:`Session.new_window`
     kwargs : dict
         Keyword arguments passed into :meth:`Session.new_window`
 
@@ -117,7 +114,7 @@ def temp_window(
     else:
         window_name = kwargs.pop("window_name")
 
-    window = session.new_window(window_name, *args, **kwargs)
+    window = session.new_window(window_name, **kwargs)
 
     # Get ``window_id`` before returning it, it may be killed within context.
     window_id = window.window_id


### PR DESCRIPTION
## Summary
- Remove `*args` from `temp_window()` signature since it cannot be forwarded to `Session.new_window()`

## Problem
`Session.new_window()` uses keyword-only arguments (has a `*` marker after `window_name`), which means it cannot accept positional arguments beyond `window_name`. However, `temp_window()` accepted `*args` and attempted to forward them, which would cause a `TypeError` at runtime if anyone tried to pass positional arguments.

Example that would fail before this fix:
```python
with temp_window(session, "positional_arg") as window:
    # TypeError: new_window() takes 2 positional arguments but 3 were given
```

Note: `temp_session()` is unaffected because `Server.new_session()` explicitly accepts `*args`.

## Test plan
- [x] All 872 tests pass
- [x] mypy passes