### PR TITLE
test_server(fix[isolation]): use `server` fixture for "no server" tests

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -40,6 +40,14 @@ $ uvx --from 'libtmux' --prerelease allow python
 _Notes on the upcoming release will go here._
 <!-- END PLACEHOLDER - ADD NEW CHANGELOG ENTRIES BELOW THIS LINE -->
 
+### Tests
+
+- `test_no_server_*` and `test_raise_if_dead_no_server_raises` now
+  reuse the `server` fixture for a unique socket name and finalizer
+  cleanup, instead of hardcoded socket names with no finalizer that
+  broke whenever a stale tmux daemon survived at the same path
+  (#665, fixes #664).
+
 ## libtmux 0.55.1 (2026-04-19)
 
 ### Fixes

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -192,22 +192,19 @@ def test_new_session_environmental_variables(
     assert my_session.show_environment()["FOO"] == "HI"
 
 
-def test_no_server_sessions() -> None:
+def test_no_server_sessions(server: Server) -> None:
     """Verify ``Server.sessions`` returns empty list without tmux server."""
-    server = Server(socket_name="test_attached_session_no_server")
     assert server.sessions == []
 
 
-def test_no_server_attached_sessions() -> None:
+def test_no_server_attached_sessions(server: Server) -> None:
     """Verify ``Server.attached_sessions`` returns empty list without tmux server."""
-    server = Server(socket_name="test_no_server_attached_sessions")
     assert server.attached_sessions == []
 
 
-def test_no_server_is_alive() -> None:
+def test_no_server_is_alive(server: Server) -> None:
     """Verify is_alive() returns False without tmux server."""
-    dead_server = Server(socket_name="test_no_server_is_alive")
-    assert not dead_server.is_alive()
+    assert not server.is_alive()
 
 
 def test_with_server_is_alive(server: Server) -> None:
@@ -216,11 +213,10 @@ def test_with_server_is_alive(server: Server) -> None:
     assert server.is_alive()
 
 
-def test_raise_if_dead_no_server_raises() -> None:
-    """Verify new_session() raises if tmux server is dead."""
-    dead_server = Server(socket_name="test_attached_session_no_server")
+def test_raise_if_dead_no_server_raises(server: Server) -> None:
+    """Verify ``Server.raise_if_dead`` raises if tmux server is dead."""
     with pytest.raises(subprocess.CalledProcessError):
-        dead_server.raise_if_dead()
+        server.raise_if_dead()
 
 
 def test_raise_if_dead_does_not_raise_if_alive(server: Server) -> None:


### PR DESCRIPTION
Fixes #664

## Summary

- Three `test_server.py` tests fail whenever a stale tmux daemon happens to be alive at the socket path they hardcode. Repros even in isolation.
- The library code (`Server.is_alive`, `Server.cmd`, `Server.raise_if_dead`, `tmux_cmd`) is correct. The defect is purely test-isolation: the tests construct `Server` with hardcoded `socket_name` strings and register no cleanup, so any daemon that ends up at one of those paths persists indefinitely (tmux doesn't reliably `unlink(2)` its socket on non-graceful exit).
- Convert the four affected tests to take the existing `server` fixture (`src/libtmux/pytest_plugin.py:144-182`), which already produces a `Server` with a unique random socket name (`libtmux_test{N}`) and registers a finalizer that kills any daemon and unlinks the socket. A freshly-created `Server` with a unique name has no daemon running on it — so it *is* the "dead server" these tests want.
- Also drops a copy-paste typo where `test_no_server_sessions` and `test_raise_if_dead_no_server_raises` both hardcoded the same unrelated socket name (`test_attached_session_no_server`).

## Test plan

- [x] Reproduce failure with stale daemon: `tmux -L test_no_server_is_alive new-session -d && uv run pytest tests/test_server.py::test_no_server_is_alive` → fails with `assert not True`
- [x] Run the four previously-failing tests after the fix: `uv run pytest tests/test_server.py::test_no_server_sessions tests/test_server.py::test_no_server_attached_sessions tests/test_server.py::test_no_server_is_alive tests/test_server.py::test_raise_if_dead_no_server_raises -v` → all PASSED, no RERUN
- [x] Full suite (`just test`): 885 passed, 1 skipped, 0 failed, 0 reruns
- [x] `uv run ruff format tests/test_server.py` → clean
- [x] `uv run ruff check tests/test_server.py` → clean
- [x] `uv run mypy tests/test_server.py` → clean
- [x] Confirm no stale `test_no_server_*` / `test_attached_session_no_server` sockets in `/tmp/tmux-<uid>/` after the run (the `server` fixture's `_reap_test_server` finalizer handles cleanup)

## Workaround for users hitting this on existing machines

```console
$ tmux -L test_attached_session_no_server kill-server 2>/dev/null
$ tmux -L test_no_server_is_alive kill-server 2>/dev/null
$ tmux -L test_no_server_attached_sessions kill-server 2>/dev/null
$ rm -f /tmp/tmux-$(id -u)/{test_attached_session_no_server,test_no_server_is_alive,test_no_server_attached_sessions}
```