### PR TITLE
fix(tests): fix flaky test_capture_pane_flags[join_wrapped_numbers]

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -45,6 +45,12 @@ $ uvx --from 'libtmux' --prerelease allow python
 _Notes on the upcoming release will go here._
 <!-- END PLACEHOLDER - ADD NEW CHANGELOG ENTRIES BELOW THIS LINE -->
 
+### Fixes
+
+#### Flaky `test_capture_pane_flags[join_wrapped_numbers]` (#655)
+
+Marker detection now skips the shell command echo line to avoid
+false-positive completion.
 ### Documentation
 
 #### Cleaner `from_env` examples (#719)

--- a/tests/test_pane_capture_pane.py
+++ b/tests/test_pane_capture_pane.py
@@ -356,10 +356,12 @@ def test_capture_pane_flags(
     full_command = f'{command}; echo "{marker}"'
     pane.send_keys(full_command, literal=False, suppress_history=False)
 
-    # Wait for marker to appear
+    # Wait for marker to appear as command output (not in the command echo line)
     def command_complete() -> bool:
-        output = "\n".join(pane.capture_pane())
-        return marker in output
+        lines = pane.capture_pane()
+        return any(
+            marker in line and not line.lstrip().startswith("$") for line in lines
+        )
 
     retry_until(command_complete, 5, raises=True)
 


### PR DESCRIPTION
## Summary
- Fix race condition in `test_capture_pane_flags[join_wrapped_numbers]` where the completion marker was detected in the shell command echo before the command actually executed

## Test plan
- [x] `uv run py.test tests/test_pane_capture_pane.py -v` — all 19 tests pass
- [ ] CI passes

Fixes #654