### PR TITLE
fix(pytest_plugin): unlink socket file on fixture teardown

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -40,6 +40,18 @@ $ uvx --from 'libtmux' --prerelease allow python
 _Notes on the upcoming release will go here._
 <!-- END PLACEHOLDER - ADD NEW CHANGELOG ENTRIES BELOW THIS LINE -->
 
+### Fixes
+
+- `pytest_plugin`: the `server` and `TestServer` fixture finalizers now
+  unlink the tmux socket file from `/tmp/tmux-<uid>/` in addition to
+  calling `server.kill()`. tmux does not reliably `unlink(2)` its
+  socket on non-graceful exit, so `/tmp/tmux-<uid>/` would otherwise
+  accumulate stale `libtmux_test*` entries across test runs (10k+
+  observed on long-lived dev machines). A new internal helper
+  `_reap_test_server` centralizes the kill + unlink flow and
+  suppresses cleanup-time errors so a finalizer failure can no longer
+  mask the real test failure (#660).
+
 ### Documentation
 
 - Visual improvements to API docs from [gp-sphinx](https://gp-sphinx.git-pull.com)-based Sphinx packages (#658)

--- a/CHANGES
+++ b/CHANGES
@@ -50,7 +50,7 @@ _Notes on the upcoming release will go here._
   observed on long-lived dev machines). A new internal helper
   `_reap_test_server` centralizes the kill + unlink flow and
   suppresses cleanup-time errors so a finalizer failure can no longer
-  mask the real test failure (#660).
+  mask the real test failure (#661, fixes #660).
 
 ### Documentation
 

--- a/src/libtmux/pytest_plugin.py
+++ b/src/libtmux/pytest_plugin.py
@@ -24,6 +24,40 @@ logger = logging.getLogger(__name__)
 USING_ZSH = "zsh" in os.getenv("SHELL", "")
 
 
+def _reap_test_server(socket_name: str | None) -> None:
+    """Kill the tmux daemon on ``socket_name`` and unlink the socket file.
+
+    Invoked from the :func:`server` and :func:`TestServer` fixture
+    finalizers to guarantee teardown even when the daemon has already
+    exited (``kill`` is a no-op then) and the socket file was left on
+    disk. tmux does not reliably ``unlink(2)`` its socket on
+    non-graceful exit, so ``/tmp/tmux-<uid>/`` otherwise accumulates
+    stale entries across test runs.
+
+    Conservative: suppresses ``LibTmuxException`` / ``OSError`` on both
+    the kill and the unlink. A finalizer that raises replaces the real
+    test failure with a cleanup error, and cleanup failures are not
+    actionable (socket already gone, permissions changed, race with a
+    concurrent pytest-xdist worker).
+    """
+    if not socket_name:
+        return
+
+    with contextlib.suppress(exc.LibTmuxException, OSError):
+        srv = Server(socket_name=socket_name)
+        if srv.is_alive():
+            srv.kill()
+
+    # ``Server(socket_name=...)`` does not populate ``socket_path`` —
+    # the Server class only derives the path when neither ``socket_name``
+    # nor ``socket_path`` was supplied. Recompute the location tmux uses
+    # so we can unlink the file regardless of daemon state.
+    tmux_tmpdir = pathlib.Path(os.environ.get("TMUX_TMPDIR", "/tmp"))
+    socket_path = tmux_tmpdir / f"tmux-{os.geteuid()}" / socket_name
+    with contextlib.suppress(OSError):
+        socket_path.unlink(missing_ok=True)
+
+
 @pytest.fixture(scope="session")
 def home_path(tmp_path_factory: pytest.TempPathFactory) -> pathlib.Path:
     """Temporary `/home/` path."""
@@ -141,7 +175,7 @@ def server(
     server = Server(socket_name=f"libtmux_test{next(namer)}")
 
     def fin() -> None:
-        server.kill()
+        _reap_test_server(server.socket_name)
 
     request.addfinalizer(fin)
 
@@ -295,11 +329,9 @@ def TestServer(
         return f"libtmux_test{next(namer)}"
 
     def fin() -> None:
-        """Kill all servers created with these sockets."""
+        """Kill all servers created with these sockets and unlink their sockets."""
         for socket_name in created_sockets:
-            server = Server(socket_name=socket_name)
-            if server.is_alive():
-                server.kill()
+            _reap_test_server(socket_name)
 
     request.addfinalizer(fin)
 

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -2,16 +2,18 @@
 
 from __future__ import annotations
 
+import contextlib
+import os
+import pathlib
 import textwrap
 import time
 import typing as t
 
+from libtmux.pytest_plugin import _reap_test_server
+from libtmux.server import Server
+
 if t.TYPE_CHECKING:
-    import pathlib
-
     import pytest
-
-    from libtmux.server import Server
 
 
 def test_plugin(
@@ -156,3 +158,66 @@ def test_test_server_multiple(TestServer: t.Callable[..., Server]) -> None:
     assert any(s.session_name == "test2" for s in server2.sessions)
     assert not any(s.session_name == "test1" for s in server2.sessions)
     assert not any(s.session_name == "test2" for s in server1.sessions)
+
+
+def _libtmux_socket_dir() -> pathlib.Path:
+    """Resolve the tmux socket directory tmux uses for this uid."""
+    tmux_tmpdir = pathlib.Path(os.environ.get("TMUX_TMPDIR", "/tmp"))
+    return tmux_tmpdir / f"tmux-{os.geteuid()}"
+
+
+def test_reap_test_server_unlinks_socket_file() -> None:
+    """``_reap_test_server`` kills the daemon *and* unlinks the socket.
+
+    Regression for #660: tmux does not reliably ``unlink(2)`` its socket
+    on non-graceful exit. Before this fix the plugin's finalizer only
+    called ``server.kill()``, so ``/tmp/tmux-<uid>/`` accumulated stale
+    ``libtmux_test*`` socket files over time.
+
+    This test boots a real tmux daemon on a unique socket, confirms the
+    socket file exists, invokes the reaper, and asserts the file is
+    gone.
+    """
+    server = Server(socket_name="libtmux_test_reap_unlink")
+    server.new_session(session_name="reap_probe")
+    socket_path = _libtmux_socket_dir() / "libtmux_test_reap_unlink"
+    try:
+        assert socket_path.exists(), (
+            f"expected tmux to have created {socket_path}, but it is missing"
+        )
+
+        _reap_test_server("libtmux_test_reap_unlink")
+
+        assert not socket_path.exists(), (
+            f"_reap_test_server should have unlinked {socket_path}"
+        )
+    finally:
+        # Belt-and-braces: if the assertion above fired before the
+        # unlink, don't leak the socket the next run of this test.
+        with contextlib.suppress(OSError):
+            socket_path.unlink(missing_ok=True)
+
+
+def test_reap_test_server_is_noop_when_socket_missing() -> None:
+    """Reaping a non-existent socket succeeds silently.
+
+    Finalizers run even when the fixture failed before the daemon ever
+    started; the reaper must tolerate the case where the socket file
+    never existed.
+    """
+    bogus_name = "libtmux_test_reap_never_existed_xyz"
+    socket_path = _libtmux_socket_dir() / bogus_name
+    assert not socket_path.exists()
+
+    # Should not raise.
+    _reap_test_server(bogus_name)
+
+
+def test_reap_test_server_tolerates_none() -> None:
+    """``_reap_test_server(None)`` is a no-op, not a crash.
+
+    The ``server`` fixture's finalizer passes ``server.socket_name``,
+    which is typed ``str | None``. Tolerate ``None`` for symmetry with
+    other nullable paths in the API.
+    """
+    _reap_test_server(None)


### PR DESCRIPTION
## Summary

The `server` and `TestServer` fixtures in `libtmux.pytest_plugin` called `server.kill()` on teardown but never unlinked the socket file under `/tmp/tmux-<uid>/`. tmux does not reliably `unlink(2)` its own socket on non-graceful exit, so every test run that used these fixtures left behind stale socket entries that accumulated indefinitely (10k+ observed on a long-lived dev machine; surfaced by `libtmux-mcp`'s `list_servers` tool as 43 live leaked servers alongside the filesystem cruft).

Introduce `_reap_test_server(socket_name)` helper that kills the daemon (if alive) **and** unconditionally unlinks the computed socket path. `Server(socket_name=...)` does not populate `socket_path`, so the helper recomputes `$TMUX_TMPDIR/tmux-<uid>/<name>` the same way tmux does. Both fixture finalizers delegate to it.

Cleanup errors are suppressed via `contextlib.suppress` so a finalizer failure can never mask the real test failure, and races with `pytest-xdist` workers stay benign. Kills ride through `LibTmuxException` / `OSError`; unlinks use `missing_ok=True` and swallow `OSError`.

## Test plan

- [x] `uv run ruff check . --fix --show-fixes`
- [x] `uv run ruff format .`
- [x] `uv run mypy`
- [x] `uv run py.test --reruns 0 -vvv` (885 passed, 1 skipped)
- [x] `just build-docs`

End-to-end verification on this machine: before the fix `ls /tmp/tmux-$(id -u) | grep -c libtmux_test` was 10693. After the fix, running the full libtmux suite from a clean `/tmp/tmux-<uid>/` leaves **0** stale sockets.

### New regression tests in `tests/test_pytest_plugin.py`

- `test_reap_test_server_unlinks_socket_file` — boots a real daemon, confirms the socket file exists, calls `_reap_test_server`, asserts the file is gone.
- `test_reap_test_server_is_noop_when_socket_missing` — the finalizer path when a fixture failed before the daemon started.
- `test_reap_test_server_tolerates_none` — nullable `Server.socket_name` argument doesn't crash the reaper.

## Downstream

Surfaced by [`tmux-python/libtmux-mcp#20`](https://github.com/tmux-python/libtmux-mcp/issues/20). That repo has a [local mitigation PR](https://github.com/tmux-python/libtmux-mcp/pull/23) that can be reverted once this lands.

Fixes #660