### PR TITLE
Restore compatibility with tmux 3.7

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.14']
-        tmux-version: ['3.2a', '3.3a', '3.4', '3.5', '3.6', 'master']
+        tmux-version: ['3.2a', '3.3a', '3.4', '3.5', '3.6', '3.7', 'master']
     steps:
       - uses: actions/checkout@v6
 

--- a/CHANGES
+++ b/CHANGES
@@ -54,8 +54,8 @@ a NULL-pointer dereference whenever a pane is broken out of a window
 without an explicit name (fixed upstream after the 3.7 release).
 {meth}`~libtmux.Pane.break_pane` now works around this on tmux 3.7 by
 always supplying a name and applying the requested one afterwards, so
-breaking a pane into a new window — and {meth}`~libtmux.Pane.join`,
-which relies on it — work again. Older and post-3.7 tmux are
+breaking a pane into a new window — and joining it back with
+{meth}`~libtmux.Pane.join` — work again. Older and post-3.7 tmux are
 unaffected.
 
 ## libtmux 0.58.1 (2026-06-16)

--- a/CHANGES
+++ b/CHANGES
@@ -45,6 +45,19 @@ $ uvx --from 'libtmux' --prerelease allow python
 _Notes on the upcoming release will go here._
 <!-- END PLACEHOLDER - ADD NEW CHANGELOG ENTRIES BELOW THIS LINE -->
 
+### Fixes
+
+#### `break-pane` no longer crashes the tmux 3.7 server (#693)
+
+tmux 3.7 shipped a regression where `break-pane` aborts the server with
+a NULL-pointer dereference whenever a pane is broken out of a window
+without an explicit name (fixed upstream after the 3.7 release).
+{meth}`~libtmux.Pane.break_pane` now works around this on tmux 3.7 by
+always supplying a name and applying the requested one afterwards, so
+breaking a pane into a new window — and {meth}`~libtmux.Pane.join`,
+which relies on it — work again. Older and post-3.7 tmux are
+unaffected.
+
 ## libtmux 0.58.1 (2026-06-16)
 
 libtmux 0.58.1 restores compatibility with pytest 9.1. The bundled

--- a/docs/topics/filtering.md
+++ b/docs/topics/filtering.md
@@ -153,12 +153,12 @@ For complex patterns, use regex lookups:
 
 ```python
 >>> # Create windows with version-like names
->>> w1 = session.new_window(window_name="app-v1.0")
->>> w2 = session.new_window(window_name="app-v2.0")
+>>> w1 = session.new_window(window_name="app-v1-0")
+>>> w2 = session.new_window(window_name="app-v2-0")
 >>> w3 = session.new_window(window_name="app-beta")
 
 >>> # Match version pattern
->>> versioned = session.windows.filter(window_name__regex=r'v\d+\.\d+$')
+>>> versioned = session.windows.filter(window_name__regex=r'v\d+-\d+$')
 >>> len(versioned) >= 2
 True
 
@@ -238,19 +238,19 @@ True
 
 ```python
 >>> # Create windows following a naming convention
->>> w1 = session.new_window(window_name="project:frontend")
->>> w2 = session.new_window(window_name="project:backend")
+>>> w1 = session.new_window(window_name="project-frontend")
+>>> w2 = session.new_window(window_name="project-backend")
 >>> w3 = session.new_window(window_name="logs")
 
 >>> # Find all project windows
->>> project_windows = session.windows.filter(window_name__startswith='project:')
+>>> project_windows = session.windows.filter(window_name__startswith='project-')
 >>> len(project_windows) >= 2
 True
 
 >>> # Get specific project window
->>> backend = session.windows.get(window_name='project:backend')
+>>> backend = session.windows.get(window_name='project-backend')
 >>> backend.window_name
-'project:backend'
+'project-backend'
 
 >>> # Clean up
 >>> w1.kill()

--- a/docs/topics/traversal.md
+++ b/docs/topics/traversal.md
@@ -205,13 +205,13 @@ For complex patterns, use `__regex` or `__iregex`:
 
 ```python
 >>> # Create versioned windows
->>> w1 = session.new_window(window_name="release-v1.0")
->>> w2 = session.new_window(window_name="release-v2.0")
+>>> w1 = session.new_window(window_name="release-v1-0")
+>>> w2 = session.new_window(window_name="release-v2-0")
 >>> w3 = session.new_window(window_name="dev")
 
->>> # Match semantic version pattern
->>> session.windows.filter(window_name__regex=r'v\d+\.\d+')  # doctest: +ELLIPSIS
-[Window(@... ...:release-v1.0, Session($... ...)), Window(@... ...:release-v2.0, Session($... ...))]
+>>> # Match version pattern
+>>> session.windows.filter(window_name__regex=r'v\d+-\d+')  # doctest: +ELLIPSIS
+[Window(@... ...:release-v1-0, Session($... ...)), Window(@... ...:release-v2-0, Session($... ...))]
 
 >>> # Clean up
 >>> w1.kill()

--- a/src/libtmux/pane.py
+++ b/src/libtmux/pane.py
@@ -2069,11 +2069,10 @@ class Pane(
         >>> new_window.window_name
         'broken'
         """
-        # tmux 3.7 segfaults on break-pane when no -n is given (a NULL window
-        # name is dereferenced); fixed upstream after the 3.7 release. Pass a
-        # placeholder -n to avoid the crash -- 3.7 ignores it and applies the
-        # default name -- then rename to the requested name below. Gated on
-        # exactly 3.7 so fixed builds, which honor -n, are left untouched.
+        # tmux 3.7 segfaults break-pane when -n is absent and ignores -n when
+        # given (NULL-deref, fixed upstream after 3.7). Always pass -n -- the
+        # requested name or a placeholder -- then set the real name via
+        # rename-window below. Gated on exactly 3.7; other builds are unaffected.
         breaks_without_name = has_version("3.7", tmux_bin=self.server.tmux_bin)
 
         tmux_args: tuple[str, ...] = ("-P", "-F#{window_id}")
@@ -2100,7 +2099,6 @@ class Pane(
         window = Window.from_window_id(server=self.server, window_id=window_id)
 
         if window_name is not None and breaks_without_name:
-            # tmux 3.7 ignored the -n above; set the requested name now.
             window.rename_window(window_name)
 
         return window

--- a/src/libtmux/pane.py
+++ b/src/libtmux/pane.py
@@ -14,7 +14,7 @@ import typing as t
 import warnings
 
 from libtmux import exc
-from libtmux.common import has_gte_version, raise_if_stderr, tmux_cmd
+from libtmux.common import has_gte_version, has_version, raise_if_stderr, tmux_cmd
 from libtmux.constants import (
     PANE_DIRECTION_FLAG_MAP,
     RESIZE_ADJUSTMENT_DIRECTION_FLAG_MAP,
@@ -2069,6 +2069,13 @@ class Pane(
         >>> new_window.window_name
         'broken'
         """
+        # tmux 3.7 segfaults on break-pane when no -n is given (a NULL window
+        # name is dereferenced); fixed upstream after the 3.7 release. Pass a
+        # placeholder -n to avoid the crash -- 3.7 ignores it and applies the
+        # default name -- then rename to the requested name below. Gated on
+        # exactly 3.7 so fixed builds, which honor -n, are left untouched.
+        breaks_without_name = has_version("3.7", tmux_bin=self.server.tmux_bin)
+
         tmux_args: tuple[str, ...] = ("-P", "-F#{window_id}")
 
         if detach:
@@ -2076,6 +2083,8 @@ class Pane(
 
         if window_name is not None:
             tmux_args += ("-n", window_name)
+        elif breaks_without_name:
+            tmux_args += ("-n", "libtmux")
 
         tmux_args += ("-s", str(self.pane_id))
 
@@ -2088,7 +2097,13 @@ class Pane(
 
         from libtmux.window import Window
 
-        return Window.from_window_id(server=self.server, window_id=window_id)
+        window = Window.from_window_id(server=self.server, window_id=window_id)
+
+        if window_name is not None and breaks_without_name:
+            # tmux 3.7 ignored the -n above; set the requested name now.
+            window.rename_window(window_name)
+
+        return window
 
     def swap(
         self,

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -219,8 +219,13 @@ WINDOW_RENAME_FIXTURES: list[WindowRenameFixture] = [
         window_name_after="ha ha ha fjewlkjflwef",
     ),
     WindowRenameFixture(
+        # Create with a plain name and only assert that rename doubles the
+        # backslash: window_set_name() has escaped names via vis(3) since tmux
+        # 2.6, so this holds on all supported versions. (new-window only began
+        # escaping names in tmux 3.7, so a backslash in the *create* name is
+        # version-dependent and must not be asserted here.)
         test_id="rename_with_escapes",
-        window_name_before=r"hello \ wazzup 0",
+        window_name_before="test",
         window_name_input=r"hello \ wazzup 0",
         window_name_after=r"hello \\ wazzup 0",
     ),

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -257,6 +257,48 @@ def test_window_rename(
     assert window.window_name == window_name_after
 
 
+class WindowNameValidationFixture(t.NamedTuple):
+    """Test fixture for tmux 3.7 window-name validation."""
+
+    test_id: str
+    window_name: str
+
+
+# tmux 3.7 rejects ':' and '.' in window names server-side; tmux 3.2a-3.6
+# accept them. See https://github.com/tmux/tmux/issues/4999.
+WINDOW_NAME_INVALID_ON_3_7_FIXTURES: list[WindowNameValidationFixture] = [
+    WindowNameValidationFixture(test_id="colon", window_name="project:frontend"),
+    WindowNameValidationFixture(test_id="period", window_name="app-v1.0"),
+]
+
+
+@pytest.mark.parametrize(
+    list(WindowNameValidationFixture._fields),
+    WINDOW_NAME_INVALID_ON_3_7_FIXTURES,
+    ids=[tc.test_id for tc in WINDOW_NAME_INVALID_ON_3_7_FIXTURES],
+)
+def test_new_window_name_invalid_on_3_7(
+    session: Session,
+    test_id: str,
+    window_name: str,
+) -> None:
+    """Tmux 3.7+ rejects ':'/'.' in window names; older tmux accepts them.
+
+    The rejection is enforced by tmux itself (no client-side validation),
+    so it surfaces as a :class:`~libtmux.exc.LibTmuxException`. On tmux
+    3.2a-3.6 the same names are accepted verbatim.
+    """
+    from libtmux.common import has_gte_version
+
+    if has_gte_version("3.7"):
+        with pytest.raises(exc.LibTmuxException, match="invalid window name"):
+            session.new_window(window_name=window_name)
+    else:
+        window = session.new_window(window_name=window_name)
+        assert window.window_name == window_name
+        window.kill()
+
+
 def test_kill_window(session: Session) -> None:
     """Test window.kill() kills window."""
     session.new_window()

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -264,7 +264,7 @@ class WindowNameValidationFixture(t.NamedTuple):
     window_name: str
 
 
-# tmux 3.7 rejects ':' and '.' in window names server-side; tmux 3.2a-3.6
+# tmux 3.7+ rejects ':' and '.' in window names server-side; tmux 3.2a-3.6
 # accept them. See https://github.com/tmux/tmux/issues/4999.
 WINDOW_NAME_INVALID_ON_3_7_FIXTURES: list[WindowNameValidationFixture] = [
     WindowNameValidationFixture(test_id="colon", window_name="project:frontend"),


### PR DESCRIPTION
## Summary

- **Fix** the tmux 3.7 `break-pane` server crash that takes out `Pane.break_pane()` and `Pane.join()` for libtmux 0.58.1 users on tmux 3.7 — the failures reported in #691.
- **Adapt** the rename-escape test and the filtering/traversal doctest examples to tmux 3.7's stricter name handling, keeping them valid across the whole supported range (tmux 3.2a–3.7).
- **Add** tmux 3.7 to the CI test matrix.

tmux 3.7 introduced two behavior changes that break libtmux's existing suite: an upstream `break-pane` regression and stricter window/session name sanitization. This branch makes libtmux work cleanly on tmux 3.7 while staying backward-compatible with tmux 3.2a–3.6.

## Changes by area

### `src/libtmux/pane.py`

**`Pane.break_pane`**: tmux 3.7 segfaults the server when `break-pane` runs without a window name (`-n`) — a NULL-pointer dereference in tmux's multi-pane code path, fixed upstream *after* the 3.7 release. The wrapper now always supplies a name on tmux 3.7 (a placeholder when none is requested, which tmux 3.7 ignores in favor of the default name) and applies the requested name afterward via `rename-window`. Gated on *exactly* `has_version("3.7")` so already-fixed builds (3.7a / master), which honor `-n`, are untouched. This also restores `Pane.join()`, which builds on `break_pane`.

### `tests/test_window.py`

**`test_window_rename[rename_with_escapes]`**: tmux 3.7 escapes window names set via `new-window`, so creating a window with a backslash now reads back doubled. The fixture creates the window with a plain name and asserts only that `rename_window` doubles the backslash — behavior that holds on every supported tmux (`window_set_name` has escaped via `vis(3)` since tmux 2.6).

### `docs/topics/filtering.md`, `docs/topics/traversal.md`

tmux 3.7 rejects `:` and `.` in window names ("invalid window name"). The filtering/traversal doctest examples switch to names valid across the whole supported range, with regexes and expected output updated to match.

| Before | After |
|---|---|
| `project:frontend` | `project-frontend` |
| `app-v1.0` | `app-v1-0` |
| `release-v1.0` | `release-v1-0` |

### `.github/workflows/tests.yml`

Add `3.7` to the tmux-version build matrix.

## Design decisions

- **Workaround, not skip**: the crash is an upstream tmux bug, but a clean libtmux-side path exists (always pass `-n`), so `break_pane` / `join` keep working for users on tmux 3.7 rather than being skipped — and the `Pane.break_pane` / `Pane.join` doctests stay executable.
- **Exact-version gate**: the bug exists only in the 3.7 release, so `has_version("3.7")` (exact equality) avoids keeping the workaround active on the already-fixed 3.7a / master, where the placeholder `-n` would otherwise leak as the window name.
- **No client-side name validation**: rather than rejecting `:` / `.` in window names client-side (which would regress 3.2a–3.6, where those names are valid), libtmux keeps relying on tmux's own server-side error, surfaced as `LibTmuxException`.

## Test plan

- [x] `uv run pytest` — full suite green on tmux 3.7, including the failures from #691 and the `Pane.break_pane` / `Pane.join` doctests
- [x] `uv run ruff check .` and `uv run ruff format .`
- [x] `uv run mypy`
- [x] `just build-docs`

Fixes #691
