### PR TITLE
fix: pre-existing issues in server.py and common.py (raise_if_dead, has_minimum_version)

### DIFF
--- a/src/libtmux/server.py
+++ b/src/libtmux/server.py
@@ -330,7 +330,11 @@ class Server(
             cmd_args.insert(0, f"-f{self.config_file}")
 
         try:
-            subprocess.check_call([resolved, *cmd_args])
+            subprocess.check_call(
+                [resolved, *cmd_args],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
         except FileNotFoundError:
             raise exc.TmuxCommandNotFound from None
 


### PR DESCRIPTION
## Summary

Three pre-existing issues surfaced during a fresh code review of PR #636. This PR addresses them as atomic commits against `master`.

- **P1** `common(fix[has_minimum_version])`: `has_minimum_version` was calling `get_version()` twice, spawning two subprocesses for no reason. Now cached in a local variable.
- **P2** `server(docs[raise_if_dead])`: `raise_if_dead` had no `Raises` section in its docstring. Both `TmuxCommandNotFound` (missing binary) and `CalledProcessError` (server not running) are now documented.
- **P3** `server(fix[raise_if_dead])`: `subprocess.check_call` in `raise_if_dead` inherited the parent process's stdout/stderr, leaking `list-sessions` output to the terminal. Now redirected to `subprocess.DEVNULL`.

## Test plan

- [x] `uv run ruff check . --fix --show-fixes` — clean
- [x] `uv run ruff format .` — no changes
- [x] `uv run mypy` — no issues (60 source files)
- [x] `uv run py.test -x -q` — 885 passed, 1 skipped