### PR TITLE
Add tmux 3.7 feature parity: floating panes, options, formats

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -51,13 +51,10 @@ _Notes on the upcoming release will go here._
 
 The option dataclasses now type tmux 3.7's new options. On the server,
 `get-clipboard`; on the session, `focus-follows-mouse`,
-`message-format` and `prompt-command-cursor-style`; on the window, the
-copy-mode line-number options (`copy-mode-line-numbers` plus its
-`-style` and `-current-line-number-style` companions), the tree-mode
-preview options (`tree-mode-preview-format`/`-style`) and the second
-status line's pane list (`window-pane-status-format` and
-`window-pane-current-status-format`). The pane `remain-on-exit` option
-gained tmux 3.7's `key` value.
+`message-format` and `prompt-command-cursor-style`; and on windows and
+panes, the copy-mode line-number options, tree-mode preview options, and
+window-pane status formats. The pane `remain-on-exit` option gained tmux
+3.7's `key` value.
 
 #### tmux 3.7 pane format variables (#694)
 

--- a/CHANGES
+++ b/CHANGES
@@ -69,6 +69,17 @@ OSC 9;4 progress report (`pane_pb_progress`, `pane_pb_state`),
 `synchronized_output_flag` screen-mode flags. Each is version-gated, so
 the format template stays clean on tmux 3.2a–3.6.
 
+#### tmux 3.7 command flags
+
+New tmux 3.7 flags are exposed on existing wrappers:
+{meth}`~libtmux.Pane.capture_pane` gains `hyperlinks` (`-H`),
+`line_numbers` (`-L`) and `line_flags` (`-F`);
+{meth}`~libtmux.Window.split` / {meth}`~libtmux.Pane.split` gain `empty`
+(`-E`, an empty pane); {meth}`~libtmux.Session.kill` gains `group`
+(`-g`, kill the session group); and {meth}`~libtmux.Pane.paste_buffer`
+gains `no_vis` (`-S`, paste raw bytes). Each warns and is ignored on
+tmux < 3.7.
+
 ## libtmux 0.59.0 (2026-06-27)
 
 libtmux 0.59.0 adds support for tmux 3.7. tmux 3.7 shipped an upstream

--- a/CHANGES
+++ b/CHANGES
@@ -47,7 +47,7 @@ _Notes on the upcoming release will go here._
 
 ### What's new
 
-#### Typed tmux 3.7 options
+#### Typed tmux 3.7 options (#694)
 
 The option dataclasses now type tmux 3.7's new options. On the server,
 `get-clipboard`; on the session, `focus-follows-mouse`,
@@ -59,7 +59,7 @@ status line's pane list (`window-pane-status-format` and
 `window-pane-current-status-format`). The pane `remain-on-exit` option
 gained tmux 3.7's `key` value.
 
-#### tmux 3.7 pane format variables
+#### tmux 3.7 pane format variables (#694)
 
 {class}`~libtmux.Pane` now exposes tmux 3.7's new pane format
 variables: the floating-pane geometry and flags (`pane_floating_flag`,
@@ -69,7 +69,7 @@ OSC 9;4 progress report (`pane_pb_progress`, `pane_pb_state`),
 `synchronized_output_flag` screen-mode flags. Each is version-gated, so
 the format template stays clean on tmux 3.2a–3.6.
 
-#### tmux 3.7 command flags
+#### tmux 3.7 command flags (#694)
 
 New tmux 3.7 flags are exposed on existing wrappers:
 {meth}`~libtmux.Pane.capture_pane` gains `hyperlinks` (`-H`),
@@ -80,16 +80,18 @@ New tmux 3.7 flags are exposed on existing wrappers:
 gains `no_vis` (`-S`, paste raw bytes). Each warns and is ignored on
 tmux < 3.7.
 
-#### Floating panes (`new-pane`)
+#### Floating panes (`new-pane`) (#694)
 
 tmux 3.7's flagship feature, floating panes, is now reachable through
-{meth}`~libtmux.Window.new_pane` and {meth}`~libtmux.Pane.new_pane`. A
+{meth}`Window.new_pane() <libtmux.Window.new_pane>` and
+{meth}`Pane.new_pane() <libtmux.Pane.new_pane>`. A
 floating pane sits above the tiled layout like a popup but behaves like
 a real pane. Pass `width`/`height` to size it and `x`/`y` to position
 it, alongside the usual `shell`, `start_directory`, `environment`,
 `zoom` and `empty`, plus `style`, `active_border_style` and
 `inactive_border_style`. The returned {class}`~libtmux.Pane` reports
-`pane_floating_flag == "1"`. Requires tmux 3.7+.
+`pane_floating_flag == "1"`. Requires tmux 3.7+. See {ref}`floating-panes`
+for a guide.
 
 ## libtmux 0.59.0 (2026-06-27)
 

--- a/CHANGES
+++ b/CHANGES
@@ -89,8 +89,9 @@ tmux 3.7's flagship feature, floating panes, is now reachable through
 floating pane sits above the tiled layout like a popup but behaves like
 a real pane. Pass `width`/`height` to size it and `x`/`y` to position
 it, alongside the usual `shell`, `start_directory`, `environment`,
-`zoom` and `empty`, plus `style`, `active_border_style` and
-`inactive_border_style`. The returned {class}`~libtmux.Pane` reports
+`zoom` and `empty`, plus `style`, `active_border_style`,
+`inactive_border_style`, `message` and `keep` (remain-on-exit). The
+returned {class}`~libtmux.Pane` reports
 `pane_floating_flag == "1"`. Requires tmux 3.7+. See {ref}`floating-panes`
 for a guide.
 

--- a/CHANGES
+++ b/CHANGES
@@ -79,8 +79,9 @@ targets only),
 `inactive_border_style` (`-s`/`-S`/`-R`), `message` (`-m`) and `keep`
 (`-k`, remain-on-exit); {meth}`~libtmux.Session.kill` gains `group`
 (`-g`, kill the session group); and {meth}`~libtmux.Pane.paste_buffer`
-gains `no_vis` (`-S`, paste raw bytes). Each warns and is ignored on
-tmux < 3.7.
+gains `no_vis` (`-S`, paste raw bytes). On the server,
+{meth}`~libtmux.Server.command_prompt` gains `no_freeze` (`-C`, don't
+freeze panes). Each warns and is ignored on tmux < 3.7.
 
 #### Floating panes (`new-pane`) (#694)
 

--- a/CHANGES
+++ b/CHANGES
@@ -55,7 +55,8 @@ The option dataclasses now type tmux 3.7's new options. On the server,
 the copy-mode line-number options, the tree-mode preview options and the
 window-pane status formats (of these, `tree-mode-preview-format` is also
 pane-scoped). The pane `remain-on-exit` option gained tmux 3.7's `key`
-value.
+value, and `pane-active-border-style` / `pane-border-style` (widened to
+pane scope in 3.7) now type on the pane too.
 
 #### tmux 3.7 pane format variables (#694)
 

--- a/CHANGES
+++ b/CHANGES
@@ -45,6 +45,20 @@ $ uvx --from 'libtmux' --prerelease allow python
 _Notes on the upcoming release will go here._
 <!-- END PLACEHOLDER - ADD NEW CHANGELOG ENTRIES BELOW THIS LINE -->
 
+### What's new
+
+#### Typed tmux 3.7 options
+
+The option dataclasses now type tmux 3.7's new options. On the server,
+`get-clipboard`; on the session, `focus-follows-mouse`,
+`message-format` and `prompt-command-cursor-style`; on the window, the
+copy-mode line-number options (`copy-mode-line-numbers` plus its
+`-style` and `-current-line-number-style` companions), the tree-mode
+preview options (`tree-mode-preview-format`/`-style`) and the second
+status line's pane list (`window-pane-status-format` and
+`window-pane-current-status-format`). The pane `remain-on-exit` option
+gained tmux 3.7's `key` value.
+
 ## libtmux 0.59.0 (2026-06-27)
 
 libtmux 0.59.0 adds support for tmux 3.7. tmux 3.7 shipped an upstream

--- a/CHANGES
+++ b/CHANGES
@@ -80,6 +80,17 @@ New tmux 3.7 flags are exposed on existing wrappers:
 gains `no_vis` (`-S`, paste raw bytes). Each warns and is ignored on
 tmux < 3.7.
 
+#### Floating panes (`new-pane`)
+
+tmux 3.7's flagship feature, floating panes, is now reachable through
+{meth}`~libtmux.Window.new_pane` and {meth}`~libtmux.Pane.new_pane`. A
+floating pane sits above the tiled layout like a popup but behaves like
+a real pane. Pass `width`/`height` to size it and `x`/`y` to position
+it, alongside the usual `shell`, `start_directory`, `environment`,
+`zoom` and `empty`, plus `style`, `active_border_style` and
+`inactive_border_style`. The returned {class}`~libtmux.Pane` reports
+`pane_floating_flag == "1"`. Requires tmux 3.7+.
+
 ## libtmux 0.59.0 (2026-06-27)
 
 libtmux 0.59.0 adds support for tmux 3.7. tmux 3.7 shipped an upstream

--- a/CHANGES
+++ b/CHANGES
@@ -74,7 +74,9 @@ New tmux 3.7 flags are exposed on existing wrappers:
 targets only),
 `line_numbers` (`-L`) and `line_flags` (`-F`);
 {meth}`~libtmux.Window.split` / {meth}`~libtmux.Pane.split` gain `empty`
-(`-E`, an empty pane); {meth}`~libtmux.Session.kill` gains `group`
+(`-E`, an empty pane) plus `style`/`active_border_style`/
+`inactive_border_style` (`-s`/`-S`/`-R`), `message` (`-m`) and `keep`
+(`-k`, remain-on-exit); {meth}`~libtmux.Session.kill` gains `group`
 (`-g`, kill the session group); and {meth}`~libtmux.Pane.paste_buffer`
 gains `no_vis` (`-S`, paste raw bytes). Each warns and is ignored on
 tmux < 3.7.

--- a/CHANGES
+++ b/CHANGES
@@ -81,8 +81,10 @@ targets only),
 (`-g`, kill the session group); and {meth}`~libtmux.Pane.paste_buffer`
 gains `no_vis` (`-S`, paste raw bytes). On the server,
 {meth}`~libtmux.Server.command_prompt` gains `no_freeze` (`-C`, don't
-freeze panes) and {meth}`~libtmux.Server.list_keys` gains `format_`
-(`-F`, custom output format). Each warns and is ignored on tmux < 3.7.
+freeze panes), {meth}`~libtmux.Server.list_keys` gains `format_`
+(`-F`, custom output format), and {meth}`~libtmux.Server.run_shell`
+accepts trailing `args` expanded as `#{1}`/`#{2}`. Each warns and is
+ignored on tmux < 3.7.
 
 #### Floating panes (`new-pane`) (#694)
 

--- a/CHANGES
+++ b/CHANGES
@@ -82,9 +82,11 @@ targets only),
 gains `no_vis` (`-S`, paste raw bytes). On the server,
 {meth}`~libtmux.Server.command_prompt` gains `no_freeze` (`-C`, don't
 freeze panes), {meth}`~libtmux.Server.list_keys` gains `format_`
-(`-F`, custom output format), and {meth}`~libtmux.Server.run_shell`
-accepts trailing `args` expanded as `#{1}`/`#{2}`. Each warns and is
-ignored on tmux < 3.7.
+(`-F`, custom output format), {meth}`~libtmux.Server.run_shell`
+accepts trailing `args` expanded as `#{1}`/`#{2}`, and
+{meth}`~libtmux.Server.refresh_client` gains `request_clipboard`
+(`-l`, request the terminal clipboard). Each warns and is ignored on
+tmux < 3.7.
 
 #### Floating panes (`new-pane`) (#694)
 

--- a/CHANGES
+++ b/CHANGES
@@ -51,10 +51,11 @@ _Notes on the upcoming release will go here._
 
 The option dataclasses now type tmux 3.7's new options. On the server,
 `get-clipboard`; on the session, `focus-follows-mouse`,
-`message-format` and `prompt-command-cursor-style`; and on windows and
-panes, the copy-mode line-number options, tree-mode preview options, and
-window-pane status formats. The pane `remain-on-exit` option gained tmux
-3.7's `key` value.
+`message-format` and `prompt-command-cursor-style`; and on the window,
+the copy-mode line-number options, the tree-mode preview options and the
+window-pane status formats (of these, `tree-mode-preview-format` is also
+pane-scoped). The pane `remain-on-exit` option gained tmux 3.7's `key`
+value.
 
 #### tmux 3.7 pane format variables (#694)
 

--- a/CHANGES
+++ b/CHANGES
@@ -59,6 +59,16 @@ status line's pane list (`window-pane-status-format` and
 `window-pane-current-status-format`). The pane `remain-on-exit` option
 gained tmux 3.7's `key` value.
 
+#### tmux 3.7 pane format variables
+
+{class}`~libtmux.Pane` now exposes tmux 3.7's new pane format
+variables: the floating-pane geometry and flags (`pane_floating_flag`,
+`pane_x`, `pane_y`, `pane_z`, `pane_flags`, `pane_zoomed_flag`), the
+OSC 9;4 progress report (`pane_pb_progress`, `pane_pb_state`),
+`pane_pipe_pid`, and the `bracket_paste_flag` and
+`synchronized_output_flag` screen-mode flags. Each is version-gated, so
+the format template stays clean on tmux 3.2a–3.6.
+
 ## libtmux 0.59.0 (2026-06-27)
 
 libtmux 0.59.0 adds support for tmux 3.7. tmux 3.7 shipped an upstream

--- a/CHANGES
+++ b/CHANGES
@@ -72,7 +72,8 @@ the format template stays clean on tmux 3.2a–3.6.
 #### tmux 3.7 command flags (#694)
 
 New tmux 3.7 flags are exposed on existing wrappers:
-{meth}`~libtmux.Pane.capture_pane` gains `hyperlinks` (`-H`),
+{meth}`~libtmux.Pane.capture_pane` gains `hyperlinks` (`-H`, hyperlink
+targets only),
 `line_numbers` (`-L`) and `line_flags` (`-F`);
 {meth}`~libtmux.Window.split` / {meth}`~libtmux.Pane.split` gain `empty`
 (`-E`, an empty pane); {meth}`~libtmux.Session.kill` gains `group`

--- a/CHANGES
+++ b/CHANGES
@@ -81,7 +81,8 @@ targets only),
 (`-g`, kill the session group); and {meth}`~libtmux.Pane.paste_buffer`
 gains `no_vis` (`-S`, paste raw bytes). On the server,
 {meth}`~libtmux.Server.command_prompt` gains `no_freeze` (`-C`, don't
-freeze panes). Each warns and is ignored on tmux < 3.7.
+freeze panes) and {meth}`~libtmux.Server.list_keys` gains `format_`
+(`-F`, custom output format). Each warns and is ignored on tmux < 3.7.
 
 #### Floating panes (`new-pane`) (#694)
 

--- a/docs/topics/floating_panes.md
+++ b/docs/topics/floating_panes.md
@@ -59,6 +59,25 @@ Floating panes accept the same overlay styling as tmux's `new-pane`: `style`
 a tmux style string, e.g. `style="bg=black"` or
 `active_border_style="fg=green"`.
 
+## Keeping a pane open
+
+By default a floating pane closes when its command exits. Pass `keep=True` to
+hold it open until a key is pressed (tmux's `-k`), or `message="..."` to hold
+it open showing a custom `remain-on-exit-format` line (tmux's `-m`); both set
+the pane's `remain-on-exit` option to `key`:
+
+```python
+>>> from libtmux.common import has_gte_version
+
+>>> if has_gte_version("3.7"):
+...     held = window.new_pane(width=20, height=5, shell="sleep 30", keep=True)
+...     remain = held.cmd("show-options", "-p", "-v", "remain-on-exit").stdout
+... else:
+...     remain = ["key"]
+>>> remain
+['key']
+```
+
 ## Identifying floating panes
 
 Every pane carries the tmux 3.7 `pane_floating_flag` field, so floating panes

--- a/docs/topics/floating_panes.md
+++ b/docs/topics/floating_panes.md
@@ -1,0 +1,83 @@
+(floating-panes)=
+
+# Floating Panes
+
+```{note}
+Floating panes require **tmux 3.7+**
+({meth}`Window.new_pane() <libtmux.Window.new_pane>` /
+{meth}`Pane.new_pane() <libtmux.Pane.new_pane>` raise
+{exc}`~libtmux.exc.LibTmuxException` on older tmux).
+```
+
+tmux 3.7 introduced *floating panes* — panes that sit above the tiled layout
+like a popup, but unlike a popup are not modal and behave like ordinary panes
+(full escape-sequence support, capture, send-keys, and so on). libtmux exposes
+them through {meth}`Window.new_pane() <libtmux.Window.new_pane>` and
+{meth}`Pane.new_pane() <libtmux.Pane.new_pane>`, which wrap tmux's `new-pane`
+command.
+
+## Creating a floating pane
+
+{meth}`Window.new_pane() <libtmux.Window.new_pane>` returns the new
+{class}`~libtmux.Pane`, just like {meth}`Window.split() <libtmux.Window.split>`.
+The returned pane reports `pane_floating_flag == "1"`:
+
+```python
+>>> from libtmux.common import has_gte_version
+
+>>> if has_gte_version("3.7"):
+...     floating = window.new_pane(width=20, height=5, shell="sleep 30")
+...     is_floating = floating.pane_floating_flag
+... else:
+...     is_floating = "1"
+>>> is_floating
+'1'
+```
+
+## Sizing and positioning
+
+`width` and `height` set the pane's **size** (tmux's `-x` / `-y`); `x` and `y`
+set its **position** in cells from the top-left of the window (tmux's `-X` /
+`-Y`). The placement is reported back by the `pane_x` / `pane_y` fields:
+
+```python
+>>> from libtmux.common import has_gte_version
+
+>>> if has_gte_version("3.7"):
+...     placed = window.new_pane(width=20, height=5, x=2, y=1, shell="sleep 30")
+...     position = (placed.pane_x, placed.pane_y)
+... else:
+...     position = ("2", "1")
+>>> position
+('2', '1')
+```
+
+## Styling
+
+Floating panes accept the same overlay styling as tmux's `new-pane`: `style`
+(the pane body), `active_border_style`, and `inactive_border_style`. Each takes
+a tmux style string, e.g. `style="bg=black"` or
+`active_border_style="fg=green"`.
+
+## Identifying floating panes
+
+Every pane carries the tmux 3.7 `pane_floating_flag` field, so floating panes
+can be told apart from tiled panes anywhere a {class}`~libtmux.Pane` is
+available — including filtering a window's {attr}`~libtmux.Window.panes`:
+
+```python
+>>> from libtmux.common import has_gte_version
+
+>>> if has_gte_version("3.7"):
+...     _ = window.new_pane(width=20, height=5, shell="sleep 30")
+...     floating = [p for p in window.panes if p.pane_floating_flag == "1"]
+...     found = len(floating) >= 1
+... else:
+...     found = True
+>>> found
+True
+```
+
+See {meth}`Pane.new_pane() <libtmux.Pane.new_pane>` for the full parameter
+reference and {ref}`format-tokens` for the floating-pane geometry fields (`pane_x`,
+`pane_y`, `pane_z`, `pane_floating_flag`).

--- a/docs/topics/format-tokens.md
+++ b/docs/topics/format-tokens.md
@@ -43,6 +43,7 @@ following are the tokens libtmux currently gates:
 | Added in | Tokens |
 |----------|--------|
 | 3.3 | `pane_dead_signal`, `pane_dead_time` |
+| 3.7 | `bracket_paste_flag`, `pane_flags`, `pane_floating_flag`, `pane_pb_progress`, `pane_pb_state`, `pane_pipe_pid`, `pane_x`, `pane_y`, `pane_z`, `pane_zoomed_flag`, `synchronized_output_flag` |
 
 Everything not listed above is safe on every supported tmux (≥ 3.2a).
 Fields for newer tmux tokens will be added as each supported version is

--- a/docs/topics/index.md
+++ b/docs/topics/index.md
@@ -29,6 +29,12 @@ Query and filter collections by attributes.
 Send keys, capture output, and interact with panes.
 :::
 
+:::{grid-item-card} Floating Panes
+:link: floating_panes
+:link-type: doc
+Create and position floating (overlay) panes on tmux 3.7+.
+:::
+
 :::{grid-item-card} Workspace Setup
 :link: workspace_setup
 :link-type: doc
@@ -77,6 +83,7 @@ public-vs-internal
 traversal
 filtering
 pane_interaction
+floating_panes
 workspace_setup
 automation_patterns
 context_managers

--- a/src/libtmux/_internal/constants.py
+++ b/src/libtmux/_internal/constants.py
@@ -257,16 +257,10 @@ class PaneOptions(
     # tmux 3.5+ options
     pane_scrollbars: t.Literal["off", "modal", "on"] | None = field(default=None)
     pane_scrollbars_style: str | None = field(default=None)
-    # tmux 3.7+ options
-    copy_mode_line_numbers: (
-        t.Literal["off", "default", "absolute", "relative", "hybrid"] | None
-    ) = field(default=None)
-    copy_mode_line_number_style: str | None = field(default=None)
-    copy_mode_current_line_number_style: str | None = field(default=None)
+    # tmux 3.7+ options. Only tree-mode-preview-format is window+pane scope;
+    # the copy-mode, tree-mode-preview-style, and window-pane-status options
+    # are window-only in tmux's options-table.c, so they live on WindowOptions.
     tree_mode_preview_format: str | None = field(default=None)
-    tree_mode_preview_style: str | None = field(default=None)
-    window_pane_status_format: str | None = field(default=None)
-    window_pane_current_status_format: str | None = field(default=None)
 
     def __init__(self, **kwargs: object) -> None:
         # Convert hyphenated keys to underscored attribute names and assign values

--- a/src/libtmux/_internal/constants.py
+++ b/src/libtmux/_internal/constants.py
@@ -257,10 +257,14 @@ class PaneOptions(
     # tmux 3.5+ options
     pane_scrollbars: t.Literal["off", "modal", "on"] | None = field(default=None)
     pane_scrollbars_style: str | None = field(default=None)
-    # tmux 3.7+ options. Only tree-mode-preview-format is window+pane scope;
-    # the copy-mode, tree-mode-preview-style, and window-pane-status options
-    # are window-only in tmux's options-table.c, so they live on WindowOptions.
+    # tmux 3.7+ options. Among the new options only tree-mode-preview-format is
+    # window+pane scope; the copy-mode, tree-mode-preview-style, and
+    # window-pane-status options are window-only, so they live on WindowOptions.
     tree_mode_preview_format: str | None = field(default=None)
+    # tmux 3.7 widened pane-active-border-style / pane-border-style from window
+    # to window+pane scope (set -p now works), so they are typed on panes too.
+    pane_active_border_style: str | None = field(default=None)
+    pane_border_style: str | None = field(default=None)
 
     def __init__(self, **kwargs: object) -> None:
         # Convert hyphenated keys to underscored attribute names and assign values

--- a/src/libtmux/_internal/constants.py
+++ b/src/libtmux/_internal/constants.py
@@ -46,6 +46,10 @@ class ServerOptions(
     # tmux 3.5+ options
     default_client_command: str | None = field(default=None)
     extended_keys_format: t.Literal["csi-u", "xterm"] | None = field(default=None)
+    # tmux 3.7+ options
+    get_clipboard: t.Literal["off", "buffer", "request", "both"] | None = field(
+        default=None,
+    )
 
     def __init__(self, **kwargs: object) -> None:
         # Convert hyphenated keys to underscored attribute names and assign values
@@ -123,6 +127,21 @@ class SessionOptions(
     visual_bell: t.Literal["on", "off", "both"] | None = field(default=None)
     visual_silence: t.Literal["on", "off", "both"] | None = field(default=None)
     word_separators: str | None = field(default=None)
+    # tmux 3.7+ options
+    focus_follows_mouse: t.Literal["on", "off"] | None = field(default=None)
+    message_format: str | None = field(default=None)
+    prompt_command_cursor_style: (
+        t.Literal[
+            "default",
+            "blinking-block",
+            "block",
+            "blinking-underline",
+            "underline",
+            "blinking-bar",
+            "bar",
+        ]
+        | None
+    ) = field(default=None)
 
     def __init__(self, **kwargs: object) -> None:
         # Convert hyphenated keys to underscored attribute names and assign values
@@ -188,6 +207,16 @@ class WindowOptions(
     wrap_search: t.Literal["on", "off"] | None = field(default=None)
     # tmux 3.5+ options
     tiled_layout_max_columns: int | None = field(default=None)
+    # tmux 3.7+ options
+    copy_mode_line_numbers: (
+        t.Literal["off", "default", "absolute", "relative", "hybrid"] | None
+    ) = field(default=None)
+    copy_mode_line_number_style: str | None = field(default=None)
+    copy_mode_current_line_number_style: str | None = field(default=None)
+    tree_mode_preview_format: str | None = field(default=None)
+    tree_mode_preview_style: str | None = field(default=None)
+    window_pane_status_format: str | None = field(default=None)
+    window_pane_current_status_format: str | None = field(default=None)
 
     def __init__(self, **kwargs: object) -> None:
         # Convert hyphenated keys to underscored attribute names and assign values
@@ -219,7 +248,7 @@ class PaneOptions(
         ]
         | None
     ) = field(default=None)
-    remain_on_exit: t.Literal["on", "off", "failed"] | None = field(default=None)
+    remain_on_exit: t.Literal["on", "off", "failed", "key"] | None = field(default=None)
     remain_on_exit_format: str | None = field(default=None)
     scroll_on_clear: t.Literal["on", "off"] | None = field(default=None)
     synchronize_panes: t.Literal["on", "off"] | None = field(default=None)

--- a/src/libtmux/_internal/constants.py
+++ b/src/libtmux/_internal/constants.py
@@ -257,6 +257,16 @@ class PaneOptions(
     # tmux 3.5+ options
     pane_scrollbars: t.Literal["off", "modal", "on"] | None = field(default=None)
     pane_scrollbars_style: str | None = field(default=None)
+    # tmux 3.7+ options
+    copy_mode_line_numbers: (
+        t.Literal["off", "default", "absolute", "relative", "hybrid"] | None
+    ) = field(default=None)
+    copy_mode_line_number_style: str | None = field(default=None)
+    copy_mode_current_line_number_style: str | None = field(default=None)
+    tree_mode_preview_format: str | None = field(default=None)
+    tree_mode_preview_style: str | None = field(default=None)
+    window_pane_status_format: str | None = field(default=None)
+    window_pane_current_status_format: str | None = field(default=None)
 
     def __init__(self, **kwargs: object) -> None:
         # Convert hyphenated keys to underscored attribute names and assign values

--- a/src/libtmux/formats.py
+++ b/src/libtmux/formats.py
@@ -104,4 +104,16 @@ PANE_FORMATS = [
     "mouse_button_flag",
     "mouse_any_flag",
     "mouse_utf8_flag",
+    # tmux 3.7
+    "pane_flags",
+    "pane_floating_flag",
+    "pane_x",
+    "pane_y",
+    "pane_z",
+    "pane_zoomed_flag",
+    "pane_pb_progress",
+    "pane_pb_state",
+    "pane_pipe_pid",
+    "bracket_paste_flag",
+    "synchronized_output_flag",
 ]

--- a/src/libtmux/neo.py
+++ b/src/libtmux/neo.py
@@ -53,6 +53,18 @@ FIELD_VERSION: dict[str, str] = {
     # release tag, e.g. https://github.com/tmux/tmux/blob/3.6a/format.c).
     "pane_dead_signal": "3.3",
     "pane_dead_time": "3.3",
+    # tmux 3.7 additions (verified against format.c / tmux.1 at the 3.7 tag).
+    "bracket_paste_flag": "3.7",
+    "pane_flags": "3.7",
+    "pane_floating_flag": "3.7",
+    "pane_pb_progress": "3.7",
+    "pane_pb_state": "3.7",
+    "pane_pipe_pid": "3.7",
+    "pane_x": "3.7",
+    "pane_y": "3.7",
+    "pane_z": "3.7",
+    "pane_zoomed_flag": "3.7",
+    "synchronized_output_flag": "3.7",
 }
 """Minimum tmux version that registers each format token.
 
@@ -109,6 +121,9 @@ _SCOPE_OVERRIDES: dict[str, str] = {
     "wrap_flag": "pane",  # ft->wp->base.mode MODE_WRAP
     "active_window_index": "session",  # ft->s->curw->idx
     "last_window_index": "session",  # ft->s
+    # tmux 3.7 pane-scope tokens that don't carry the pane_ prefix.
+    "bracket_paste_flag": "pane",  # ft->wp->screen->mode MODE_BRACKETPASTE
+    "synchronized_output_flag": "pane",  # ft->wp->base.mode MODE_SYNC
 }
 
 
@@ -296,6 +311,7 @@ class Obj:
     active_window_index: str | None = None
     alternate_saved_x: str | None = None
     alternate_saved_y: str | None = None
+    bracket_paste_flag: str | None = None
     buffer_name: str | None = None
     buffer_sample: str | None = None
     buffer_size: str | None = None
@@ -366,6 +382,8 @@ class Obj:
     pane_dead_status: str | None = None
     pane_dead_time: str | None = None
     pane_fg: str | None = None
+    pane_flags: str | None = None
+    pane_floating_flag: str | None = None
     pane_format: str | None = None
     pane_height: str | None = None
     pane_id: str | None = None
@@ -378,8 +396,11 @@ class Obj:
     pane_marked_set: str | None = None
     pane_mode: str | None = None
     pane_path: str | None = None
+    pane_pb_progress: str | None = None
+    pane_pb_state: str | None = None
     pane_pid: str | None = None
     pane_pipe: str | None = None
+    pane_pipe_pid: str | None = None
     pane_right: str | None = None
     pane_search_string: str | None = None
     pane_start_command: str | None = None
@@ -390,6 +411,10 @@ class Obj:
     pane_top: str | None = None
     pane_tty: str | None = None
     pane_width: str | None = None
+    pane_x: str | None = None
+    pane_y: str | None = None
+    pane_z: str | None = None
+    pane_zoomed_flag: str | None = None
     pid: str | None = None
     scroll_position: str | None = None
     scroll_region_lower: str | None = None
@@ -422,6 +447,7 @@ class Obj:
     session_windows: str | None = None
     socket_path: str | None = None
     start_time: str | None = None
+    synchronized_output_flag: str | None = None
     uid: str | None = None
     user: str | None = None
     version: str | None = None

--- a/src/libtmux/pane.py
+++ b/src/libtmux/pane.py
@@ -460,9 +460,8 @@ class Pane(
             .. versionadded:: 0.57
         hyperlinks : bool, optional
             Capture only hyperlink targets in the selected lines (``-H``
-            flag); for full pane text use ``escape_sequences`` instead.
-            Requires tmux 3.7+. If used with tmux < 3.7, a warning is
-            issued and the flag is ignored.
+            flag). Requires tmux 3.7+. If used with tmux < 3.7, a warning
+            is issued and the flag is ignored.
             Default: False
         line_numbers : bool, optional
             Prefix each captured line with its line number (``-L`` flag).

--- a/src/libtmux/pane.py
+++ b/src/libtmux/pane.py
@@ -1400,12 +1400,7 @@ class Pane(
 
         pane_cmd = self.cmd("new-pane", *tmux_args, target=target)
 
-        if pane_cmd.stderr:
-            raise exc.LibTmuxException(
-                pane_cmd.stderr,
-                self.__dict__,
-                self.window.panes,
-            )
+        raise_if_stderr(pane_cmd, "new-pane")
 
         pane_output = pane_cmd.stdout[0]
 

--- a/src/libtmux/pane.py
+++ b/src/libtmux/pane.py
@@ -1330,9 +1330,9 @@ class Pane(
     ) -> Pane:
         """Create a floating :class:`Pane` via ``$ tmux new-pane`` (tmux 3.7+).
 
-        Floating panes sit above the tiled layout like a popup, but unlike a
-        popup they are not modal and behave like normal panes. The returned
-        pane has ``pane_floating_flag == "1"``.
+        Use :meth:`split` for a tiled pane. Floating panes sit above the tiled
+        layout like a popup, but unlike a popup they are not modal and behave
+        like normal panes. The returned pane has ``pane_floating_flag == "1"``.
 
         Parameters
         ----------

--- a/src/libtmux/pane.py
+++ b/src/libtmux/pane.py
@@ -1145,7 +1145,7 @@ class Pane(
         inactive_border_style : str, optional
             Inactive-pane border style (``-R``). Requires tmux 3.7+.
         message : str, optional
-            Keep the pane open after exit, showing this
+            Keep the pane open (until a key is pressed) after exit, showing this
             ``remain-on-exit-format`` message (``-m``). Requires tmux 3.7+.
         keep : bool, optional
             Keep the pane open until a key is pressed after exit (``-k``).

--- a/src/libtmux/pane.py
+++ b/src/libtmux/pane.py
@@ -340,6 +340,9 @@ class Pane(
         quiet: bool = ...,
         mode_screen: bool = ...,
         pending: bool = ...,
+        hyperlinks: bool = ...,
+        line_numbers: bool = ...,
+        line_flags: bool = ...,
         to_buffer: str,
     ) -> None: ...
 
@@ -358,6 +361,9 @@ class Pane(
         quiet: bool = ...,
         mode_screen: bool = ...,
         pending: bool = ...,
+        hyperlinks: bool = ...,
+        line_numbers: bool = ...,
+        line_flags: bool = ...,
         to_buffer: None = ...,
     ) -> list[str]: ...
 
@@ -375,6 +381,9 @@ class Pane(
         quiet: bool = False,
         mode_screen: bool = False,
         pending: bool = False,
+        hyperlinks: bool = False,
+        line_numbers: bool = False,
+        line_flags: bool = False,
         to_buffer: str | None = None,
     ) -> list[str] | None:
         r"""Capture text from pane.
@@ -449,6 +458,21 @@ class Pane(
             Default: False
 
             .. versionadded:: 0.57
+        hyperlinks : bool, optional
+            Include hyperlink escape sequences in the capture (``-H`` flag).
+            Requires tmux 3.7+. If used with tmux < 3.7, a warning is issued
+            and the flag is ignored.
+            Default: False
+        line_numbers : bool, optional
+            Prefix each captured line with its line number (``-L`` flag).
+            Requires tmux 3.7+. If used with tmux < 3.7, a warning is issued
+            and the flag is ignored.
+            Default: False
+        line_flags : bool, optional
+            Prefix each captured line with its flags, e.g. ``H`` for a line
+            with a hyperlink (``-F`` flag). Requires tmux 3.7+. If used with
+            tmux < 3.7, a warning is issued and the flag is ignored.
+            Default: False
         to_buffer : str, optional
             Write the capture into the named tmux buffer (``-b`` flag)
             instead of returning it. When set, ``-p`` is omitted and
@@ -516,6 +540,30 @@ class Pane(
                 )
         if pending:
             cmd.append("-P")
+        if hyperlinks:
+            if has_gte_version("3.7", tmux_bin=self.server.tmux_bin):
+                cmd.append("-H")
+            else:
+                warnings.warn(
+                    "hyperlinks requires tmux 3.7+, ignoring",
+                    stacklevel=2,
+                )
+        if line_numbers:
+            if has_gte_version("3.7", tmux_bin=self.server.tmux_bin):
+                cmd.append("-L")
+            else:
+                warnings.warn(
+                    "line_numbers requires tmux 3.7+, ignoring",
+                    stacklevel=2,
+                )
+        if line_flags:
+            if has_gte_version("3.7", tmux_bin=self.server.tmux_bin):
+                cmd.append("-F")
+            else:
+                warnings.warn(
+                    "line_flags requires tmux 3.7+, ignoring",
+                    stacklevel=2,
+                )
         proc = self.cmd(*cmd)
         if to_buffer is not None:
             return None
@@ -1046,6 +1094,7 @@ class Pane(
         size: str | int | None = None,
         percentage: int | None = None,
         environment: dict[str, str] | None = None,
+        empty: bool | None = None,
     ) -> Pane:
         """Split window and return :class:`Pane`, by default beneath current pane.
 
@@ -1080,6 +1129,10 @@ class Pane(
             .. versionadded:: 0.56
         environment: dict, optional
             Environmental variables for new pane. Passthrough to ``-e``.
+        empty : bool, optional
+            Create an empty pane with no command (``-E`` flag) instead of
+            spawning the default shell. Requires tmux 3.7+. If used with
+            tmux < 3.7, a warning is issued and the flag is ignored.
 
         Examples
         --------
@@ -1171,6 +1224,15 @@ class Pane(
         if environment:
             for k, v in environment.items():
                 tmux_args += (f"-e{k}={v}",)
+
+        if empty:
+            if has_gte_version("3.7", tmux_bin=self.server.tmux_bin):
+                tmux_args += ("-E",)
+            else:
+                warnings.warn(
+                    "empty requires tmux 3.7+, ignoring",
+                    stacklevel=2,
+                )
 
         if shell:
             tmux_args += (shell,)
@@ -1489,6 +1551,7 @@ class Pane(
         linefeed_separator: bool | None = None,
         bracket: bool | None = None,
         separator: str | None = None,
+        no_vis: bool | None = None,
     ) -> None:
         """Paste a buffer into the pane via ``$ tmux paste-buffer``.
 
@@ -1505,6 +1568,12 @@ class Pane(
             Use bracketed paste mode (``-p`` flag).
         separator : str, optional
             Separator between lines (``-s`` flag).
+        no_vis : bool, optional
+            Paste the buffer's raw bytes without passing them through
+            ``vis(3)`` escaping (``-S`` flag). tmux 3.7 escapes pasted
+            content by default; set this to restore the raw behaviour.
+            Requires tmux 3.7+. If used with tmux < 3.7, a warning is issued
+            and the flag is ignored.
 
         Examples
         --------
@@ -1527,6 +1596,15 @@ class Pane(
 
         if separator is not None:
             tmux_args += ("-s", separator)
+
+        if no_vis:
+            if has_gte_version("3.7", tmux_bin=self.server.tmux_bin):
+                tmux_args += ("-S",)
+            else:
+                warnings.warn(
+                    "no_vis requires tmux 3.7+, ignoring",
+                    stacklevel=2,
+                )
 
         proc = self.cmd("paste-buffer", *tmux_args)
 

--- a/src/libtmux/pane.py
+++ b/src/libtmux/pane.py
@@ -459,9 +459,10 @@ class Pane(
 
             .. versionadded:: 0.57
         hyperlinks : bool, optional
-            Include hyperlink escape sequences in the capture (``-H`` flag).
-            Requires tmux 3.7+. If used with tmux < 3.7, a warning is issued
-            and the flag is ignored.
+            Capture only hyperlink targets in the selected lines (``-H`` flag).
+            Use ``escape_sequences=True`` to preserve escape sequences in
+            normal pane text. Requires tmux 3.7+. If used with tmux < 3.7, a
+            warning is issued and the flag is ignored.
             Default: False
         line_numbers : bool, optional
             Prefix each captured line with its line number (``-L`` flag).

--- a/src/libtmux/pane.py
+++ b/src/libtmux/pane.py
@@ -1329,8 +1329,8 @@ class Pane(
         inactive_border_style : str, optional
             Border style when the pane is inactive (``-R`` flag).
         message : str, optional
-            Keep the pane open after the command exits and show this
-            ``remain-on-exit-format`` message (``-m`` flag).
+            Keep the pane open (until a key is pressed) after the command
+            exits, showing this ``remain-on-exit-format`` message (``-m`` flag).
 
         Returns
         -------

--- a/src/libtmux/pane.py
+++ b/src/libtmux/pane.py
@@ -1095,6 +1095,11 @@ class Pane(
         percentage: int | None = None,
         environment: dict[str, str] | None = None,
         empty: bool | None = None,
+        style: str | None = None,
+        active_border_style: str | None = None,
+        inactive_border_style: str | None = None,
+        message: str | None = None,
+        keep: bool | None = None,
     ) -> Pane:
         """Split window and return :class:`Pane`, by default beneath current pane.
 
@@ -1133,6 +1138,18 @@ class Pane(
             Create an empty pane with no command (``-E`` flag) instead of
             spawning the default shell. Requires tmux 3.7+. If used with
             tmux < 3.7, a warning is issued and the flag is ignored.
+        style : str, optional
+            Style for the new pane (``-s``). Requires tmux 3.7+.
+        active_border_style : str, optional
+            Active-pane border style (``-S``). Requires tmux 3.7+.
+        inactive_border_style : str, optional
+            Inactive-pane border style (``-R``). Requires tmux 3.7+.
+        message : str, optional
+            Keep the pane open after exit, showing this
+            ``remain-on-exit-format`` message (``-m``). Requires tmux 3.7+.
+        keep : bool, optional
+            Keep the pane open until a key is pressed after exit (``-k``).
+            Requires tmux 3.7+. These 3.7 flags warn and are ignored below 3.7.
 
         Examples
         --------
@@ -1231,6 +1248,25 @@ class Pane(
             else:
                 warnings.warn(
                     "empty requires tmux 3.7+, ignoring",
+                    stacklevel=2,
+                )
+
+        styling = {
+            "-s": style,
+            "-S": active_border_style,
+            "-R": inactive_border_style,
+            "-m": message,
+        }
+        if keep or any(v is not None for v in styling.values()):
+            if has_gte_version("3.7", tmux_bin=self.server.tmux_bin):
+                for flag, value in styling.items():
+                    if value is not None:
+                        tmux_args += (f"{flag}{value}",)
+                if keep:
+                    tmux_args += ("-k",)
+            else:
+                warnings.warn(
+                    "style/border/message/keep on split require tmux 3.7+, ignoring",
                     stacklevel=2,
                 )
 

--- a/src/libtmux/pane.py
+++ b/src/libtmux/pane.py
@@ -1372,13 +1372,13 @@ class Pane(
         if zoom:
             tmux_args += ("-Z",)
         if style is not None:
-            tmux_args += (f"-s{style}",)
+            tmux_args += ("-s", style)
         if active_border_style is not None:
-            tmux_args += (f"-S{active_border_style}",)
+            tmux_args += ("-S", active_border_style)
         if inactive_border_style is not None:
-            tmux_args += (f"-R{inactive_border_style}",)
+            tmux_args += ("-R", inactive_border_style)
         if message is not None:
-            tmux_args += (f"-m{message}",)
+            tmux_args += ("-m", message)
 
         tmux_args += ("-P", "-F{}".format("".join(tmux_formats)))  # output
 

--- a/src/libtmux/pane.py
+++ b/src/libtmux/pane.py
@@ -1299,8 +1299,8 @@ class Pane(
 
         Parameters
         ----------
-        target : optional
-            Optional, custom *target-pane*, used by :meth:`Window.new_pane`.
+        target : int or str, optional
+            Custom *target-pane*, used by :meth:`Window.new_pane`.
         start_directory : str or PathLike, optional
             Working directory for the new pane (``-c`` flag).
         attach : bool, optional

--- a/src/libtmux/pane.py
+++ b/src/libtmux/pane.py
@@ -1326,6 +1326,7 @@ class Pane(
         active_border_style: str | None = None,
         inactive_border_style: str | None = None,
         message: str | None = None,
+        keep: bool | None = None,
     ) -> Pane:
         """Create a floating :class:`Pane` via ``$ tmux new-pane`` (tmux 3.7+).
 
@@ -1367,6 +1368,9 @@ class Pane(
         message : str, optional
             Keep the pane open (until a key is pressed) after the command
             exits, showing this ``remain-on-exit-format`` message (``-m`` flag).
+        keep : bool, optional
+            Keep the pane open until a key is pressed after the command exits
+            (``-k`` flag), using the default ``remain-on-exit-format``.
 
         Returns
         -------
@@ -1415,6 +1419,8 @@ class Pane(
             tmux_args += ("-R", inactive_border_style)
         if message is not None:
             tmux_args += ("-m", message)
+        if keep:
+            tmux_args += ("-k",)
 
         tmux_args += ("-P", "-F{}".format("".join(tmux_formats)))  # output
 

--- a/src/libtmux/pane.py
+++ b/src/libtmux/pane.py
@@ -459,10 +459,10 @@ class Pane(
 
             .. versionadded:: 0.57
         hyperlinks : bool, optional
-            Capture only hyperlink targets in the selected lines (``-H`` flag).
-            Use ``escape_sequences=True`` to preserve escape sequences in
-            normal pane text. Requires tmux 3.7+. If used with tmux < 3.7, a
-            warning is issued and the flag is ignored.
+            Capture only hyperlink targets in the selected lines (``-H``
+            flag); for full pane text use ``escape_sequences`` instead.
+            Requires tmux 3.7+. If used with tmux < 3.7, a warning is
+            issued and the flag is ignored.
             Default: False
         line_numbers : bool, optional
             Prefix each captured line with its line number (``-L`` flag).

--- a/src/libtmux/pane.py
+++ b/src/libtmux/pane.py
@@ -1272,6 +1272,164 @@ class Pane(
 
         return pane
 
+    def new_pane(
+        self,
+        /,
+        target: int | str | None = None,
+        start_directory: StrPath | None = None,
+        attach: bool = False,
+        shell: str | None = None,
+        environment: dict[str, str] | None = None,
+        width: int | None = None,
+        height: int | None = None,
+        x: int | None = None,
+        y: int | None = None,
+        zoom: bool | None = None,
+        empty: bool | None = None,
+        style: str | None = None,
+        active_border_style: str | None = None,
+        inactive_border_style: str | None = None,
+        message: str | None = None,
+    ) -> Pane:
+        """Create a floating :class:`Pane` via ``$ tmux new-pane`` (tmux 3.7+).
+
+        Floating panes sit above the tiled layout like a popup, but unlike a
+        popup they are not modal and behave like normal panes. The returned
+        pane has ``pane_floating_flag == "1"``.
+
+        Parameters
+        ----------
+        target : optional
+            Optional, custom *target-pane*, used by :meth:`Window.new_pane`.
+        start_directory : str or PathLike, optional
+            Working directory for the new pane (``-c`` flag).
+        attach : bool, optional
+            Make the new pane the active pane, default False (``-d`` when
+            not attaching).
+        shell : str, optional
+            Command to run in the pane. The pane closes when it exits.
+        environment : dict, optional
+            Environment variables for the new pane (``-e`` flag).
+        width : int, optional
+            Width of the floating pane in cells (``-x`` flag).
+        height : int, optional
+            Height of the floating pane in cells (``-y`` flag).
+        x : int, optional
+            X position of the floating pane in cells (``-X`` flag).
+        y : int, optional
+            Y position of the floating pane in cells (``-Y`` flag).
+        zoom : bool, optional
+            Zoom the pane (``-Z`` flag).
+        empty : bool, optional
+            Create an empty pane with no command (``-E`` flag).
+        style : str, optional
+            Style for the floating pane (``-s`` flag).
+        active_border_style : str, optional
+            Border style when the pane is active (``-S`` flag).
+        inactive_border_style : str, optional
+            Border style when the pane is inactive (``-R`` flag).
+        message : str, optional
+            Message line shown for the floating pane (``-m`` flag).
+
+        Returns
+        -------
+        :class:`Pane`
+            The newly created floating pane.
+
+        Raises
+        ------
+        :exc:`libtmux.exc.LibTmuxException`
+            If the tmux server is older than 3.7 (``new-pane`` is unavailable).
+
+        Examples
+        --------
+        >>> from libtmux.common import has_gte_version
+        >>> if has_gte_version("3.7"):
+        ...     floating = pane.new_pane(width=40, height=10, shell="sleep 5")
+        ...     is_floating = floating.pane_floating_flag
+        ... else:
+        ...     is_floating = "1"
+        >>> is_floating
+        '1'
+        """
+        if not has_gte_version("3.7", tmux_bin=self.server.tmux_bin):
+            msg = "new_pane (floating panes) requires tmux 3.7+"
+            raise exc.LibTmuxException(msg)
+
+        tmux_formats = ["#{pane_id}" + FORMAT_SEPARATOR]
+
+        tmux_args: tuple[str, ...] = ()
+
+        if width is not None:
+            tmux_args += (f"-x{width}",)
+        if height is not None:
+            tmux_args += (f"-y{height}",)
+        if x is not None:
+            tmux_args += (f"-X{x}",)
+        if y is not None:
+            tmux_args += (f"-Y{y}",)
+        if zoom:
+            tmux_args += ("-Z",)
+        if style is not None:
+            tmux_args += (f"-s{style}",)
+        if active_border_style is not None:
+            tmux_args += (f"-S{active_border_style}",)
+        if inactive_border_style is not None:
+            tmux_args += (f"-R{inactive_border_style}",)
+        if message is not None:
+            tmux_args += (f"-m{message}",)
+
+        tmux_args += ("-P", "-F{}".format("".join(tmux_formats)))  # output
+
+        if start_directory:
+            start_path = pathlib.Path(start_directory).expanduser()
+            tmux_args += (f"-c{start_path}",)
+
+        if not attach:
+            tmux_args += ("-d",)
+
+        if environment:
+            for k, v in environment.items():
+                tmux_args += (f"-e{k}={v}",)
+
+        if empty:
+            tmux_args += ("-E",)
+
+        if shell:
+            tmux_args += (shell,)
+
+        pane_cmd = self.cmd("new-pane", *tmux_args, target=target)
+
+        if pane_cmd.stderr:
+            raise exc.LibTmuxException(
+                pane_cmd.stderr,
+                self.__dict__,
+                self.window.panes,
+            )
+
+        pane_output = pane_cmd.stdout[0]
+
+        pane_formatters = dict(
+            zip(["pane_id"], pane_output.split(FORMAT_SEPARATOR), strict=False),
+        )
+
+        pane = self.from_pane_id(server=self.server, pane_id=pane_formatters["pane_id"])
+
+        extra: dict[str, str] = {
+            "tmux_subcommand": "new-pane",
+            "tmux_pane": str(pane.pane_id),
+        }
+        if self.session.session_name is not None:
+            extra["tmux_session"] = str(self.session.session_name)
+        if self.window.window_name is not None:
+            extra["tmux_window"] = str(self.window.window_name)
+        if target is not None:
+            extra["tmux_target"] = str(target)
+
+        logger.info("floating pane created", extra=extra)
+
+        return pane
+
     """
     Commands (helpers)
     """

--- a/src/libtmux/pane.py
+++ b/src/libtmux/pane.py
@@ -1330,7 +1330,8 @@ class Pane(
         inactive_border_style : str, optional
             Border style when the pane is inactive (``-R`` flag).
         message : str, optional
-            Message line shown for the floating pane (``-m`` flag).
+            Keep the pane open after the command exits and show this
+            ``remain-on-exit-format`` message (``-m`` flag).
 
         Returns
         -------

--- a/src/libtmux/pane.py
+++ b/src/libtmux/pane.py
@@ -1261,7 +1261,7 @@ class Pane(
             if has_gte_version("3.7", tmux_bin=self.server.tmux_bin):
                 for flag, value in styling.items():
                     if value is not None:
-                        tmux_args += (f"{flag}{value}",)
+                        tmux_args += (flag, value)
                 if keep:
                     tmux_args += ("-k",)
             else:

--- a/src/libtmux/server.py
+++ b/src/libtmux/server.py
@@ -692,6 +692,7 @@ class Server(
         self,
         *,
         key_table: str | None = None,
+        format_: str | None = None,
     ) -> list[str]:
         """List key bindings via ``$ tmux list-keys``.
 
@@ -699,6 +700,9 @@ class Server(
         ----------
         key_table : str, optional
             Filter by key table (``-T`` flag).
+        format_ : str, optional
+            Custom output format applied to each line (``-F`` flag).
+            Requires tmux 3.7+; warns and is ignored on older tmux.
 
         Returns
         -------
@@ -715,6 +719,15 @@ class Server(
 
         if key_table is not None:
             tmux_args += ("-T", key_table)
+
+        if format_ is not None:
+            if has_gte_version("3.7", tmux_bin=self.tmux_bin):
+                tmux_args += ("-F", format_)
+            else:
+                warnings.warn(
+                    "format requires tmux 3.7+, ignoring",
+                    stacklevel=2,
+                )
 
         proc = self.cmd("list-keys", *tmux_args)
 

--- a/src/libtmux/server.py
+++ b/src/libtmux/server.py
@@ -1109,6 +1109,7 @@ class Server(
         expand_format: bool | None = None,
         literal: bool | None = None,
         bspace_exit: bool | None = None,
+        no_freeze: bool | None = None,
     ) -> None:
         """Open a command prompt via ``$ tmux command-prompt``.
 
@@ -1146,6 +1147,10 @@ class Server(
         bspace_exit : bool, optional
             Close the prompt when the user empties it with backspace
             (``-e`` flag, ``PROMPT_BSPACE_EXIT``). Requires tmux 3.7+ (upstream master).
+        no_freeze : bool, optional
+            Do not freeze panes while the prompt is open (``-C`` flag,
+            ``PROMPT_NOFREEZE``), matching ``display-message -C``. Requires
+            tmux 3.7+; warns and is ignored on older tmux.
 
         Examples
         --------
@@ -1204,6 +1209,15 @@ class Server(
             else:
                 warnings.warn(
                     "bspace_exit requires tmux 3.7+ (upstream master), ignoring",
+                    stacklevel=2,
+                )
+
+        if no_freeze:
+            if has_gte_version("3.7", tmux_bin=self.tmux_bin):
+                tmux_args += ("-C",)
+            else:
+                warnings.warn(
+                    "no_freeze requires tmux 3.7+, ignoring",
                     stacklevel=2,
                 )
 

--- a/src/libtmux/server.py
+++ b/src/libtmux/server.py
@@ -866,7 +866,12 @@ class Server(
             return proc.stdout
         return None
 
-    def refresh_client(self, *, target_client: str | None = None) -> None:
+    def refresh_client(
+        self,
+        *,
+        target_client: str | None = None,
+        request_clipboard: bool = False,
+    ) -> None:
         """Refresh a client's display via ``$ tmux refresh-client``.
 
         Requires an attached client.
@@ -875,6 +880,11 @@ class Server(
         ----------
         target_client : str, optional
             Target client (``-t`` flag).
+        request_clipboard : bool, optional
+            Request the clipboard from the terminal (``-l`` flag,
+            ``tty_clipboard_query``) — the runtime companion to the
+            ``get-clipboard`` option. Requires tmux 3.7+; warns and is
+            ignored on older tmux (where ``-l`` is the legacy forward form).
 
         Examples
         --------
@@ -885,6 +895,15 @@ class Server(
 
         if target_client is not None:
             tmux_args += ("-t", target_client)
+
+        if request_clipboard:
+            if has_gte_version("3.7", tmux_bin=self.tmux_bin):
+                tmux_args += ("-l",)
+            else:
+                warnings.warn(
+                    "request_clipboard requires tmux 3.7+, ignoring",
+                    stacklevel=2,
+                )
 
         proc = self.cmd("refresh-client", *tmux_args)
 

--- a/src/libtmux/server.py
+++ b/src/libtmux/server.py
@@ -464,6 +464,7 @@ class Server(
         target_pane: str | None = None,
         cwd: StrPath | None = None,
         show_stderr: bool | None = None,
+        args: list[str] | None = None,
     ) -> list[str] | None:
         r"""Execute a shell command via ``$ tmux run-shell``.
 
@@ -499,6 +500,10 @@ class Server(
             on older tmux a warning is emitted and the kwarg is ignored.
 
             .. versionadded:: 0.57
+        args : list of str, optional
+            Positional arguments passed after *command*, expanded as
+            ``#{1}``, ``#{2}``, … inside it. Requires tmux 3.7+; warns and
+            is ignored on older tmux.
 
         Returns
         -------
@@ -545,6 +550,15 @@ class Server(
                 )
 
         tmux_args += (command,)
+
+        if args:
+            if has_gte_version("3.7", tmux_bin=self.tmux_bin):
+                tmux_args += tuple(args)
+            else:
+                warnings.warn(
+                    "args requires tmux 3.7+, ignoring",
+                    stacklevel=2,
+                )
 
         proc = self.cmd("run-shell", *tmux_args)
 

--- a/src/libtmux/session.py
+++ b/src/libtmux/session.py
@@ -11,9 +11,10 @@ import dataclasses
 import logging
 import pathlib
 import typing as t
+import warnings
 
 from libtmux._internal.query_list import QueryList
-from libtmux.common import raise_if_stderr, tmux_cmd
+from libtmux.common import has_gte_version, raise_if_stderr, tmux_cmd
 from libtmux.constants import WINDOW_DIRECTION_FLAG_MAP, OptionScope, WindowDirection
 from libtmux.formats import FORMAT_SEPARATOR
 from libtmux.hooks import HooksMixin
@@ -568,6 +569,7 @@ class Session(
         self,
         all_except: bool | None = None,
         clear: bool | None = None,
+        group: bool | None = None,
     ) -> None:
         """Kill :class:`Session`, closes linked windows and detach all clients.
 
@@ -579,6 +581,10 @@ class Session(
             Kill all sessions in server except this one.
         clear : bool, optional
             Clear alerts (bell, activity, or silence) in all windows.
+        group : bool, optional
+            Kill all sessions in this session's group (``-g`` flag).
+            Requires tmux 3.7+. If used with tmux < 3.7, a warning is issued
+            and the flag is ignored.
 
         Examples
         --------
@@ -619,6 +625,15 @@ class Session(
 
         if clear:  # Clear alerts (bell, activity, or silence) in all windows
             flags += ("-C",)
+
+        if group:  # Kill all sessions in this session's group (tmux 3.7+)
+            if has_gte_version("3.7", tmux_bin=self.server.tmux_bin):
+                flags += ("-g",)
+            else:
+                warnings.warn(
+                    "group requires tmux 3.7+, ignoring",
+                    stacklevel=2,
+                )
 
         proc = self.cmd(
             "kill-session",

--- a/src/libtmux/window.py
+++ b/src/libtmux/window.py
@@ -457,7 +457,8 @@ class Window(
         inactive_border_style : str, optional
             Border style when the pane is inactive (``-R``).
         message : str, optional
-            Message line shown for the floating pane (``-m``).
+            Keep the pane open after the command exits and show this
+            ``remain-on-exit-format`` message (``-m``).
 
         Returns
         -------

--- a/src/libtmux/window.py
+++ b/src/libtmux/window.py
@@ -344,6 +344,7 @@ class Window(
         size: str | int | None = None,
         percentage: int | None = None,
         environment: dict[str, str] | None = None,
+        empty: bool | None = None,
     ) -> Pane:
         """Split window on active pane and return the created :class:`Pane`.
 
@@ -376,6 +377,9 @@ class Window(
             .. versionadded:: 0.56
         environment : dict, optional
             Environmental variables for new pane. Passthrough to ``-e``.
+        empty : bool, optional
+            Create an empty pane with no command (``-E`` flag) instead of
+            spawning the default shell. Requires tmux 3.7+.
 
         Returns
         -------
@@ -394,6 +398,7 @@ class Window(
             size=size,
             percentage=percentage,
             environment=environment,
+            empty=empty,
         )
 
     def resize(

--- a/src/libtmux/window.py
+++ b/src/libtmux/window.py
@@ -345,6 +345,11 @@ class Window(
         percentage: int | None = None,
         environment: dict[str, str] | None = None,
         empty: bool | None = None,
+        style: str | None = None,
+        active_border_style: str | None = None,
+        inactive_border_style: str | None = None,
+        message: str | None = None,
+        keep: bool | None = None,
     ) -> Pane:
         """Split window on active pane and return the created :class:`Pane`.
 
@@ -381,6 +386,18 @@ class Window(
             Create an empty pane with no command (``-E`` flag) instead of
             spawning the default shell. Requires tmux 3.7+. If used with
             tmux < 3.7, a warning is issued and the flag is ignored.
+        style : str, optional
+            Style for the new pane (``-s``). Requires tmux 3.7+.
+        active_border_style : str, optional
+            Active-pane border style (``-S``). Requires tmux 3.7+.
+        inactive_border_style : str, optional
+            Inactive-pane border style (``-R``). Requires tmux 3.7+.
+        message : str, optional
+            Keep the pane open after exit, showing this
+            ``remain-on-exit-format`` message (``-m``). Requires tmux 3.7+.
+        keep : bool, optional
+            Keep the pane open until a key is pressed after exit (``-k``).
+            Requires tmux 3.7+. These 3.7 flags warn and are ignored below 3.7.
 
         Returns
         -------
@@ -400,6 +417,11 @@ class Window(
             percentage=percentage,
             environment=environment,
             empty=empty,
+            style=style,
+            active_border_style=active_border_style,
+            inactive_border_style=inactive_border_style,
+            message=message,
+            keep=keep,
         )
 
     def new_pane(

--- a/src/libtmux/window.py
+++ b/src/libtmux/window.py
@@ -393,7 +393,7 @@ class Window(
         inactive_border_style : str, optional
             Inactive-pane border style (``-R``). Requires tmux 3.7+.
         message : str, optional
-            Keep the pane open after exit, showing this
+            Keep the pane open (until a key is pressed) after exit, showing this
             ``remain-on-exit-format`` message (``-m``). Requires tmux 3.7+.
         keep : bool, optional
             Keep the pane open until a key is pressed after exit (``-k``).

--- a/src/libtmux/window.py
+++ b/src/libtmux/window.py
@@ -422,8 +422,41 @@ class Window(
     ) -> Pane:
         """Create a floating :class:`Pane` in this window (``$ tmux new-pane``).
 
-        Floating panes require tmux 3.7+. See :meth:`Pane.new_pane` for the
-        full parameter reference.
+        Floating panes require tmux 3.7+. Delegates to :meth:`Pane.new_pane`
+        on the active pane.
+
+        Parameters
+        ----------
+        target : int or str, optional
+            Custom *target-pane*.
+        start_directory : str or PathLike, optional
+            Working directory for the new pane (``-c``).
+        attach : bool, optional
+            Make the new pane active, default False (``-d`` otherwise).
+        shell : str, optional
+            Command to run; the pane closes when it exits.
+        environment : dict, optional
+            Environment variables for the new pane (``-e``).
+        width : int, optional
+            Width in cells (``-x``).
+        height : int, optional
+            Height in cells (``-y``).
+        x : int, optional
+            X position in cells (``-X``).
+        y : int, optional
+            Y position in cells (``-Y``).
+        zoom : bool, optional
+            Zoom the pane (``-Z``).
+        empty : bool, optional
+            Create an empty pane with no command (``-E``).
+        style : str, optional
+            Style for the floating pane (``-s``).
+        active_border_style : str, optional
+            Border style when the pane is active (``-S``).
+        inactive_border_style : str, optional
+            Border style when the pane is inactive (``-R``).
+        message : str, optional
+            Message line shown for the floating pane (``-m``).
 
         Returns
         -------

--- a/src/libtmux/window.py
+++ b/src/libtmux/window.py
@@ -401,6 +401,65 @@ class Window(
             empty=empty,
         )
 
+    def new_pane(
+        self,
+        /,
+        target: int | str | None = None,
+        start_directory: StrPath | None = None,
+        attach: bool = False,
+        shell: str | None = None,
+        environment: dict[str, str] | None = None,
+        width: int | None = None,
+        height: int | None = None,
+        x: int | None = None,
+        y: int | None = None,
+        zoom: bool | None = None,
+        empty: bool | None = None,
+        style: str | None = None,
+        active_border_style: str | None = None,
+        inactive_border_style: str | None = None,
+        message: str | None = None,
+    ) -> Pane:
+        """Create a floating :class:`Pane` in this window (``$ tmux new-pane``).
+
+        Floating panes require tmux 3.7+. See :meth:`Pane.new_pane` for the
+        full parameter reference.
+
+        Returns
+        -------
+        :class:`Pane`
+            The newly created floating pane.
+
+        Examples
+        --------
+        >>> from libtmux.common import has_gte_version
+        >>> if has_gte_version("3.7"):
+        ...     floating = window.new_pane(width=40, height=10, shell="sleep 5")
+        ...     is_floating = floating.pane_floating_flag
+        ... else:
+        ...     is_floating = "1"
+        >>> is_floating
+        '1'
+        """
+        active_pane = self.active_pane or self.panes[0]
+        return active_pane.new_pane(
+            target=target,
+            start_directory=start_directory,
+            attach=attach,
+            shell=shell,
+            environment=environment,
+            width=width,
+            height=height,
+            x=x,
+            y=y,
+            zoom=zoom,
+            empty=empty,
+            style=style,
+            active_border_style=active_border_style,
+            inactive_border_style=inactive_border_style,
+            message=message,
+        )
+
     def resize(
         self,
         /,

--- a/src/libtmux/window.py
+++ b/src/libtmux/window.py
@@ -379,7 +379,8 @@ class Window(
             Environmental variables for new pane. Passthrough to ``-e``.
         empty : bool, optional
             Create an empty pane with no command (``-E`` flag) instead of
-            spawning the default shell. Requires tmux 3.7+.
+            spawning the default shell. Requires tmux 3.7+. If used with
+            tmux < 3.7, a warning is issued and the flag is ignored.
 
         Returns
         -------

--- a/src/libtmux/window.py
+++ b/src/libtmux/window.py
@@ -442,6 +442,7 @@ class Window(
         active_border_style: str | None = None,
         inactive_border_style: str | None = None,
         message: str | None = None,
+        keep: bool | None = None,
     ) -> Pane:
         """Create a floating :class:`Pane` in this window (``$ tmux new-pane``).
 
@@ -481,6 +482,9 @@ class Window(
         message : str, optional
             Keep the pane open (until a key is pressed) after the command
             exits, showing this ``remain-on-exit-format`` message (``-m``).
+        keep : bool, optional
+            Keep the pane open until a key is pressed after exit (``-k``),
+            using the default ``remain-on-exit-format``.
 
         Returns
         -------
@@ -515,6 +519,7 @@ class Window(
             active_border_style=active_border_style,
             inactive_border_style=inactive_border_style,
             message=message,
+            keep=keep,
         )
 
     def resize(

--- a/src/libtmux/window.py
+++ b/src/libtmux/window.py
@@ -457,8 +457,8 @@ class Window(
         inactive_border_style : str, optional
             Border style when the pane is inactive (``-R``).
         message : str, optional
-            Keep the pane open after the command exits and show this
-            ``remain-on-exit-format`` message (``-m``).
+            Keep the pane open (until a key is pressed) after the command
+            exits, showing this ``remain-on-exit-format`` message (``-m``).
 
         Returns
         -------

--- a/src/libtmux/window.py
+++ b/src/libtmux/window.py
@@ -446,8 +446,8 @@ class Window(
     ) -> Pane:
         """Create a floating :class:`Pane` in this window (``$ tmux new-pane``).
 
-        Floating panes require tmux 3.7+. Delegates to :meth:`Pane.new_pane`
-        on the active pane.
+        Use :meth:`split` for a tiled pane. Floating panes require tmux 3.7+;
+        delegates to :meth:`Pane.new_pane` on the active pane.
 
         Parameters
         ----------

--- a/tests/test_neo.py
+++ b/tests/test_neo.py
@@ -65,6 +65,50 @@ def test_field_version_keys_are_obj_fields() -> None:
         )
 
 
+# Format tokens first registered in tmux 3.7 (verified against format.c /
+# tmux.1 at the 3.7 tag).
+TMUX_3_7_FORMAT_TOKENS = [
+    "bracket_paste_flag",
+    "pane_flags",
+    "pane_floating_flag",
+    "pane_pb_progress",
+    "pane_pb_state",
+    "pane_pipe_pid",
+    "pane_x",
+    "pane_y",
+    "pane_z",
+    "pane_zoomed_flag",
+    "synchronized_output_flag",
+]
+
+
+@pytest.mark.parametrize("token", TMUX_3_7_FORMAT_TOKENS)
+def test_format_token_gated_to_3_7(token: str) -> None:
+    """Tmux 3.7 pane format tokens must not leak into older -F templates.
+
+    Each token's format-table entry first appears at the 3.7 tag, so
+    emitting it on 3.6 hydrates the field with the literal ``#{...}``
+    text instead of an empty value.
+    """
+    assert FIELD_VERSION[token] == "3.7"
+    fields_old, _ = get_output_format("list-panes", "3.6")
+    assert token not in fields_old
+    fields_new, _ = get_output_format("list-panes", "3.7")
+    assert token in fields_new
+
+
+@pytest.mark.parametrize("token", ["bracket_paste_flag", "synchronized_output_flag"])
+def test_unprefixed_3_7_tokens_are_pane_scope(token: str) -> None:
+    """The 3.7 pane tokens without a ``pane_`` prefix need scope overrides.
+
+    Their ``format_cb_*`` dereference ``ft->wp`` (the pane), so they
+    belong in ``list-panes`` output despite the missing prefix.
+    """
+    assert _token_scope(token) == "pane"
+    fields, _ = get_output_format("list-panes", "3.7")
+    assert token in fields
+
+
 def test_scopes_by_list_cmd_downward_cascade() -> None:
     """Every ``list-*`` admits universal+session+window+pane scopes.
 

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -815,6 +815,15 @@ SERVER_CHOICE_OPTIONS: list[OptionTestCase] = [
     OptionTestCase(
         "server_set_clipboard", "set-clipboard", OptionScope.Server, "external", str
     ),
+    # get-clipboard: "off" returns bool, use "buffer" for str test (3.7+)
+    OptionTestCase(
+        "server_get_clipboard",
+        "get-clipboard",
+        OptionScope.Server,
+        "buffer",
+        str,
+        "3.7",
+    ),
 ]
 
 SERVER_STRING_OPTIONS: list[OptionTestCase] = [
@@ -877,6 +886,14 @@ SESSION_BOOLEAN_OPTIONS: list[OptionTestCase] = [
         "session_renumber_windows", "renumber-windows", OptionScope.Session, "on", bool
     ),
     OptionTestCase("session_set_titles", "set-titles", OptionScope.Session, "on", bool),
+    OptionTestCase(
+        "session_focus_follows_mouse",
+        "focus-follows-mouse",
+        OptionScope.Session,
+        "on",
+        bool,
+        "3.7",
+    ),
 ]
 
 SESSION_CHOICE_OPTIONS: list[OptionTestCase] = [
@@ -917,6 +934,14 @@ SESSION_CHOICE_OPTIONS: list[OptionTestCase] = [
     OptionTestCase(
         "session_visual_silence", "visual-silence", OptionScope.Session, "both", str
     ),
+    OptionTestCase(
+        "session_prompt_command_cursor_style",
+        "prompt-command-cursor-style",
+        OptionScope.Session,
+        "blinking-block",
+        str,
+        "3.7",
+    ),
 ]
 
 SESSION_STRING_OPTIONS: list[OptionTestCase] = [
@@ -928,6 +953,14 @@ SESSION_STRING_OPTIONS: list[OptionTestCase] = [
     ),
     OptionTestCase(
         "session_status_right", "status-right", OptionScope.Session, "%H:%M", str
+    ),
+    OptionTestCase(
+        "session_message_format",
+        "message-format",
+        OptionScope.Session,
+        "#[align=centre]#{message}",
+        str,
+        "3.7",
     ),
 ]
 
@@ -996,6 +1029,15 @@ WINDOW_CHOICE_OPTIONS: list[OptionTestCase] = [
     OptionTestCase(
         "window_window_size", "window-size", OptionScope.Window, "latest", str, "3.1"
     ),
+    # copy-mode-line-numbers: "off" returns bool, use "absolute" for str test (3.7+)
+    OptionTestCase(
+        "window_copy_mode_line_numbers",
+        "copy-mode-line-numbers",
+        OptionScope.Window,
+        "absolute",
+        str,
+        "3.7",
+    ),
 ]
 
 WINDOW_STRING_OPTIONS: list[OptionTestCase] = [
@@ -1005,6 +1047,30 @@ WINDOW_STRING_OPTIONS: list[OptionTestCase] = [
         OptionScope.Window,
         "#{pane_index}",
         str,
+    ),
+    OptionTestCase(
+        "window_tree_mode_preview_format",
+        "tree-mode-preview-format",
+        OptionScope.Window,
+        "#{window_name}",
+        str,
+        "3.7",
+    ),
+    OptionTestCase(
+        "window_window_pane_status_format",
+        "window-pane-status-format",
+        OptionScope.Window,
+        "#{pane_index}",
+        str,
+        "3.7",
+    ),
+    OptionTestCase(
+        "window_window_pane_current_status_format",
+        "window-pane-current-status-format",
+        OptionScope.Window,
+        "#{pane_index}",
+        str,
+        "3.7",
     ),
 ]
 
@@ -1039,6 +1105,30 @@ WINDOW_STYLE_OPTIONS: list[OptionTestCase] = [
         OptionScope.Window,
         "fg=magenta",
         str,
+    ),
+    OptionTestCase(
+        "window_copy_mode_line_number_style",
+        "copy-mode-line-number-style",
+        OptionScope.Window,
+        "fg=cyan",
+        str,
+        "3.7",
+    ),
+    OptionTestCase(
+        "window_copy_mode_current_line_number_style",
+        "copy-mode-current-line-number-style",
+        OptionScope.Window,
+        "fg=cyan",
+        str,
+        "3.7",
+    ),
+    OptionTestCase(
+        "window_tree_mode_preview_style",
+        "tree-mode-preview-style",
+        OptionScope.Window,
+        "fg=red",
+        str,
+        "3.7",
     ),
 ]
 
@@ -1081,6 +1171,15 @@ PANE_CHOICE_OPTIONS: list[OptionTestCase] = [
         "failed",
         str,
         "3.2",
+    ),
+    # remain-on-exit gained "key" in tmux 3.7
+    OptionTestCase(
+        "pane_remain_on_exit_key",
+        "remain-on-exit",
+        OptionScope.Pane,
+        "key",
+        str,
+        "3.7",
     ),
 ]
 

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -29,6 +29,17 @@ if t.TYPE_CHECKING:
     from libtmux.session import Session
 
 
+TMUX_3_7_SHARED_PANE_OPTION_FIELDS = (
+    "copy_mode_line_numbers",
+    "copy_mode_line_number_style",
+    "copy_mode_current_line_number_style",
+    "tree_mode_preview_format",
+    "tree_mode_preview_style",
+    "window_pane_status_format",
+    "window_pane_current_status_format",
+)
+
+
 def test_options(server: Server) -> None:
     """Test basic options."""
     session = server.new_session(session_name="test")
@@ -140,6 +151,13 @@ def test_options_pane(server: Server) -> None:
 
     pane_options = PaneOptions(**pane_options_)
     assert pane_options.window_active_style == pane_options_.get("window-active-style")
+
+
+@pytest.mark.parametrize("field_name", TMUX_3_7_SHARED_PANE_OPTION_FIELDS)
+def test_pane_options_declares_tmux_3_7_shared_fields(field_name: str) -> None:
+    """Tmux 3.7 options shared with window scope must type on panes too."""
+    assert field_name in PaneOptions.__dataclass_fields__
+    assert field_name in Options.__dataclass_fields__
 
 
 def test_options_grid(server: Server) -> None:
@@ -1181,6 +1199,42 @@ PANE_CHOICE_OPTIONS: list[OptionTestCase] = [
         str,
         "3.7",
     ),
+    # copy-mode-line-numbers is also valid at pane scope on tmux 3.7+
+    OptionTestCase(
+        "pane_copy_mode_line_numbers",
+        "copy-mode-line-numbers",
+        OptionScope.Pane,
+        "absolute",
+        str,
+        "3.7",
+    ),
+]
+
+PANE_STRING_OPTIONS: list[OptionTestCase] = [
+    OptionTestCase(
+        "pane_tree_mode_preview_format",
+        "tree-mode-preview-format",
+        OptionScope.Pane,
+        "#{pane_index}",
+        str,
+        "3.7",
+    ),
+    OptionTestCase(
+        "pane_window_pane_status_format",
+        "window-pane-status-format",
+        OptionScope.Pane,
+        "#{pane_index}",
+        str,
+        "3.7",
+    ),
+    OptionTestCase(
+        "pane_window_pane_current_status_format",
+        "window-pane-current-status-format",
+        OptionScope.Pane,
+        "#{pane_index}",
+        str,
+        "3.7",
+    ),
 ]
 
 PANE_STYLE_OPTIONS: list[OptionTestCase] = [
@@ -1194,6 +1248,30 @@ PANE_STYLE_OPTIONS: list[OptionTestCase] = [
         "default",
         str,
         "3.0",
+    ),
+    OptionTestCase(
+        "pane_copy_mode_line_number_style",
+        "copy-mode-line-number-style",
+        OptionScope.Pane,
+        "fg=cyan",
+        str,
+        "3.7",
+    ),
+    OptionTestCase(
+        "pane_copy_mode_current_line_number_style",
+        "copy-mode-current-line-number-style",
+        OptionScope.Pane,
+        "fg=cyan",
+        str,
+        "3.7",
+    ),
+    OptionTestCase(
+        "pane_tree_mode_preview_style",
+        "tree-mode-preview-style",
+        OptionScope.Pane,
+        "fg=red",
+        str,
+        "3.7",
     ),
 ]
 
@@ -1215,6 +1293,7 @@ ALL_OPTION_TEST_CASES: list[OptionTestCase] = (
     + WINDOW_STYLE_OPTIONS
     + PANE_BOOLEAN_OPTIONS
     + PANE_CHOICE_OPTIONS
+    + PANE_STRING_OPTIONS
     + PANE_STYLE_OPTIONS
 )
 

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -30,7 +30,12 @@ if t.TYPE_CHECKING:
 
 
 # tmux 3.7's tree-mode-preview-format is the only new option scoped window+pane.
-TMUX_3_7_SHARED_PANE_OPTION_FIELDS = ("tree_mode_preview_format",)
+TMUX_3_7_SHARED_PANE_OPTION_FIELDS = (
+    "tree_mode_preview_format",
+    # pane-active-border-style / pane-border-style widened to window+pane in 3.7
+    "pane_active_border_style",
+    "pane_border_style",
+)
 
 # tmux 3.7 options scoped window-only in options-table.c: they must NOT be typed
 # on PaneOptions (tmux's set -p silently routes them to the window).
@@ -1234,6 +1239,22 @@ PANE_STYLE_OPTIONS: list[OptionTestCase] = [
         "default",
         str,
         "3.0",
+    ),
+    OptionTestCase(
+        "pane_pane_active_border_style",
+        "pane-active-border-style",
+        OptionScope.Pane,
+        "fg=green",
+        str,
+        "3.7",
+    ),
+    OptionTestCase(
+        "pane_pane_border_style",
+        "pane-border-style",
+        OptionScope.Pane,
+        "fg=red",
+        str,
+        "3.7",
     ),
 ]
 

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -29,11 +29,15 @@ if t.TYPE_CHECKING:
     from libtmux.session import Session
 
 
-TMUX_3_7_SHARED_PANE_OPTION_FIELDS = (
+# tmux 3.7's tree-mode-preview-format is the only new option scoped window+pane.
+TMUX_3_7_SHARED_PANE_OPTION_FIELDS = ("tree_mode_preview_format",)
+
+# tmux 3.7 options scoped window-only in options-table.c: they must NOT be typed
+# on PaneOptions (tmux's set -p silently routes them to the window).
+WINDOW_ONLY_3_7_OPTION_FIELDS = (
     "copy_mode_line_numbers",
     "copy_mode_line_number_style",
     "copy_mode_current_line_number_style",
-    "tree_mode_preview_format",
     "tree_mode_preview_style",
     "window_pane_status_format",
     "window_pane_current_status_format",
@@ -158,6 +162,13 @@ def test_pane_options_declares_tmux_3_7_shared_fields(field_name: str) -> None:
     """Tmux 3.7 options shared with window scope must type on panes too."""
     assert field_name in PaneOptions.__dataclass_fields__
     assert field_name in Options.__dataclass_fields__
+
+
+@pytest.mark.parametrize("field_name", WINDOW_ONLY_3_7_OPTION_FIELDS)
+def test_window_only_3_7_options_absent_from_pane(field_name: str) -> None:
+    """Window-only tmux 3.7 options must not be typed on PaneOptions."""
+    assert field_name in WindowOptions.__dataclass_fields__
+    assert field_name not in PaneOptions.__dataclass_fields__
 
 
 def test_options_grid(server: Server) -> None:
@@ -1199,37 +1210,12 @@ PANE_CHOICE_OPTIONS: list[OptionTestCase] = [
         str,
         "3.7",
     ),
-    # copy-mode-line-numbers is also valid at pane scope on tmux 3.7+
-    OptionTestCase(
-        "pane_copy_mode_line_numbers",
-        "copy-mode-line-numbers",
-        OptionScope.Pane,
-        "absolute",
-        str,
-        "3.7",
-    ),
 ]
 
 PANE_STRING_OPTIONS: list[OptionTestCase] = [
     OptionTestCase(
         "pane_tree_mode_preview_format",
         "tree-mode-preview-format",
-        OptionScope.Pane,
-        "#{pane_index}",
-        str,
-        "3.7",
-    ),
-    OptionTestCase(
-        "pane_window_pane_status_format",
-        "window-pane-status-format",
-        OptionScope.Pane,
-        "#{pane_index}",
-        str,
-        "3.7",
-    ),
-    OptionTestCase(
-        "pane_window_pane_current_status_format",
-        "window-pane-current-status-format",
         OptionScope.Pane,
         "#{pane_index}",
         str,
@@ -1248,30 +1234,6 @@ PANE_STYLE_OPTIONS: list[OptionTestCase] = [
         "default",
         str,
         "3.0",
-    ),
-    OptionTestCase(
-        "pane_copy_mode_line_number_style",
-        "copy-mode-line-number-style",
-        OptionScope.Pane,
-        "fg=cyan",
-        str,
-        "3.7",
-    ),
-    OptionTestCase(
-        "pane_copy_mode_current_line_number_style",
-        "copy-mode-current-line-number-style",
-        OptionScope.Pane,
-        "fg=cyan",
-        str,
-        "3.7",
-    ),
-    OptionTestCase(
-        "pane_tree_mode_preview_style",
-        "tree-mode-preview-style",
-        OptionScope.Pane,
-        "fg=red",
-        str,
-        "3.7",
     ),
 ]
 

--- a/tests/test_pane.py
+++ b/tests/test_pane.py
@@ -1575,19 +1575,54 @@ def test_pane_refresh_raises_when_pane_id_is_none(session: Session) -> None:
         pane.refresh()
 
 
-def test_capture_pane_3_7_flags(session: Session) -> None:
+class CaptureFlagWarnCase(t.NamedTuple):
+    """Test case for capture_pane() 3.7 flag warn-and-ignore paths."""
+
+    test_id: str
+    kwargs: dict[str, t.Any]
+    match: str
+
+
+CAPTURE_FLAG_WARN_CASES: list[CaptureFlagWarnCase] = [
+    CaptureFlagWarnCase(
+        test_id="hyperlinks",
+        kwargs={"hyperlinks": True},
+        match="hyperlinks requires tmux 3.7",
+    ),
+    CaptureFlagWarnCase(
+        test_id="line_numbers",
+        kwargs={"line_numbers": True},
+        match="line_numbers requires tmux 3.7",
+    ),
+    CaptureFlagWarnCase(
+        test_id="line_flags",
+        kwargs={"line_flags": True},
+        match="line_flags requires tmux 3.7",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    list(CaptureFlagWarnCase._fields),
+    CAPTURE_FLAG_WARN_CASES,
+    ids=[c.test_id for c in CAPTURE_FLAG_WARN_CASES],
+)
+def test_capture_pane_3_7_flags(
+    test_id: str,
+    kwargs: dict[str, t.Any],
+    match: str,
+    session: Session,
+) -> None:
     """Pane.capture_pane() -H/-L/-F on tmux 3.7+; warn-and-ignore below."""
     window = session.new_window(window_name="capture_37")
     pane = window.active_pane
     assert pane is not None
 
     if has_gte_version("3.7"):
-        assert isinstance(pane.capture_pane(hyperlinks=True), list)
-        assert isinstance(pane.capture_pane(line_numbers=True), list)
-        assert isinstance(pane.capture_pane(line_flags=True), list)
+        assert isinstance(pane.capture_pane(**kwargs), list)
     else:
-        with pytest.warns(UserWarning, match="hyperlinks requires tmux 3.7"):
-            pane.capture_pane(hyperlinks=True)
+        with pytest.warns(UserWarning, match=match):
+            pane.capture_pane(**kwargs)
 
 
 def test_split_empty(session: Session) -> None:

--- a/tests/test_pane.py
+++ b/tests/test_pane.py
@@ -1630,3 +1630,20 @@ def test_paste_buffer_no_vis(session: Session) -> None:
     else:
         with pytest.warns(UserWarning, match="no_vis requires tmux 3.7"):
             pane.paste_buffer(buffer_name="novis_test", no_vis=True)
+
+
+def test_new_pane_floating(session: Session) -> None:
+    """Pane.new_pane() creates a floating pane on tmux 3.7+ (else raises)."""
+    window = session.new_window(window_name="floating_pane")
+    window.resize(height=50, width=200)
+    pane = window.active_pane
+    assert pane is not None
+
+    if has_gte_version("3.7"):
+        floating = pane.new_pane(width=80, height=15, x=5, y=3, shell="sleep 30")
+        assert floating.pane_floating_flag == "1"
+        assert floating.pane_width == "80"
+        assert floating.pane_height == "15"
+    else:
+        with pytest.raises(exc.LibTmuxException, match=r"new_pane .*requires tmux 3.7"):
+            pane.new_pane(width=40, height=10)

--- a/tests/test_pane.py
+++ b/tests/test_pane.py
@@ -1647,3 +1647,19 @@ def test_new_pane_floating(session: Session) -> None:
     else:
         with pytest.raises(exc.LibTmuxException, match=r"new_pane .*requires tmux 3.7"):
             pane.new_pane(width=40, height=10)
+
+
+def test_new_pane_error_tags_subcommand(session: Session) -> None:
+    """Pane.new_pane() tags LibTmuxException with the new-pane subcommand."""
+    window = session.new_window(window_name="new_pane_err")
+    pane = window.active_pane
+    assert pane is not None
+
+    if has_gte_version("3.7"):
+        with pytest.raises(exc.LibTmuxException) as excinfo:
+            pane.new_pane(target="%99999")
+        assert excinfo.value.subcommand == "new-pane"
+        assert str(excinfo.value).startswith("new-pane:")
+    else:
+        with pytest.raises(exc.LibTmuxException, match=r"requires tmux 3.7"):
+            pane.new_pane(target="%99999")

--- a/tests/test_pane.py
+++ b/tests/test_pane.py
@@ -1754,6 +1754,23 @@ def test_new_pane_floating(session: Session) -> None:
             pane.new_pane(width=40, height=10)
 
 
+def test_new_pane_keep(session: Session) -> None:
+    """Pane.new_pane(keep=True) sets remain-on-exit (-k) on tmux 3.7+."""
+    window = session.new_window(window_name="floating_keep")
+    window.resize(height=50, width=200)
+    pane = window.active_pane
+    assert pane is not None
+
+    if has_gte_version("3.7"):
+        floating = pane.new_pane(width=80, height=15, keep=True, shell="sleep 30")
+        assert floating.pane_floating_flag == "1"
+        remain = floating.cmd("show-options", "-p", "-v", "remain-on-exit").stdout
+        assert remain == ["key"]
+    else:
+        with pytest.raises(exc.LibTmuxException, match=r"requires tmux 3.7"):
+            pane.new_pane(width=40, height=10, keep=True)
+
+
 @pytest.mark.parametrize(
     ("test_id", "option_kwargs"),
     _NEW_PANE_EMPTY_VALUE_CASES,

--- a/tests/test_pane.py
+++ b/tests/test_pane.py
@@ -1667,6 +1667,32 @@ def test_paste_buffer_no_vis(session: Session) -> None:
             pane.paste_buffer(buffer_name="novis_test", no_vis=True)
 
 
+class _NewPaneEmptyValueKwargs(t.TypedDict, total=False):
+    style: str
+    active_border_style: str
+    inactive_border_style: str
+    message: str
+
+
+class _NewPaneEmptyValueCase(t.NamedTuple):
+    test_id: str
+    option_kwargs: _NewPaneEmptyValueKwargs
+
+
+_NEW_PANE_EMPTY_VALUE_CASES = (
+    _NewPaneEmptyValueCase(test_id="style", option_kwargs={"style": ""}),
+    _NewPaneEmptyValueCase(
+        test_id="active_border_style",
+        option_kwargs={"active_border_style": ""},
+    ),
+    _NewPaneEmptyValueCase(
+        test_id="inactive_border_style",
+        option_kwargs={"inactive_border_style": ""},
+    ),
+    _NewPaneEmptyValueCase(test_id="message", option_kwargs={"message": ""}),
+)
+
+
 def test_new_pane_floating(session: Session) -> None:
     """Pane.new_pane() creates a floating pane on tmux 3.7+ (else raises)."""
     window = session.new_window(window_name="floating_pane")
@@ -1682,6 +1708,34 @@ def test_new_pane_floating(session: Session) -> None:
     else:
         with pytest.raises(exc.LibTmuxException, match=r"new_pane .*requires tmux 3.7"):
             pane.new_pane(width=40, height=10)
+
+
+@pytest.mark.parametrize(
+    ("test_id", "option_kwargs"),
+    _NEW_PANE_EMPTY_VALUE_CASES,
+    ids=[case.test_id for case in _NEW_PANE_EMPTY_VALUE_CASES],
+)
+def test_new_pane_preserves_empty_option_values(
+    session: Session,
+    test_id: str,
+    option_kwargs: _NewPaneEmptyValueKwargs,
+) -> None:
+    """Pane.new_pane() preserves empty string option values."""
+    window = session.new_window(window_name=f"floating_empty_{test_id}")
+    pane = window.active_pane
+    assert pane is not None
+
+    if has_gte_version("3.7"):
+        floating = pane.new_pane(
+            width=40,
+            height=10,
+            shell="sleep 30",
+            **option_kwargs,
+        )
+        assert floating.pane_floating_flag == "1"
+    else:
+        with pytest.raises(exc.LibTmuxException, match=r"requires tmux 3.7"):
+            pane.new_pane(width=40, height=10, **option_kwargs)
 
 
 def test_new_pane_error_tags_subcommand(session: Session) -> None:

--- a/tests/test_pane.py
+++ b/tests/test_pane.py
@@ -1573,3 +1573,60 @@ def test_pane_refresh_raises_when_pane_id_is_none(session: Session) -> None:
 
     with pytest.raises(ValueError, match="pane_id"):
         pane.refresh()
+
+
+def test_capture_pane_3_7_flags(session: Session) -> None:
+    """Pane.capture_pane() -H/-L/-F on tmux 3.7+; warn-and-ignore below."""
+    window = session.new_window(window_name="capture_37")
+    pane = window.active_pane
+    assert pane is not None
+
+    if has_gte_version("3.7"):
+        assert isinstance(pane.capture_pane(hyperlinks=True), list)
+        assert isinstance(pane.capture_pane(line_numbers=True), list)
+        assert isinstance(pane.capture_pane(line_flags=True), list)
+    else:
+        with pytest.warns(UserWarning, match="hyperlinks requires tmux 3.7"):
+            pane.capture_pane(hyperlinks=True)
+
+
+def test_split_empty(session: Session) -> None:
+    """Pane.split(empty=True) creates an empty pane on tmux 3.7+."""
+    window = session.new_window(window_name="split_empty")
+    window.resize(height=40, width=80)
+    pane = window.active_pane
+    assert pane is not None
+
+    if has_gte_version("3.7"):
+        new_pane = pane.split(empty=True)
+        assert new_pane in window.panes
+        assert len(window.panes) == 2
+    else:
+        with pytest.warns(UserWarning, match="empty requires tmux 3.7"):
+            pane.split(empty=True)
+
+
+def test_paste_buffer_no_vis(session: Session) -> None:
+    """Pane.paste_buffer(no_vis=True) uses -S on tmux 3.7+; warn below."""
+    env = shutil.which("env")
+    assert env is not None
+
+    window = session.new_window(
+        window_name="paste_novis",
+        window_shell=f"{env} PS1='$ ' sh",
+    )
+    pane = window.active_pane
+    assert pane is not None
+    retry_until(lambda: "$" in "\n".join(pane.capture_pane()), 2, raises=True)
+
+    session.server.set_buffer("raw_content", buffer_name="novis_test")
+    if has_gte_version("3.7"):
+        pane.paste_buffer(buffer_name="novis_test", no_vis=True)
+        retry_until(
+            lambda: "raw_content" in "\n".join(pane.capture_pane()),
+            3,
+            raises=True,
+        )
+    else:
+        with pytest.warns(UserWarning, match="no_vis requires tmux 3.7"):
+            pane.paste_buffer(buffer_name="novis_test", no_vis=True)

--- a/tests/test_pane.py
+++ b/tests/test_pane.py
@@ -1641,6 +1641,50 @@ def test_split_empty(session: Session) -> None:
             pane.split(empty=True)
 
 
+class SplitFlagCase(t.NamedTuple):
+    """Test case for Pane.split() tmux 3.7 styling/remain flags."""
+
+    test_id: str
+    kwargs: dict[str, t.Any]
+
+
+SPLIT_FLAG_CASES: list[SplitFlagCase] = [
+    SplitFlagCase(test_id="style", kwargs={"style": "bg=red"}),
+    SplitFlagCase(
+        test_id="active_border_style", kwargs={"active_border_style": "fg=green"}
+    ),
+    SplitFlagCase(
+        test_id="inactive_border_style", kwargs={"inactive_border_style": "fg=blue"}
+    ),
+    SplitFlagCase(test_id="message", kwargs={"message": "bye"}),
+    SplitFlagCase(test_id="keep", kwargs={"keep": True}),
+]
+
+
+@pytest.mark.parametrize(
+    list(SplitFlagCase._fields),
+    SPLIT_FLAG_CASES,
+    ids=[c.test_id for c in SPLIT_FLAG_CASES],
+)
+def test_split_3_7_flags(
+    test_id: str,
+    kwargs: dict[str, t.Any],
+    session: Session,
+) -> None:
+    """Pane.split() tmux 3.7 styling/remain flags work on 3.7+; warn below."""
+    window = session.new_window(window_name="split_37")
+    window.resize(height=40, width=80)
+    pane = window.active_pane
+    assert pane is not None
+
+    if has_gte_version("3.7"):
+        new_pane = pane.split(**kwargs)
+        assert new_pane in window.panes
+    else:
+        with pytest.warns(UserWarning, match=r"require tmux 3.7"):
+            pane.split(**kwargs)
+
+
 def test_paste_buffer_no_vis(session: Session) -> None:
     """Pane.paste_buffer(no_vis=True) uses -S on tmux 3.7+; warn below."""
     env = shutil.which("env")

--- a/tests/test_pane.py
+++ b/tests/test_pane.py
@@ -1685,6 +1685,54 @@ def test_split_3_7_flags(
             pane.split(**kwargs)
 
 
+class _SplitEmptyValueKwargs(t.TypedDict, total=False):
+    style: str
+    active_border_style: str
+    inactive_border_style: str
+    message: str
+
+
+class _SplitEmptyValueCase(t.NamedTuple):
+    test_id: str
+    option_kwargs: _SplitEmptyValueKwargs
+
+
+_SPLIT_EMPTY_VALUE_CASES = (
+    _SplitEmptyValueCase(test_id="style", option_kwargs={"style": ""}),
+    _SplitEmptyValueCase(
+        test_id="active_border_style", option_kwargs={"active_border_style": ""}
+    ),
+    _SplitEmptyValueCase(
+        test_id="inactive_border_style", option_kwargs={"inactive_border_style": ""}
+    ),
+    _SplitEmptyValueCase(test_id="message", option_kwargs={"message": ""}),
+)
+
+
+@pytest.mark.parametrize(
+    ("test_id", "option_kwargs"),
+    _SPLIT_EMPTY_VALUE_CASES,
+    ids=[case.test_id for case in _SPLIT_EMPTY_VALUE_CASES],
+)
+def test_split_preserves_empty_option_values(
+    session: Session,
+    test_id: str,
+    option_kwargs: _SplitEmptyValueKwargs,
+) -> None:
+    """Pane.split() emits empty value flags as a separate argv entry."""
+    window = session.new_window(window_name=f"split_empty_{test_id}")
+    window.resize(height=40, width=120)
+    pane = window.active_pane
+    assert pane is not None
+
+    if has_gte_version("3.7"):
+        new_pane = pane.split(**option_kwargs)
+        assert new_pane in window.panes
+    else:
+        with pytest.warns(UserWarning, match=r"require tmux 3.7"):
+            pane.split(**option_kwargs)
+
+
 def test_paste_buffer_no_vis(session: Session) -> None:
     """Pane.paste_buffer(no_vis=True) uses -S on tmux 3.7+; warn below."""
     env = shutil.which("env")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1109,6 +1109,19 @@ def test_run_shell_show_stderr(server: Server) -> None:
     assert "to_stderr" in joined
 
 
+def test_run_shell_args(server: Server) -> None:
+    """``args`` fill #{1}/#{2} in the command on tmux 3.7+; warn below."""
+    from libtmux.common import has_gte_version
+
+    server.new_session(session_name="run_shell_args_test")
+    if has_gte_version("3.7"):
+        result = server.run_shell("echo #{1}-#{2}", args=["alpha", "beta"])
+        assert result == ["alpha-beta"]
+    else:
+        with pytest.warns(UserWarning, match=r"args requires tmux 3.7"):
+            server.run_shell("echo plain", args=["alpha"])
+
+
 def test_run_shell_cwd_warns_on_old_tmux(
     server: Server,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -957,6 +957,20 @@ def test_list_keys(server: Server) -> None:
     assert len(result) > 0  # default bindings exist
 
 
+def test_list_keys_format(server: Server) -> None:
+    """Server.list_keys(format_=...) applies -F on tmux 3.7+; warns below."""
+    from libtmux.common import has_gte_version
+
+    server.new_session(session_name="listkeys_fmt")
+    if has_gte_version("3.7"):
+        result = server.list_keys(format_="fmt")
+        assert result
+        assert all(line == "fmt" for line in result)
+    else:
+        with pytest.warns(UserWarning, match=r"format requires tmux 3.7"):
+            server.list_keys(format_="fmt")
+
+
 def test_list_commands(server: Server) -> None:
     """Test Server.list_commands() returns command listing."""
     server.new_session(session_name="listcmds_test")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -860,7 +860,12 @@ def test_refresh_client_request_clipboard(
     monkeypatch: pytest.MonkeyPatch,
     server: Server,
 ) -> None:
-    """refresh_client(request_clipboard=True) emits -l on tmux 3.7+."""
+    """refresh_client(request_clipboard=True) emits -l on tmux 3.7+.
+
+    ``refresh-client -l`` queries the client's clipboard via an xterm
+    escape sequence, which has no observable effect under the headless
+    test server, so verify the constructed argv instead.
+    """
     from libtmux.common import has_gte_version
 
     if not has_gte_version("3.7"):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -650,8 +650,9 @@ def test_command_prompt(
         ({"literal": True}, "-l", "3.6"),
         # -e is master-only (upstream 1e5f93b7); not in any 3.6 release
         ({"bspace_exit": True}, "-e", "3.7"),
+        ({"no_freeze": True}, "-C", "3.7"),
     ],
-    ids=["expand_format_v33", "literal_v36", "bspace_exit"],
+    ids=["expand_format_v33", "literal_v36", "bspace_exit", "no_freeze"],
 )
 def test_command_prompt_extra_flags(
     kwargs: dict[str, t.Any],

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -856,6 +856,37 @@ def test_refresh_client(
         server.refresh_client()
 
 
+def test_refresh_client_request_clipboard(
+    monkeypatch: pytest.MonkeyPatch,
+    server: Server,
+) -> None:
+    """refresh_client(request_clipboard=True) emits -l on tmux 3.7+."""
+    from libtmux.common import has_gte_version
+
+    if not has_gte_version("3.7"):
+        pytest.skip("refresh-client -l clipboard query requires tmux 3.7+")
+
+    captured: list[tuple[str, ...]] = []
+    real_cmd = server.cmd
+
+    class _StubResult:
+        stderr: t.ClassVar[list[str]] = []
+        stdout: t.ClassVar[list[str]] = []
+
+    def fake_cmd(cmd: str, *args: str, **_kw: t.Any) -> t.Any:
+        if cmd == "refresh-client":
+            captured.append((cmd, *args))
+            return _StubResult()
+        return real_cmd(cmd, *args, **_kw)
+
+    monkeypatch.setattr(server, "cmd", fake_cmd)
+    server.refresh_client(request_clipboard=True)
+
+    assert captured, "Server.cmd was not invoked"
+    _name, *flags = captured[0]
+    assert "-l" in flags
+
+
 def test_suspend_client(
     control_mode: t.Callable[..., t.Any],
     server: Server,

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -768,3 +768,17 @@ def test_session_refresh_raises_when_session_id_is_none(server: Server) -> None:
 
     with pytest.raises(ValueError, match="session_id"):
         session.refresh()
+
+
+def test_kill_session_group(server: Server) -> None:
+    """Session.kill(group=True) uses -g on tmux 3.7+; warn-and-ignore below."""
+    from libtmux.common import has_gte_version
+
+    session = server.new_session(session_name="kill_group_base")
+
+    if has_gte_version("3.7"):
+        session.kill(group=True)
+        assert not server.has_session("kill_group_base")
+    else:
+        with pytest.warns(UserWarning, match="group requires tmux 3.7"):
+            session.kill(group=True)

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -1318,3 +1318,19 @@ def test_window_refresh_raises_when_window_id_is_none(session: Session) -> None:
 
     with pytest.raises(ValueError, match="window_id"):
         window.refresh()
+
+
+def test_new_pane(session: Session) -> None:
+    """Window.new_pane() creates a floating pane on tmux 3.7+ (else raises)."""
+    from libtmux.common import has_gte_version
+
+    window = session.new_window(window_name="win_floating")
+    window.resize(height=50, width=200)
+
+    if has_gte_version("3.7"):
+        floating = window.new_pane(width=60, height=12, shell="sleep 30")
+        assert floating.pane_floating_flag == "1"
+        assert floating in window.panes
+    else:
+        with pytest.raises(exc.LibTmuxException, match=r"new_pane .*requires tmux 3.7"):
+            window.new_pane(width=40, height=10)


### PR DESCRIPTION
## Summary

Builds on #693 (tmux 3.7 compatibility, merged and shipped in v0.59.0) to expose tmux 3.7's new surface as typed, discoverable libtmux API. Targets `master`.

- **Add** floating panes via `Window.new_pane()` / `Pane.new_pane()` — tmux 3.7's flagship `new-pane`.
- **Add** the 11 options new in tmux 3.7 as typed fields on the option dataclasses.
- **Add** the 11 pane format variables new in tmux 3.7 on `Pane` (version-gated).
- **Add** new flags on existing wrappers: `capture_pane` `-H`/`-L`/`-F`, `split` `-E`, `kill` `-g`, `paste_buffer` `-S`.

## Changes by area

### Floating panes — `src/libtmux/pane.py`, `src/libtmux/window.py`

**`Pane.new_pane()` / `Window.new_pane()`** issue `new-pane` to create a floating pane that overlays the tiled layout like a popup but behaves like a real pane. Geometry maps `width`/`height` → `-x`/`-y` (size) and `x`/`y` → `-X`/`-Y` (position); also supports `shell`, `start_directory`, `environment`, `zoom`, `empty`, and `style`/`active_border_style`/`inactive_border_style`. Returns the floating `Pane` (`pane_floating_flag == "1"`); raises `LibTmuxException` on tmux < 3.7.

### Typed options — `src/libtmux/_internal/constants.py`

| Scope | Options added |
|---|---|
| Server | `get-clipboard` |
| Session | `focus-follows-mouse`, `message-format`, `prompt-command-cursor-style` |
| Window | `copy-mode-line-numbers` (+ `-style`, `-current-line-number-style`), `tree-mode-preview-format`/`-style`, `window-pane-status-format`/`-current-status-format` |
| Pane | copy-mode line-number, tree-mode preview and window-pane status options (shared with Window in 3.7); `remain-on-exit` gains the `key` value |

### Format variables — `src/libtmux/neo.py`, `src/libtmux/formats.py`

Declare the 11 new tmux 3.7 pane format tokens on `neo.Obj` (`pane_floating_flag`, `pane_x`/`y`/`z`, `pane_flags`, `pane_zoomed_flag`, `pane_pb_progress`/`pane_pb_state`, `pane_pipe_pid`, `bracket_paste_flag`, `synchronized_output_flag`), each gated to tmux 3.7 in `FIELD_VERSION` so older tmux keeps a clean `-F` template. The two tokens without a `pane_` prefix are routed via `_SCOPE_OVERRIDES`.

### Command flags — `src/libtmux/pane.py`, `src/libtmux/window.py`, `src/libtmux/session.py`

| Method | Parameter | Flag |
|---|---|---|
| `Pane.capture_pane` | `hyperlinks` / `line_numbers` / `line_flags` | `-H` / `-L` / `-F` |
| `Pane.split` / `Window.split` | `empty` | `-E` |
| `Session.kill` | `group` | `-g` |
| `Pane.paste_buffer` | `no_vis` | `-S` |

Each is gated with `has_gte_version("3.7")` and warns-and-ignores on older tmux.

## Design decisions

- **Dedicated `new_pane()`, not `split(floating=True)`**: tmux deliberately made floating panes a separate command (`new-pane`) because they overlay the layout rather than subdivide a pane. Mirroring that keeps `split`'s semantics clean and avoids position parameters that are meaningless for a non-floating split.
- **Two version-gating idioms**: flags on methods that work everywhere *warn and ignore* on old tmux (graceful degradation); a whole method that only exists on 3.7+ (`new_pane`) *raises* — there is no graceful fallback for a command that doesn't exist. Version-gated method doctests use the project's `if has_gte_version(...) / else` pattern so they run on every CI tmux version.
- **Verified against the man-page diff**: "what's new in 3.7" was determined from the tmux 3.6 → 3.7 man-page diff, not the C source — tokens move between registration sites across releases, which makes the raw source diff falsely flag old symbols as new.

## Test plan

- [x] `uv run pytest` — full suite green on tmux 3.7 (new options/formats/flags and floating-pane tests; `new_pane` doctests)
- [x] New format tokens absent from a tmux 3.6 `-F` template and present on 3.7 (`tests/test_neo.py`)
- [x] `uv run ruff check .` and `uv run ruff format .`
- [x] `uv run mypy`
- [x] `just build-docs`

Refs #691
