### PR TITLE
Server(fix[new_session]): Harden error handling and TMUX env restoration

### DIFF
--- a/src/libtmux/server.py
+++ b/src/libtmux/server.py
@@ -2377,6 +2377,10 @@ class Server(
 
             raise_if_stderr(proc, "new-session")
 
+            if not proc.stdout:
+                msg = "new-session produced no output"
+                raise exc.LibTmuxException(msg)
+
             session_stdout = proc.stdout[0]
 
         finally:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -121,6 +121,94 @@ def test_new_session(server: Server) -> None:
     assert server.has_session("test_new_session")
 
 
+def test_new_session_empty_stdout(
+    server: Server,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Server.new_session raises LibTmuxException when tmux returns no output.
+
+    monkeypatch is used to simulate empty stdout, which cannot be triggered
+    through normal tmux operations on a healthy server.
+    """
+    original_cmd = server.cmd
+
+    def mock_cmd(cmd: str, *args: t.Any, **kwargs: t.Any) -> t.Any:
+        result = original_cmd(cmd, *args, **kwargs)
+        if cmd == "new-session":
+            result.stdout = []
+        return result
+
+    monkeypatch.setattr(server, "cmd", mock_cmd)
+
+    with pytest.raises(exc.LibTmuxException, match="new-session produced no output"):
+        server.new_session(session_name="test_empty_stdout")
+
+    monkeypatch.undo()
+    if server.has_session("test_empty_stdout"):
+        server.kill_session("test_empty_stdout")
+
+
+def test_new_session_restores_tmux_env_on_error(
+    server: Server,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Server.new_session restores TMUX env var when an exception is raised.
+
+    monkeypatch is used to simulate empty stdout (forcing the exception path),
+    which cannot be triggered through normal tmux operations.
+    """
+    original_cmd = server.cmd
+    sentinel = "/tmp/libtmux-test-fake-socket,12345,0"
+
+    monkeypatch.setenv("TMUX", sentinel)
+
+    def mock_cmd(cmd: str, *args: t.Any, **kwargs: t.Any) -> t.Any:
+        result = original_cmd(cmd, *args, **kwargs)
+        if cmd == "new-session":
+            result.stdout = []
+        return result
+
+    monkeypatch.setattr(server, "cmd", mock_cmd)
+
+    with pytest.raises(exc.LibTmuxException, match="new-session produced no output"):
+        server.new_session(session_name="test_env_restore")
+
+    assert os.environ.get("TMUX") == sentinel
+
+    monkeypatch.undo()
+    if server.has_session("test_env_restore"):
+        server.kill_session("test_env_restore")
+
+
+def test_new_session_restores_tmux_env_on_setup_error(
+    server: Server,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pathlib.Path,
+) -> None:
+    """Server.new_session restores TMUX env when setup code before cmd() raises.
+
+    monkeypatch makes pathlib.Path.expanduser raise to verify the try/finally
+    covers the arg-building phase, not just the cmd() call.
+    """
+    sentinel = "/tmp/libtmux-test-fake-socket,99999,0"
+
+    monkeypatch.setenv("TMUX", sentinel)
+
+    def broken_expanduser(self: pathlib.Path) -> t.Any:
+        msg = "injected setup error"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr(pathlib.Path, "expanduser", broken_expanduser)
+
+    with pytest.raises(RuntimeError, match="injected setup error"):
+        server.new_session(
+            session_name="test_setup_error",
+            start_directory=tmp_path,
+        )
+
+    assert os.environ.get("TMUX") == sentinel
+
+
 def test_new_session_returns_populated_session(server: Server) -> None:
     """Server.new_session returns Session populated from -P output."""
     session = server.new_session(session_name="test_populated")


### PR DESCRIPTION
## Summary

- `new_session()` deletes `os.environ["TMUX"]` before calling tmux but only restores it on the success path — any exception permanently leaks the deletion. This wraps all post-deletion code in `try/finally`.
- `proc.stdout[0]` raises an unhelpful `IndexError` if tmux produces no output. This adds an explicit guard with a descriptive `LibTmuxException`.

Split out from #576 — hardening that's independent of the race condition fix itself.

## Changes

**`src/libtmux/server.py`**:
- Wrap all code after `del os.environ["TMUX"]` in `try/finally` to ensure restoration on any exception (including setup-phase errors like `pathlib.Path.expanduser()`)
- Guard against empty `proc.stdout` with descriptive `LibTmuxException`

**`tests/test_server.py`**:
- `test_new_session_empty_stdout` — verifies error on empty stdout
- `test_new_session_restores_tmux_env_on_error` — verifies TMUX restored after cmd error
- `test_new_session_restores_tmux_env_on_setup_error` — verifies TMUX restored after setup-phase error

## Test plan

- [x] `uv run pytest` — 875 passed, 1 skipped
- [x] `uv run ruff check .` — all checks passed
- [x] `uv run mypy src tests` — no issues