### PR TITLE
Fix pytest 9.1 fixture-mark import failure

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -45,6 +45,15 @@ $ uvx --from 'libtmux' --prerelease allow python
 _Notes on the upcoming release will go here._
 <!-- END PLACEHOLDER - ADD NEW CHANGELOG ENTRIES BELOW THIS LINE -->
 
+### Fixes
+
+#### pytest 9.1 compatibility for the pytest plugin (#687)
+
+libtmux's pytest plugin (see {ref}`pytest_plugin`) now imports cleanly
+under pytest 9.1, which began rejecting marks applied to fixture
+functions. Projects that use libtmux's fixtures can upgrade to pytest
+9.1+ without the plugin aborting before test collection.
+
 ## libtmux 0.58.0 (2026-05-23)
 
 libtmux 0.58.0 fixes subprocess output decoding on non-UTF-8 locales.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -253,5 +253,4 @@ markers = [
 ]
 filterwarnings = [
   "ignore:The frontend.Option(Parser)? class.*:DeprecationWarning::",
-  "ignore::DeprecationWarning:tests:",  # tests/
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -253,6 +253,5 @@ markers = [
 ]
 filterwarnings = [
   "ignore:The frontend.Option(Parser)? class.*:DeprecationWarning::",
-  "ignore::DeprecationWarning:libtmux.*:",
   "ignore::DeprecationWarning:tests:",  # tests/
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -251,6 +251,3 @@ testpaths = [
 markers = [
   "integration: sphinx integration tests (require full sphinx build)",
 ]
-filterwarnings = [
-  "ignore:The frontend.Option(Parser)? class.*:DeprecationWarning::",
-]

--- a/src/libtmux/pytest_plugin.py
+++ b/src/libtmux/pytest_plugin.py
@@ -82,7 +82,6 @@ def user_path(home_path: pathlib.Path, home_user_name: str) -> pathlib.Path:
     return p
 
 
-@pytest.mark.skipif(USING_ZSH, reason="Using ZSH")
 @pytest.fixture(scope="session")
 def zshrc(user_path: pathlib.Path) -> pathlib.Path:
     """Suppress ZSH default message.


### PR DESCRIPTION
## Summary

Fixes #686.

This PR keeps libtmux's `zshrc` fixture, but removes the pytest mark that was applied directly to the fixture function. Pytest 9.1 rejects that pattern during plugin import, before collection reaches any tests.

It also removes the project-level pytest `filterwarnings` block one entry at a time so pytest-facing compatibility warnings stay visible in development and CI instead of being hidden by configuration.

## Upstream pytest context

Pytest documents marks on fixtures as deprecated in 7.4 and removed in 9.0:

- https://github.com/pytest-dev/pytest/blob/9.1.0/doc/en/deprecations.rst#L576-L582

In pytest 9.1, mark application now checks whether the target is a fixture and fails during decorator evaluation:

- https://github.com/pytest-dev/pytest/blob/9.1.0/src/_pytest/mark/structures.py#L405-L418
- https://github.com/pytest-dev/pytest/blob/9.1.0/src/_pytest/mark/structures.py#L482-L495

Reversing decorator order is not a compatible workaround, because fixture creation also rejects functions that already carry pytest marks:

- https://github.com/pytest-dev/pytest/blob/9.1.0/src/_pytest/fixtures.py#L1363-L1367

## Testing

- `uv run python -c 'import libtmux.pytest_plugin'`
- `uv run ruff check .`
- `uv run mypy`
- `TMUX= TMUX_PANE= SHELL=/bin/sh uv run pytest -q -W error::pytest.PytestWarning`
  - `1258 passed, 2 skipped`