### PR TITLE
Preview gp-sphinx#36 curated default-value rendering

### DIFF
--- a/src/libtmux/constants.py
+++ b/src/libtmux/constants.py
@@ -54,11 +54,25 @@ PANE_DIRECTION_FLAG_MAP: dict[PaneDirection, list[str]] = {
 
 
 class _DefaultOptionScope:
-    # Sentinel value for default scope
-    ...
+    """Sentinel type for the ``scope=`` parameter's default value.
+
+    The lone instance :data:`DEFAULT_OPTION_SCOPE` is used as the
+    default for option-related helpers; receiving methods use ``is``
+    comparison against the sentinel to detect "no explicit scope was
+    passed" and infer the right scope from the bound object type.
+    """
 
 
 DEFAULT_OPTION_SCOPE: _DefaultOptionScope = _DefaultOptionScope()
+"""Sentinel default for ``scope=`` parameters on option / hook helpers.
+
+When ``scope is DEFAULT_OPTION_SCOPE`` the caller hasn't selected an
+explicit :class:`OptionScope`; the receiving method
+(:meth:`Pane._show_option`, :meth:`Server.show_options`, etc.)
+infers the appropriate scope from the bound object type
+(``Pane`` → ``OptionScope.Pane``, ``Server`` → ``OptionScope.Server``,
+…).
+"""
 
 
 class OptionScope(enum.Enum):


### PR DESCRIPTION
## Summary

- **Preview branch** for [git-pull/gp-sphinx#36](https://github.com/git-pull/gp-sphinx/pull/36), which curates parameter and data-attribute default-value rendering across the workspace. This PR pulls the gp-sphinx-family deps from that branch via `[tool.uv.sources]` so the docs build picks up the changes before a release bump propagates them via PyPI.
- **Empirical impact (libtmux):** the audit drops from **171 ugly parameter defaults to 0**. Method signatures like `Pane._show_option(scope=<libtmux.constants._DefaultOptionScope object>, …)` now render as `Pane._show_option(scope=DEFAULT_OPTION_SCOPE, …)` with `DEFAULT_OPTION_SCOPE` linked to the documented constant in the same `<a class="reference internal"><code class="xref py py-class">…</code></a>` HTML shape that inline `:py:class:` roles produce. Hook dataclass `__init__` defaults stop showing `=<factory>` and instead render `=[]`, `={}`, `=set()`, etc.
- **Includes a `[DO NOT MERGE]` commit** that adds the branch to `.github/workflows/docs.yml`'s `on.push.branches` list so the live docs site previews the branch. **Revert that commit before merging.**

After gp-sphinx>=0.0.1a18 ships, replace this with a normal version bump (`0.0.1a17` → `0.0.1a18` across the four pinned gp-sphinx-family packages) and revert both commits in this branch.

## Test plan

- [x] `uv lock` resolves all gp-sphinx-family workspace siblings to commit `8c3a1418` on the branch
- [x] `uv sync --all-extras --dev` clean install from git sources
- [x] Local docs rebuild succeeds: `cd docs && just html`
- [x] Audit script confirms zero ugly parameter defaults: `uv run python ../gp-sphinx/packages/sphinx-autodoc-typehints-gp/scripts/audit_defaults.py libtmux=docs/_build/html`
- [x] Visual spot-check: `Pane._show_option`, `Pane._show_hook`, hook dataclass `__init__` signatures
- [ ] CI: `docs` workflow runs against this branch (enabled by the `[DO NOT MERGE]` commit) and publishes to the docs site for live preview