### PR TITLE
docs: lead topic pages with the concept, add docs voice guide

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,80 @@
+# Documentation voice
+
+This file covers the *voice* of prose under `docs/` — how to frame a
+feature page so a reader meets the idea before its configuration. It
+complements the repository-root `AGENTS.md`, which already governs code
+blocks, shell-command formatting, changelog conventions, and MyST
+roles. When the two overlap, the root file wins; this one only answers
+the question it leaves open: how should the prose sound?
+
+## Who you are writing for
+
+The default reader runs tmuxp and writes workspace files in YAML or
+JSON. They are fluent in tmux itself — servers, sessions, windows,
+panes, layouts, the shell and its prompt — but you cannot assume they
+read Python, know tmuxp's internals, or have heard of its builder
+architecture, entry points, or `sys.path`.
+
+A second, smaller reader writes Python: custom builders, plugins, code
+against libtmux. Serve them too, but mark their material as opt-in
+("for the braver cases", "advanced") so the default reader knows they
+can stop. Never make the common case pay a comprehension tax for the
+advanced one.
+
+## Voice
+
+- **Second person, present tense, active.** "You name the builder", not
+  "The builder is selected". Address the reader who is doing the thing.
+- **Concept before configuration.** Open by saying what the thing *is*
+  and what it does for the reader. The YAML surface — the keys, the
+  flags — is the last detail they need, not the first. A page that
+  opens with "set these keys" has buried the idea under its mechanics.
+- **Say when they can stop.** Lead with the default and the
+  reassurance: most readers never touch this, it works out of the box,
+  everything here is optional. Let a skimmer leave after one sentence.
+- **Progressive disclosure.** Order by how many readers need it:
+  default → the one option a few will tune → swapping the whole thing
+  → writing your own. Each step is for a smaller audience than the last.
+- **Name the trade-off.** If an option costs something — load time, a
+  slower attach — say so, and say what it buys ("a little slower, but
+  the workspace is fully prepped before you attach"). State it; don't
+  sell it.
+- **Frame by concept, not by mechanism.** Don't call a feature "the
+  keys" or "the flags" in prose; that names the implementation surface,
+  which is the reader's last concern. Name the concept. The mechanics
+  vocabulary — a `Key` / `Type` / `Default` table — is correct in a
+  reference table, and only there.
+
+## What stays precise
+
+Warm the framing, never the facts. Resolution-order lists, value
+tables, exact error strings, and class or function cross-references
+carry meaning in their exact form — leave them alone. The friendly
+voice belongs in the sentences *around* a precise block, introducing
+it, not inside it paraphrasing it into vagueness.
+
+## Cross-references
+
+Point the advanced reader at the deep-dive rather than inlining it, and
+put the link where their interest peaks — on the phrase that made them
+curious ("write your own") — not as a standalone footnote the eye
+skips. Use the MyST roles listed in the root `AGENTS.md`.
+
+## A page that does this
+
+`docs/configuration/workspace-builders.md` is the worked example:
+a concept-first intro, an out-of-the-box reassurance, sections ordered
+by shrinking audience, an honest trade-off on the prompt wait, and
+precise reference tables left precise. Read it before reshaping another
+page.
+
+## Before you commit
+
+- Does the page open with what the feature *is*, or with how to
+  configure it?
+- Can a reader who needs only the default stop after the first
+  paragraph?
+- Is anything framed as "the keys/flags" that should be named by
+  concept instead?
+- Are the advanced and Python-only parts clearly marked opt-in?
+- Did you leave every table, error string, and cross-reference exact?

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,80 +1,121 @@
 # Documentation voice
 
 This file covers the *voice* of prose under `docs/` — how to frame a
-feature page so a reader meets the idea before its configuration. It
-complements the repository-root `AGENTS.md`, which already governs code
-blocks, shell-command formatting, changelog conventions, and MyST
+page so a reader meets the idea before its API surface. It complements
+the repository-root `AGENTS.md`, which already governs code blocks,
+shell-command formatting, doctests, changelog conventions, and MyST
 roles. When the two overlap, the root file wins; this one only answers
 the question it leaves open: how should the prose sound?
 
 ## Who you are writing for
 
-The default reader runs tmuxp and writes workspace files in YAML or
-JSON. They are fluent in tmux itself — servers, sessions, windows,
-panes, layouts, the shell and its prompt — but you cannot assume they
-read Python, know tmuxp's internals, or have heard of its builder
-architecture, entry points, or `sys.path`.
+The default reader writes Python and drives tmux through libtmux's
+object API — `Server`, `Session`, `Window`, `Pane`. They are fluent in
+tmux itself — servers, sessions, windows, panes, targets, formats — and
+comfortable in Python, but you cannot assume they know libtmux's
+internals: the format-string query layer, `neo`, the options and hooks
+machinery, or when an object goes stale and needs `refresh()`.
 
-A second, smaller reader writes Python: custom builders, plugins, code
-against libtmux. Serve them too, but mark their material as opt-in
-("for the braver cases", "advanced") so the default reader knows they
-can stop. Never make the common case pay a comprehension tax for the
-advanced one.
+A second, smaller reader works *on* libtmux or against its lower
+layers: format tokens, the neo query interface, custom traversal, or
+contributing. Serve them too, but mark their material opt-in ("for the
+rarer cases", "advanced") so the default reader knows they can stop.
+Never make the common case pay a comprehension tax for the advanced one.
 
 ## Voice
 
-- **Second person, present tense, active.** "You name the builder", not
-  "The builder is selected". Address the reader who is doing the thing.
-- **Concept before configuration.** Open by saying what the thing *is*
-  and what it does for the reader. The YAML surface — the keys, the
-  flags — is the last detail they need, not the first. A page that
-  opens with "set these keys" has buried the idea under its mechanics.
+- **Second person, present tense, active.** "You split the window", not
+  "A pane is created". Address the reader who is doing the thing.
+- **Concept before API surface.** Open by saying what the object or
+  method *is* and what it does for the reader. The signature — the
+  parameters, the flags — is the last detail they need, not the first.
+  A page that opens with a method signature has buried the idea under
+  its mechanics.
 - **Say when they can stop.** Lead with the default and the
-  reassurance: most readers never touch this, it works out of the box,
-  everything here is optional. Let a skimmer leave after one sentence.
-- **Progressive disclosure.** Order by how many readers need it:
-  default → the one option a few will tune → swapping the whole thing
-  → writing your own. Each step is for a smaller audience than the last.
-- **Name the trade-off.** If an option costs something — load time, a
-  slower attach — say so, and say what it buys ("a little slower, but
-  the workspace is fully prepped before you attach"). State it; don't
-  sell it.
-- **Frame by concept, not by mechanism.** Don't call a feature "the
-  keys" or "the flags" in prose; that names the implementation surface,
-  which is the reader's last concern. Name the concept. The mechanics
-  vocabulary — a `Key` / `Type` / `Default` table — is correct in a
-  reference table, and only there.
+  reassurance: most readers never reach for this, the defaults work,
+  the advanced parts are optional. Let a skimmer leave after one
+  paragraph.
+- **Grant permission, don't demand attention.** "Reach for this
+  when…", "for the rarer cases" — tell readers they're in the right
+  place without implying they must read on.
+- **Progressive disclosure.** Order by how many readers need it: the
+  common call → the one argument a few will tune → the lower-level
+  primitive → querying tmux directly. Each step is for a smaller
+  audience than the last.
+- **Lean on the hierarchy.** The reader thinks Server → Session →
+  Window → Pane; reinforce that chain when you explain containment or
+  traversal. It is the mental model the whole library hangs on.
+- **Name the trade-off.** If a call costs something — an extra tmux
+  round-trip, a stale object needing `refresh()`, a polling wait — say
+  so, and say what it buys ("a busy wait, not an event, but reliable").
+  State it; don't sell it.
+- **Frame by concept, not by mechanism.** Don't headline a feature by
+  its tmux flag or format token in prose; that names the implementation
+  surface, which is the reader's last concern. Name the concept. The
+  mechanics vocabulary — a parameter table, a `#{format}` token, the
+  `-t` target — belongs in a reference table or the API docs, and only
+  there.
+
+## Examples that run
+
+Prose examples under `docs/` are doctests, and the root `AGENTS.md`
+requires them to actually execute — `testpaths` includes `docs/`, so
+pytest runs every one. Lead with a small, runnable example early rather
+than after paragraphs of prose; libtmux is code-first.
+
+- Use the `doctest_namespace` fixtures — `server`, `session`, `window`,
+  `pane` (and `Server` / `Session` / `Window` / `Pane` / `Client`) —
+  instead of building a server by hand.
+- Fence a `>>>` session as a ```` ```python ```` block, and reach for
+  `# doctest: +ELLIPSIS` when output varies (ids like `@1`, `$2`,
+  socket names). Use a ```` ```console ```` block for shell commands at
+  a `$` prompt.
+- The code blocks on a page share one doctest session, so a later
+  block can use a `pane` an earlier block created. That makes their
+  **order load-bearing**: never reorder, add, or drop a code block when
+  you reshape the prose around it.
 
 ## What stays precise
 
 Warm the framing, never the facts. Resolution-order lists, value
-tables, exact error strings, and class or function cross-references
-carry meaning in their exact form — leave them alone. The friendly
-voice belongs in the sentences *around* a precise block, introducing
-it, not inside it paraphrasing it into vagueness.
+tables, exact error strings, format tokens, and class or method
+cross-references carry meaning in their exact form — leave them alone.
+The friendly voice belongs in the sentences *around* a precise block,
+introducing it, not inside it paraphrasing it into vagueness.
 
 ## Cross-references
 
 Point the advanced reader at the deep-dive rather than inlining it, and
 put the link where their interest peaks — on the phrase that made them
-curious ("write your own") — not as a standalone footnote the eye
-skips. Use the MyST roles listed in the root `AGENTS.md`.
+curious ("query tmux directly", "write your own traversal") — not as a
+standalone footnote the eye skips. Use the MyST roles listed in the
+root `AGENTS.md` (`{meth}`, `{class}`, `{func}`, `{attr}`, `{exc}`,
+`{ref}`, `{doc}`, `{term}`). A `{ref}` must match its target's anchor
+exactly — anchors mix underscore and hyphen forms across pages
+(`context_managers`, `pane-interaction`). `just build-docs` catches a
+broken cross-reference; the doctests do not — so build the docs before
+you commit.
 
 ## A page that does this
 
-`docs/configuration/workspace-builders.md` is the worked example:
-a concept-first intro, an out-of-the-box reassurance, sections ordered
-by shrinking audience, an honest trade-off on the prompt wait, and
-precise reference tables left precise. Read it before reshaping another
-page.
+`docs/topics/pane_interaction.md` is the worked example: a concept-first
+intro that says what a `Pane` *is* and which two methods (`send_keys`,
+`capture_pane`) cover most uses before any signature, an explicit "you
+can stop after the first two sections" reassurance, sections ordered by
+shrinking audience, honest trade-offs (polling is a busy wait; a resize
+is a request, not a guarantee), methods named by what they do with
+`{meth}` cross-references, and precise capture-flag and format tables
+left exact. Read it before reshaping another page.
 
 ## Before you commit
 
-- Does the page open with what the feature *is*, or with how to
-  configure it?
-- Can a reader who needs only the default stop after the first
+- Does the page open with what the feature *is*, or with how to call it?
+- Can a reader who needs only the common case stop after the first
   paragraph?
-- Is anything framed as "the keys/flags" that should be named by
-  concept instead?
-- Are the advanced and Python-only parts clearly marked opt-in?
-- Did you leave every table, error string, and cross-reference exact?
+- Is anything framed by its tmux flag or format token that should be
+  named by concept instead?
+- Are the advanced and lower-level parts clearly marked opt-in?
+- Do the doctests run, and did you leave every code block, table, error
+  string, and cross-reference exact?
+- Did `just build-docs` stay clean — no new warning, no broken
+  cross-reference?

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,5 +52,8 @@ conf = merge_sphinx_config(
     html_css_files=["css/custom.css"],
     html_extra_path=["manifest.json"],
     rediraffe_redirects="redirects.txt",
+    # AGENTS.md is agent guidance, not a site page; keep Sphinx from
+    # treating it as an orphan document.
+    exclude_patterns=["_build", "AGENTS.md"],
 )
 globals().update(conf)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,8 +52,8 @@ conf = merge_sphinx_config(
     html_css_files=["css/custom.css"],
     html_extra_path=["manifest.json"],
     rediraffe_redirects="redirects.txt",
-    # AGENTS.md is agent guidance, not a site page; keep Sphinx from
-    # treating it as an orphan document.
-    exclude_patterns=["_build", "AGENTS.md"],
+    # AGENTS.md (+ its CLAUDE.md symlink) is agent guidance, not a site
+    # page; keep Sphinx from treating it as an orphan document.
+    exclude_patterns=["_build", "AGENTS.md", "CLAUDE.md"],
 )
 globals().update(conf)

--- a/docs/topics/architecture.md
+++ b/docs/topics/architecture.md
@@ -44,10 +44,12 @@ Server
 | {class}`~libtmux.pane.Pane` | None | {class}`~libtmux.window.Window` |
 | {class}`~libtmux.client.Client` | None | {class}`~libtmux.server.Server` |
 
-{class}`~libtmux.common.TmuxRelationalObject` acts as the base container
-connecting these relationships.
+The Session, Window, Pane, and Client classes share a common dataclass
+base (`Obj`) defined in {mod}`libtmux.neo`, which fetches each object's
+fields from tmux; the parent and child links above are plain properties
+on each class.
 
-One object breaks the ownership chain: {class}`~libtmux.Client` is a
+One object breaks the ownership chain: {class}`~libtmux.client.Client` is a
 *view*, not a child. Each attached terminal points at the
 Session/Window/Pane it is currently displaying, but is not owned by
 them — so its view can change the moment a user switches sessions. See
@@ -57,10 +59,10 @@ them — so its view can change the moment a user switches sessions. See
 
 When tmux state changes, libtmux needs a way to recognize that the same
 window is still the same window. tmux assigns each session, window, and
-pane a unique ID for exactly this, and libtmux holds onto it — via
-{class}`~libtmux.common.TmuxMappingObject` — to track objects reliably
-across state refreshes rather than relying on names or indexes that
-shift around.
+pane a unique ID for exactly this, and libtmux stores it as a dataclass
+attribute on each object (`session_id`, `window_id`, `pane_id`) to track
+objects reliably across state refreshes rather than relying on names or
+indexes that shift around.
 
 | Object | Prefix | Example |
 |--------|--------|---------|

--- a/docs/topics/architecture.md
+++ b/docs/topics/architecture.md
@@ -2,15 +2,31 @@
 
 # Architecture
 
-libtmux is a [typed](https://docs.python.org/3/library/typing.html)
-abstraction layer for tmux. It builds upon tmux's concept of targets
-(`-t`) to direct commands against individual sessions, windows, and panes,
-and `FORMATS` — template variables tmux exposes to describe object
+When you use libtmux, you work through a hierarchy of typed Python
+objects — {class}`~libtmux.server.Server`, {class}`~libtmux.session.Session`,
+{class}`~libtmux.window.Window`, and {class}`~libtmux.pane.Pane` — each a
+proxy for the tmux entity it represents. You navigate from one to the
+next (a server's sessions, a session's windows, a window's panes), and
+every method you call turns into a tmux command directed at that exact
+object.
+
+You don't need anything on this page to use the API; the objects and
+their methods work out of the box. This is reference material for when
+you're curious how libtmux tracks those objects, keeps their identities
+stable across refreshes, and lays out the code underneath. Skim the
+first section and stop whenever you've seen enough.
+
+Under the hood, libtmux is a [typed](https://docs.python.org/3/library/typing.html)
+abstraction layer built on two tmux primitives: targets (`-t`), which
+direct a command at an individual session, window, or pane, and
+`FORMATS`, the template variables tmux exposes to describe each object's
 properties.
 
-## Object Hierarchy
+## Object hierarchy
 
-libtmux mirrors tmux's object hierarchy as a typed Python ORM:
+libtmux mirrors tmux's object hierarchy as a typed Python ORM, so the
+parent-child relationships you know from tmux carry over directly into
+the objects you hold:
 
 ```
 Server
@@ -31,16 +47,20 @@ Server
 {class}`~libtmux.common.TmuxRelationalObject` acts as the base container
 connecting these relationships.
 
-{class}`~libtmux.Client` is a *view*, not part of the ownership chain:
-each attached terminal points at a Session/Window/Pane it is currently
-displaying, but is not owned by them. See {ref}`clients` for the view-
-vs-identity distinction.
+One object breaks the ownership chain: {class}`~libtmux.Client` is a
+*view*, not a child. Each attached terminal points at the
+Session/Window/Pane it is currently displaying, but is not owned by
+them — so its view can change the moment a user switches sessions. See
+{ref}`clients` for the view-vs-identity distinction.
 
-## Internal Identifiers
+## Internal identifiers
 
-tmux assigns unique IDs to sessions, windows, and panes. libtmux uses
-these — via {class}`~libtmux.common.TmuxMappingObject` — to track objects
-reliably across state refreshes.
+When tmux state changes, libtmux needs a way to recognize that the same
+window is still the same window. tmux assigns each session, window, and
+pane a unique ID for exactly this, and libtmux holds onto it — via
+{class}`~libtmux.common.TmuxMappingObject` — to track objects reliably
+across state refreshes rather than relying on names or indexes that
+shift around.
 
 | Object | Prefix | Example |
 |--------|--------|---------|
@@ -49,9 +69,11 @@ reliably across state refreshes.
 | {class}`~libtmux.window.Window` | `@` | `@3243` |
 | {class}`~libtmux.pane.Pane` | `%` | `%5433` |
 
-## Core Objects
+## Core objects
 
-Each level wraps tmux commands and format queries:
+These are the five classes you'll actually hold and call methods on.
+Each level wraps the tmux commands and format queries for its tier of
+the hierarchy:
 
 - {class}`~libtmux.server.Server` — entry point, manages sessions, executes raw tmux commands
 - {class}`~libtmux.session.Session` — manages windows within a session
@@ -59,7 +81,13 @@ Each level wraps tmux commands and format queries:
 - {class}`~libtmux.pane.Pane` — terminal instance, sends keys and captures output
 - {class}`~libtmux.client.Client` — attached terminal viewing a session, window, and pane
 
-## Data Flow
+## Data flow
+
+Every interaction follows the same round-trip: you act on a Python
+object, libtmux talks to tmux, and the result comes back as more typed
+objects. Reading state and changing it both cost a tmux call, which is
+why an object can go stale and why you refresh it rather than trust a
+cached value indefinitely.
 
 1. User creates a `Server` (connects to a running tmux server)
 2. Queries use tmux format strings ({mod}`libtmux.constants`) to fetch state
@@ -67,7 +95,12 @@ Each level wraps tmux commands and format queries:
 4. Mutations dispatch tmux commands via the `cmd()` method
 5. Objects refresh state from tmux on demand
 
-## Module Map
+## Module map
+
+The codebase splits along the same hierarchy: one module per tier, plus
+shared plumbing. The first block is what you import and use day to day;
+the second is lower-level and mostly of interest to contributors or
+deeper integrations.
 
 | Module | Role |
 |--------|------|
@@ -77,13 +110,19 @@ Each level wraps tmux commands and format queries:
 | {mod}`libtmux.pane` | Pane I/O and capture |
 | {mod}`libtmux.client` | Attached-client view and live-attachment lookup |
 | {mod}`libtmux.common` | Base classes, command execution |
+
+The remaining modules are advanced — reach for them only when the core
+objects don't cover your case:
+
+| Module | Role |
+|--------|------|
 | {mod}`libtmux.neo` | Modern dataclass-based query interface |
 | {mod}`libtmux.constants` | Format string constants |
 | {mod}`libtmux.options` | tmux option get/set |
 | {mod}`libtmux.hooks` | tmux hook management |
 | {mod}`libtmux.exc` | Exception hierarchy |
 
-## Naming Conventions
+## Naming conventions
 
 tmux commands use dashes (`new-window`). libtmux replaces these with
 underscores (`new_window`) to follow Python naming conventions.

--- a/docs/topics/automation_patterns.md
+++ b/docs/topics/automation_patterns.md
@@ -1,10 +1,29 @@
 (automation-patterns)=
 
-# Automation Patterns
+# Automation patterns
 
-libtmux is ideal for automating terminal workflows, orchestrating multiple processes,
-and building agentic systems that interact with terminal applications. This guide covers
-practical patterns for automation use cases.
+When you automate a terminal workflow, you are usually coordinating more than one
+process: you kick off work in one pane, watch another for a completion signal, and
+keep several tasks moving without blocking on any single one. libtmux's object API
+makes that coordination ordinary Python — you start commands with
+{meth}`~libtmux.Pane.send_keys`, read what came back with
+{meth}`~libtmux.Pane.capture_pane`, and fan work across panes with
+{meth}`~libtmux.Pane.split`. This guide collects the patterns that turn a loose
+pile of `send_keys()` calls into automation you can trust: output monitoring,
+timeouts, retries, and multi-pane orchestration.
+
+Most scripts only need the first two sections. Output monitoring and the context
+manager patterns cover the common case — send a command, wait for a marker, clean
+up after yourself — and you can stop reading there. The later sections (state
+machines, task queues) are for the rarer cases where a single pane drives a longer
+sequence of steps; reach for them when you actually need them.
+
+These patterns lean on polling: you call {meth}`~libtmux.Pane.capture_pane` in a
+loop and `sleep` between reads. That is simpler than wiring up an event-driven
+system, and it costs you latency — each poll is a tmux round-trip, and a `sleep`
+between polls is dead time you pay whether the command finished or not. For most
+automation that trade is worth it. When milliseconds matter, look instead at tmux
+hooks or an external event-driven framework.
 
 Open two terminals:
 
@@ -20,9 +39,20 @@ Terminal two, `python` or `ptpython` if you have it:
 $ python
 ```
 
-## Process Control
+The examples below assume you already have `server` and `session` objects in scope.
+In this documentation they come from libtmux's pytest fixtures, which run the
+doctests against a live tmux server; in your own scripts you create them yourself
+(a {class}`~libtmux.Server` and a session from
+{meth}`~libtmux.Server.new_session`). Each example builds its own window or pane and
+tears it down at the end, so the snippets stand alone and don't depend on each other.
+
+## Process control
 
 ### Starting long-running processes
+
+When you send a command to a pane with {meth}`~libtmux.Pane.send_keys`, it runs in
+the background — control returns to your script immediately, while the command keeps
+going in the pane. The pane object stays your handle on that running work.
 
 ```python
 >>> import time
@@ -43,6 +73,10 @@ $ python
 ```
 
 ### Checking process status
+
+Because `send_keys()` doesn't wait, you find out whether a command is still running
+the same way a person would: by reading what's on screen. Capture the pane and look
+for a marker your command prints when it reaches a known state.
 
 ```python
 >>> import time
@@ -72,9 +106,15 @@ True
 >>> status_window.kill()
 ```
 
-## Output Monitoring
+## Output monitoring
 
 ### Waiting for specific output
+
+The workhorse of terminal automation is "run something, then block until a string
+shows up." You wrap {meth}`~libtmux.Pane.capture_pane` in a loop with a timeout, so a
+command that never finishes can't hang your script forever. The `poll_interval` is
+the latency/work trade in one knob: poll faster to react sooner, slower to spare tmux
+the round-trips.
 
 ```python
 >>> import time
@@ -101,6 +141,10 @@ True
 ```
 
 ### Detecting errors in output
+
+Waiting for success is only half the job — you also want to notice failure. The same
+capture-and-scan approach works for spotting error patterns, so you can bail out
+early instead of timing out on a command that already crashed.
 
 ```python
 >>> import time
@@ -129,6 +173,11 @@ True
 ```
 
 ### Capturing output between markers
+
+Sometimes you don't want the whole scrollback — you want just the lines a command
+produced. Bracket the interesting output with a marker you control, then return
+everything that follows it. This is how you pull a command's result out of a shared
+pane without dragging along the prompt and prior history.
 
 ```python
 >>> import time
@@ -167,9 +216,15 @@ True
 >>> capture_window.kill()
 ```
 
-## Multi-Pane Orchestration
+## Multi-pane orchestration
 
 ### Running parallel tasks
+
+To run work in parallel, give each task its own pane. You split the window with
+{meth}`~libtmux.Pane.split`, choosing where the new pane lands with
+{class}`~libtmux.constants.PaneDirection`, then fire a command into each. Because
+`send_keys()` returns immediately, the tasks run concurrently; you gather their
+results afterward by capturing every pane.
 
 ```python
 >>> import time
@@ -206,6 +261,11 @@ True
 
 ### Monitoring multiple panes for completion
 
+A fixed `sleep` only works when you know how long the slowest task takes. When tasks
+finish at different times, watch them all at once and drop each pane from the
+watch-list as its marker appears — you return as soon as the last one completes,
+instead of always waiting for a worst-case timeout.
+
 ```python
 >>> import time
 >>> from libtmux.constants import PaneDirection
@@ -241,9 +301,15 @@ True
 >>> multi_window.kill()
 ```
 
-## Context Manager Patterns
+## Context manager patterns
 
 ### Temporary session for isolated work
+
+Cleanup is the part of automation that's easy to forget — and forgetting leaves
+orphaned sessions and windows behind on the tmux server. A `with` block makes the
+cleanup automatic: the session lives for the body and is killed on the way out, even
+if an exception interrupts you. It costs a little to spin a session up and tear it
+down, but you get a guaranteed-clean slate that never leaks.
 
 ```python
 >>> # Create isolated session for a task
@@ -262,6 +328,10 @@ True
 
 ### Temporary window for subtask
 
+When you only need a scratch space for one subtask, scope a window the same way. The
+window opens for the body of the block and is gone afterward, so a short-lived job
+never outlives its purpose.
+
 ```python
 >>> import time
 
@@ -277,9 +347,14 @@ True
 True
 ```
 
-## Timeout Handling
+## Timeout handling
 
 ### Command with timeout
+
+Any command you wait on can hang, so give every wait an upper bound. Pair the command
+with a completion marker and poll until either the marker shows up or the clock runs
+out — and when it runs out, raise, so a stuck command surfaces as an error you can
+catch instead of a script that quietly stalls.
 
 ```python
 >>> import time
@@ -313,6 +388,11 @@ True
 
 ### Retry pattern
 
+For flaky work that succeeds on a later attempt, retry until a success marker
+appears. Be honest about the cost: each retry runs the command again and waits the
+full `delay`, so a slow `delay` times `max_retries` is the worst case you're signing
+up for. Tune both for how expensive the command is and how patient you can be.
+
 ```python
 >>> import time
 
@@ -342,9 +422,17 @@ True
 >>> retry_window.kill()
 ```
 
-## Agentic Workflow Patterns
+## Agentic workflow patterns
+
+The patterns so far drive one command at a time. The two below compose them into
+longer sequences that one pane runs end to end — reach for these when a task is
+genuinely a pipeline of steps, not a single call.
 
 ### Task queue processor
+
+A task queue runs a list of commands in order, waiting for each to finish before
+starting the next. You tag every task with an indexed marker so you know exactly
+which step you're waiting on, and you collect a pass/fail result per task.
 
 ```python
 >>> import time
@@ -379,6 +467,11 @@ True
 ```
 
 ### State machine runner
+
+When the next step depends on the previous one finishing, model the work as a state
+machine: each state runs a command and waits for the transition marker that unlocks
+the next. A per-state timeout keeps a single stuck step from stalling the whole run,
+and the history tells you how far you got before it stopped.
 
 ```python
 >>> import time
@@ -424,11 +517,13 @@ True
 >>> state_window.kill()
 ```
 
-## Best Practices
+## Best practices
 
 ### 1. Always use markers for completion detection
 
-Instead of relying on timing, use explicit markers:
+Timing is a guess; a marker is a fact. Instead of sleeping long enough and hoping a
+command finished, have it print an explicit marker and poll for that. Your automation
+then reacts to what actually happened rather than to a clock.
 
 ```python
 >>> bp_window = session.new_window(window_name='best-practice', attach=False)
@@ -448,7 +543,9 @@ True
 
 ### 2. Clean up resources
 
-Always clean up windows and sessions when done:
+Every window and session you create lives on the tmux server until something kills
+it. Tear down what you opened when you're done, so a long-running automation process
+doesn't accumulate orphaned objects.
 
 ```python
 >>> cleanup_window = session.new_window(window_name='cleanup-demo', attach=False)
@@ -465,6 +562,10 @@ True
 
 ### 3. Use context managers for automatic cleanup
 
+Better still, let a `with` block do the cleanup for you. It runs even when the body
+raises, which is exactly when manual cleanup tends to get skipped — so the resource
+is released whether the work succeeded or blew up.
+
 ```python
 >>> # Context managers ensure cleanup even on exceptions
 >>> with session.new_window(window_name='safe-work') as safe_window:
@@ -476,6 +577,6 @@ True
 :::{seealso}
 - {ref}`pane-interaction` for basic pane operations
 - {ref}`workspace-setup` for creating workspace layouts
-- {ref}`context-managers` for resource management patterns
+- {ref}`context_managers` for resource management patterns
 - {class}`~libtmux.Pane` for all pane methods
 :::

--- a/docs/topics/automation_patterns.md
+++ b/docs/topics/automation_patterns.md
@@ -12,9 +12,9 @@ makes that coordination ordinary Python — you start commands with
 pile of `send_keys()` calls into automation you can trust: output monitoring,
 timeouts, retries, and multi-pane orchestration.
 
-Most scripts only need the first two sections. Output monitoring and the context
-manager patterns cover the common case — send a command, wait for a marker, clean
-up after yourself — and you can stop reading there. The later sections (state
+Most scripts only need a couple of these patterns. Output monitoring and the
+context manager patterns cover the common case — send a command, wait for a
+marker, clean up after yourself — so start there. The later sections (state
 machines, task queues) are for the rarer cases where a single pane drives a longer
 sequence of steps; reach for them when you actually need them.
 
@@ -27,7 +27,7 @@ hooks or an external event-driven framework.
 
 Open two terminals:
 
-Terminal one: start tmux in a separate terminal:
+Terminal one: start tmux:
 
 ```console
 $ tmux

--- a/docs/topics/clients.md
+++ b/docs/topics/clients.md
@@ -57,7 +57,7 @@ session to its
 {attr}`~libtmux.Client.attached_pane` follows that window to its
 {attr}`~libtmux.window.Window.active_pane`. The three properties chain,
 so reading {attr}`~libtmux.Client.attached_pane` does one
-`list-clients` refresh plus two object lookups.
+`list-clients` refresh, then walks to the active window and its active pane.
 
 ```python
 >>> with control_mode() as ctl:

--- a/docs/topics/clients.md
+++ b/docs/topics/clients.md
@@ -14,14 +14,19 @@ It sits outside the
 ownership hierarchy: a client *points at* a Session/Window/Pane it is
 currently viewing, but is not owned by them.
 
+Most code reads a client's current attachment once and branches on it;
+the details about staleness and refresh below rarely matter in practice.
+
 ## View, not identity
 
-The fields that look like foreign keys — `client_session`, `session_id`,
-`window_id`, and `pane_id` — are snapshots of where the client was attached
-when libtmux read it. They go stale the instant the user runs
-`switch-client`, `select-window`, or `select-pane`. The client's *identity*
-is `client_name` (the tty path on Unix), which is stable for the lifetime of
-the attachment.
+You rarely need this detail unless you're tracking a client across
+several user commands, but it's worth understanding why certain fields
+go stale. The fields that look like foreign keys — `client_session`,
+`session_id`, `window_id`, and `pane_id` — are snapshots of where the
+client was attached when libtmux read it. They go stale the instant the
+user runs `switch-client`, `select-window`, or `select-pane`. The
+client's *identity* is `client_name` (the tty path on Unix), which is
+stable for the lifetime of the attachment.
 
 | Field | What it is | Stable? |
 |-------|------------|---------|
@@ -33,9 +38,10 @@ the attachment.
 ## Live attachment with `attached_*`
 
 When you want the *current* attachment — not the snapshot — use the
-three live properties. Each calls
-{meth}`~libtmux.Client.refresh` to re-read the client from
-`list-clients`, then resolves the typed Session/Window/Pane:
+three live properties. Each calls {meth}`~libtmux.Client.refresh` to
+query the current state (one tmux round-trip) and then resolves the
+typed Session/Window/Pane it's viewing. This costs a little — you're
+asking for the live state — but you get the current view in return:
 
 ```python
 >>> with control_mode() as ctl:
@@ -63,7 +69,8 @@ True
 
 ## Iterating attached clients
 
-{attr}`~libtmux.Server.clients` returns a
+If you need to find or filter clients, you iterate over or query the
+server's client collection. {attr}`~libtmux.Server.clients` returns a
 {class}`~libtmux._internal.query_list.QueryList` of every client tmux
 reports through `list-clients`. Filter or `get()` it the same way as
 {attr}`~libtmux.Server.sessions`:
@@ -79,14 +86,16 @@ reports through `list-clients`. Filter or `get()` it the same way as
 True
 ```
 
-There is no `search_clients()` method yet. Use
-`server.clients.filter(...)` for client filtering; see
-{ref}`native-filtering` for tmux-native filtering on sessions, windows, panes,
-and buffers.
+For filtering clients, use `server.clients.filter(...)` or iterate over
+{attr}`~libtmux.Server.clients` directly; see {ref}`native-filtering` if
+you want tmux's native format-based filtering on sessions, windows,
+panes, and buffers.
 
 ## When `attached_*` returns `None`
 
-The properties return `None` when:
+When a client detaches or its view becomes stale, the `attached_*`
+properties return `None` so you can branch on truthiness without a
+`try`/`except` block. This happens in three cases:
 
 - the snapshot `session_id` is empty (e.g. the client is at the tmux
   command prompt rather than viewing a session),
@@ -96,8 +105,7 @@ The properties return `None` when:
 
 Calling {meth}`~libtmux.Client.refresh` directly still raises
 {exc}`~libtmux.exc.TmuxObjectDoesNotExist` on a detached client; the
-`attached_*` properties catch that case and return `None` so callers
-can branch on truthiness without a `try`/`except`.
+`attached_*` properties catch that case and return `None` for you.
 
 ## See also
 

--- a/docs/topics/configuration.md
+++ b/docs/topics/configuration.md
@@ -1,17 +1,37 @@
 # Configuration
 
-## Environment Variables
+You configure libtmux entirely through Python. There are no config files
+and no environment variables that libtmux itself reads — you set
+everything through method calls on {class}`~libtmux.Server`,
+{class}`~libtmux.Session`, {class}`~libtmux.Window`, and
+{class}`~libtmux.Pane` objects, and the defaults are sensible. If you're
+driving tmux through the standard object API, you're already configured
+correctly and can stop reading here.
 
-libtmux itself does not read environment variables for configuration.
-All configuration is done programmatically through the Python API.
+The rest of this page is for the rarer cases. It documents two lower
+layers you can reach for when the defaults aren't enough: the tmux
+environment variables that decide which server you connect to, and the
+format-string system libtmux uses internally to read tmux state.
 
-The tmux server libtmux connects to may be influenced by standard tmux
-environment variables (`TMUX`, `TMUX_TMPDIR`).
+## Environment variables
 
-## Format Strings
+libtmux reads no environment variables of its own, so there's nothing to
+set here in normal use. What can still matter is the tmux *server* you
+connect to: the standard tmux variables `TMUX` (the address of an
+existing server) and `TMUX_TMPDIR` (where tmux keeps its socket) shape
+which server a fresh {class}`~libtmux.Server` finds. If you run several
+servers, or point tmux at a custom socket directory, those two variables
+decide which one you land on — otherwise you can ignore them.
 
-libtmux uses tmux's format system to query state. Format constants are
-defined in {mod}`libtmux.formats` and used internally by all object types.
+## Format strings
 
-See the [tmux man page](http://man.openbsd.org/OpenBSD-current/man1/tmux.1)
-for the full list of available formats.
+When you read a typed attribute like {attr}`~libtmux.Window.window_name`
+or `pane.pane_current_path`, libtmux is querying tmux behind the scenes
+through tmux's own format system. The format constants that drive those
+queries live in {mod}`libtmux.formats` and are used internally by every
+object type, so in normal use you never write format strings yourself —
+the typed attributes on each object hand you the values directly.
+
+For the rarer case where you want to know exactly which formats tmux
+exposes, see the [tmux man page](http://man.openbsd.org/OpenBSD-current/man1/tmux.1)
+for the full list.

--- a/docs/topics/configuration.md
+++ b/docs/topics/configuration.md
@@ -1,12 +1,11 @@
 # Configuration
 
-You configure libtmux entirely through Python. There are no config files
-and no environment variables that libtmux itself reads — you set
-everything through method calls on {class}`~libtmux.Server`,
+You configure libtmux through Python: there are no config files, and you
+set everything through method calls on {class}`~libtmux.Server`,
 {class}`~libtmux.Session`, {class}`~libtmux.Window`, and
-{class}`~libtmux.Pane` objects, and the defaults are sensible. If you're
-driving tmux through the standard object API, you're already configured
-correctly and can stop reading here.
+{class}`~libtmux.Pane` objects, with sensible defaults. If you're driving
+tmux through the standard object API, you're already configured correctly
+and can stop reading here.
 
 The rest of this page is for the rarer cases. It documents two lower
 layers you can reach for when the defaults aren't enough: the tmux
@@ -15,9 +14,13 @@ format-string system libtmux uses internally to read tmux state.
 
 ## Environment variables
 
-libtmux reads no environment variables of its own, so there's nothing to
-set here in normal use. What can still matter is the tmux *server* you
-connect to: the standard tmux variables `TMUX` (the address of an
+libtmux reads almost nothing from the environment, so in normal use
+there's nothing to set here. The one knob it does read is
+`LIBTMUX_TMUX_FORMAT_SEPARATOR`, an advanced override for the separator
+(default `␞`) libtmux uses internally to parse tmux's format output — you'd
+touch it only if that character ever collided with your own data. What more
+often matters is the tmux *server* you connect to: the standard tmux
+variables `TMUX` (the address of an
 existing server) and `TMUX_TMPDIR` (where tmux keeps its socket) shape
 which server a fresh {class}`~libtmux.Server` finds. If you run several
 servers, or point tmux at a custom socket directory, those two variables

--- a/docs/topics/context_managers.md
+++ b/docs/topics/context_managers.md
@@ -1,8 +1,19 @@
 (context_managers)=
 
-# Context Managers
+# Context managers
 
-libtmux provides context managers for all main tmux objects to ensure proper cleanup of resources. This is done through Python's `with` statement, which automatically handles cleanup when you're done with the tmux objects.
+When you create tmux objects through libtmux, they normally live until you
+explicitly kill them. A context manager hands that cleanup back to Python: you
+scope an object to a block, and libtmux kills the underlying tmux object the
+moment you leave it — whether you exit cleanly or an exception unwinds the
+stack. The {class}`~libtmux.Server`, {class}`~libtmux.Session`,
+{class}`~libtmux.Window`, and {class}`~libtmux.Pane` classes (all main tmux
+objects) support this.
+
+Most readers never reach for this. If you're building a long-running
+application, you typically let objects persist and tear them down yourself. The
+context-manager form earns its keep in test fixtures and short-lived scripts,
+where you want a tmux object to exist for exactly one block and then vanish.
 
 Open two terminals:
 
@@ -24,9 +35,9 @@ Import `libtmux`:
 import libtmux
 ```
 
-## Server Context Manager
+## Server context manager
 
-Create a temporary server that will be killed when you're done:
+You create a temporary server that will be killed when you're done:
 
 ```python
 >>> with Server() as server:
@@ -37,9 +48,9 @@ True
 False
 ```
 
-## Session Context Manager
+## Session context manager
 
-Create a temporary session that will be killed when you're done:
+You create a temporary session that will be killed when you're done:
 
 ```python
 >>> server = Server()
@@ -51,9 +62,9 @@ True
 False
 ```
 
-## Window Context Manager
+## Window context manager
 
-Create a temporary window that will be killed when you're done:
+You create a temporary window that will be killed when you're done:
 
 ```python
 >>> server = Server()
@@ -66,9 +77,9 @@ True
 False
 ```
 
-## Pane Context Manager
+## Pane context manager
 
-Create a temporary pane that will be killed when you're done:
+You create a temporary pane that will be killed when you're done:
 
 ```python
 >>> server = Server()
@@ -82,9 +93,10 @@ True
 False
 ```
 
-## Nested Context Managers
+## Nested context managers
 
-Context managers can be nested to create a clean hierarchy of tmux objects that are automatically cleaned up:
+For complex setups, you can nest contexts to build a whole tmux hierarchy at
+once and have every layer torn down for you:
 
 ```python
 >>> with Server() as server:
@@ -107,22 +119,20 @@ The cleanup happens in reverse order (pane → window → session → server), e
 
 ## Benefits
 
-Using context managers provides several advantages:
+Reaching for a context manager buys you a few things. Resources clean themselves
+up the moment you leave the block, so you never manually call the
+{meth}`~libtmux.Server.kill`, {meth}`~libtmux.Session.kill`,
+{meth}`~libtmux.Window.kill`, or {meth}`~libtmux.Pane.kill` methods and the code
+stays uncluttered. Because cleanup runs on the way out of the block, it fires
+even when an exception unwinds the stack — so you don't leak a stray session or
+pane on the error path. And when you nest contexts, the objects tear down in
+hierarchical order, which keeps tmux's own bookkeeping consistent.
 
-1. **Automatic Cleanup**: Resources are automatically cleaned up when you're done with them
-2. **Clean Code**: No need to manually call `kill()` methods
-3. **Exception Safety**: Resources are cleaned up even if an exception occurs
-4. **Hierarchical Cleanup**: Nested contexts ensure proper cleanup order
-5. **Resource Management**: Prevents resource leaks by ensuring tmux objects are properly destroyed
+## When to use
 
-## When to Use
-
-Context managers are particularly useful when:
-
-1. Creating temporary tmux objects for testing
-2. Running short-lived tmux sessions
-3. Managing multiple tmux servers
-4. Ensuring cleanup in scripts that may raise exceptions
-5. Creating isolated environments that need to be cleaned up afterward
+Use context managers when you're writing test fixtures, running short-lived
+sessions, or managing several tmux servers that each need to disappear cleanly.
+They also pay off in any script that might raise partway through, or when you're
+spinning up an isolated environment that has to be cleaned up afterward.
 
 [target]: http://man.openbsd.org/OpenBSD-5.9/man1/tmux.1#COMMANDS

--- a/docs/topics/design-decisions.md
+++ b/docs/topics/design-decisions.md
@@ -1,34 +1,75 @@
-# Design Decisions
+# Design decisions
 
-## Why ORM-Style Objects
+This page explains the "why" behind libtmux's shape: the four core choices it
+makes about representing tmux to your Python code. You don't need any of it to
+get started — the defaults work out of the box, and most code never thinks about
+the rationale below. Read on when a choice starts to matter to you: why
+{attr}`session.windows <libtmux.Session.windows>` is a live collection, why
+properties read cleanly off an object, and what to expect from a pre-1.0 API.
 
-tmux organizes terminals in a strict hierarchy: Server → Session → Window → Pane. Each level owns the next. libtmux mirrors this with Python objects that maintain the same parent-child relationships.
+## Why ORM-style objects
 
-The alternative — a flat command-builder API (`tmux("new-session", "-s", "foo")`) — loses the relational structure. You'd have to track which windows belong to which session manually. The ORM approach lets you write `session.windows` and get a live, filterable collection.
+Most of your code just writes {attr}`session.windows <libtmux.Session.windows>`
+and gets a live, filterable collection back — you rarely think about why it's
+shaped that way. This section is for when you're curious about the design.
 
-## Why Format Strings
+tmux organizes terminals in a strict hierarchy: Server → Session → Window →
+Pane. Each level owns the next. libtmux mirrors that hierarchy with Python
+objects — {class}`~libtmux.Server`, {class}`~libtmux.Session`,
+{class}`~libtmux.Window`, and {class}`~libtmux.Pane` — that maintain the same
+parent-child relationships, so navigating tmux feels like navigating Python.
 
-tmux exposes object properties through its format system (`-F` flags). For example, `tmux list-sessions -F '#{session_id}:#{session_name}'` returns structured data.
+What you get is a relational structure you can walk in either direction:
+`session.windows` lists a session's windows, `pane.window` points back up to the
+pane's parent. The alternative — a flat command-builder API
+(`tmux("new-session", "-s", "foo")`) — hands back raw strings and leaves you to
+track which windows belong to which session yourself.
 
-libtmux uses this instead of parsing human-readable `tmux ls` output because:
+The trade-off is that an object is a snapshot. If tmux state changes out from
+under you — another client splits a window, a process exits — your object can go
+stale, and you reach for {meth}`~libtmux.Session.refresh` to re-read it. You
+trade that occasional refresh for an API that reads like the hierarchy it
+models.
+
+## Why format strings
+
+tmux exposes object properties through its format system (`-F` flags). For
+example, `tmux list-sessions -F '#{session_id}:#{session_name}'` returns
+structured data.
+
+libtmux queries through this system instead of parsing human-readable `tmux ls`
+output because:
 
 - **Stability**: format variables are part of tmux's documented interface
 - **Precision**: no regex fragility from parsing prose output
 - **Completeness**: formats expose properties (like `session_id`) that don't appear in default output
 
-Format constants are defined in {mod}`libtmux.formats`.
+The cost is a tmux round-trip: reading a property runs a subprocess against the
+server rather than touching a cached Python attribute. What it buys is a value
+you can trust — pulled straight from tmux's own reporting, not reconstructed by
+guessing at the layout of display text. The format constants that make this work
+live in {mod}`libtmux.formats`.
 
-## Why Dataclasses in `neo.py`
+## Why dataclasses in `neo.py`
 
-{mod}`libtmux.neo` provides a modern dataclass-based interface alongside the legacy dict-style objects. The motivation:
+Advanced — for contributors and lower-level query work. Most code uses the ORM
+objects above and never touches this layer directly.
+
+{mod}`libtmux.neo` provides a modern dataclass-based interface alongside the
+legacy dict-style objects. The motivation:
 
 - **Type safety**: dataclass fields have declared types, enabling mypy checks and IDE completion
 - **Predictability**: attribute access (`session.session_name`) instead of dict access (`session["session_name"]`)
 - **Migration path**: the two interfaces coexist, allowing gradual adoption without breaking existing code
 
-## Pre-1.0 API Evolution
+Coexistence is the honest trade-off: two interfaces are more surface area to
+learn than one. The payoff is that you can adopt the typed path incrementally,
+file by file, without a flag-day rewrite.
 
-libtmux is pre-1.0. This is a deliberate choice — the API is still maturing. What this means in practice:
+## Pre-1.0 API evolution
+
+libtmux is pre-1.0. This is a deliberate choice — the API is still maturing.
+What this means in practice for code you write today:
 
 - **Minor versions** (0.x → 0.y) may include breaking changes
 - **Patch versions** (0.x.y → 0.x.z) are bug fixes only

--- a/docs/topics/design-decisions.md
+++ b/docs/topics/design-decisions.md
@@ -44,8 +44,10 @@ output because:
 - **Precision**: no regex fragility from parsing prose output
 - **Completeness**: formats expose properties (like `session_id`) that don't appear in default output
 
-The cost is a tmux round-trip: reading a property runs a subprocess against the
-server rather than touching a cached Python attribute. What it buys is a value
+The cost is a tmux round-trip on the live collections: reading a property like
+`session.windows` runs a subprocess against the server each time you access it,
+not a cached value (the scalar fields like `session.session_name` are different
+— read once when the object is built). What it buys is a value
 you can trust — pulled straight from tmux's own reporting, not reconstructed by
 guessing at the layout of display text. The format constants that make this work
 live in {mod}`libtmux.formats`.

--- a/docs/topics/filtering.md
+++ b/docs/topics/filtering.md
@@ -1,24 +1,35 @@
 (querylist-filtering)=
 
-# QueryList Filtering
+# QueryList filtering
 
-libtmux uses `QueryList` to enable Django-style filtering on tmux objects.
-Every collection (`server.sessions`, `session.windows`, `window.panes`) returns
-a `QueryList`, letting you filter sessions, windows, and panes with a fluent,
-chainable API.
+Every collection libtmux hands you — `server.sessions`, `session.windows`,
+`window.panes` — is a `QueryList`, a list that knows how to filter itself. You
+narrow one by calling {meth}`~libtmux._internal.query_list.QueryList.filter`
+with keyword arguments, optionally suffixed with a lookup like `__contains`,
+`__startswith`, or `__regex`, and you get back another `QueryList` you can
+iterate or chain further. It's Django-style filtering applied to sessions,
+windows, and panes.
 
-## Basic Filtering
+Most readers never look beyond `.filter()`. It's the common path, it works out
+of the box on every collection, and the lookup suffixes and chaining cover
+almost every query you'll write. The tmux-native `.search_*()` methods at the
+end of this page are an optional escape hatch for large servers — you can skip
+them until you measure a reason to care.
 
-The `filter()` method accepts keyword arguments with optional lookup suffixes:
+## Basic filtering
+
+Every collection is already a `QueryList`, so you can inspect one before you
+narrow it. Here's the full set of sessions on your server:
 
 ```python
 >>> server.sessions  # doctest: +ELLIPSIS
 [Session($... ...)]
 ```
 
-### Exact Match
+### Exact match
 
-The default lookup is `exact`:
+When you pass a bare keyword like `session_name=...`, the default lookup is
+`exact` — so these two calls mean the same thing:
 
 ```python
 >>> # These are equivalent
@@ -28,9 +39,10 @@ The default lookup is `exact`:
 [Session($... ...)]
 ```
 
-### Contains and Startswith
+### Contains and startswith
 
-Use suffixes for partial matching:
+Add a suffix to the keyword to match part of a value instead of the whole
+thing:
 
 ```python
 >>> # Create windows for this example
@@ -54,7 +66,10 @@ True
 >>> w3.kill()
 ```
 
-## Available Lookups
+## Available lookups
+
+Each suffix you append after the `__` selects one of these lookups. The
+`i`-prefixed variants ignore case:
 
 | Lookup | Description |
 |--------|-------------|
@@ -71,9 +86,10 @@ True
 | `regex` | Regular expression match |
 | `iregex` | Case-insensitive regex |
 
-## Getting a Single Item
+## Getting a single item
 
-Use `get()` to retrieve exactly one matching item:
+When you expect exactly one match and want the object itself rather than a
+list, reach for {meth}`~libtmux._internal.query_list.QueryList.get`:
 
 ```python
 >>> window = session.windows.get(window_id=session.active_window.window_id)
@@ -81,21 +97,24 @@ Use `get()` to retrieve exactly one matching item:
 Window(@... ..., Session($... ...))
 ```
 
-If no match or multiple matches are found, `get()` raises an exception:
+`get()` insists on exactly one result. If the query matches the wrong number of
+objects, it raises:
 
-- `ObjectDoesNotExist` - no matching object found
-- `MultipleObjectsReturned` - more than one object matches
+- {exc}`~libtmux._internal.query_list.ObjectDoesNotExist` - no matching object found
+- {exc}`~libtmux._internal.query_list.MultipleObjectsReturned` - more than one object matches
 
-You can provide a default value to avoid the exception:
+Pass a `default` to get a fallback value back instead of an exception:
 
 ```python
 >>> session.windows.get(window_name="nonexistent", default=None) is None
 True
 ```
 
-## Chaining Filters
+## Chaining filters
 
-Filters can be chained for complex queries:
+You can stack conditions two ways, and both narrow with AND. Pass several
+keywords to a single `.filter()` call, or chain `.filter()` calls one after
+another:
 
 ```python
 >>> # Create windows for this example
@@ -124,9 +143,9 @@ Filters can be chained for complex queries:
 >>> w3.kill()
 ```
 
-## Case-Insensitive Filtering
+## Case-insensitive filtering
 
-Use `i` prefix variants for case-insensitive matching:
+Reach for the `i`-prefixed variants when the casing of a name shouldn't matter:
 
 ```python
 >>> # Create windows with mixed case
@@ -147,9 +166,10 @@ True
 >>> w2.kill()
 ```
 
-## Regex Filtering
+## Regex filtering
 
-For complex patterns, use regex lookups:
+When a prefix or substring isn't expressive enough, the regex lookups match
+against a full pattern:
 
 ```python
 >>> # Create windows with version-like names
@@ -172,9 +192,10 @@ True
 >>> w3.kill()
 ```
 
-## Filtering by List Membership
+## Filtering by list membership
 
-Use `in` and `nin` (not in) for list-based filtering:
+When you already have a set of names in hand, `in` keeps the matches and `nin`
+(not in) drops them:
 
 ```python
 >>> # Create test windows
@@ -198,9 +219,14 @@ False
 >>> w3.kill()
 ```
 
-## Filtering Across the Hierarchy
+## Filtering across the hierarchy
 
-Filter at any level of the tmux hierarchy:
+You aren't limited to one window's panes. Every level of the hierarchy returns
+a `QueryList`, and the server-wide collections — `server.panes`,
+`server.windows`, `server.sessions` — flatten everything beneath them into a
+single list. That lets you query the whole server at once, which is handy when
+you want a pane by some attribute and don't care which session or window it
+lives in:
 
 ```python
 >>> # All panes across all windows in the server
@@ -213,9 +239,13 @@ Filter at any level of the tmux hierarchy:
 Pane(%... Window(@... ..., Session($... ...)))
 ```
 
-## Real-World Examples
+## Real-world examples
+
+A couple of patterns you'll reach for in practice.
 
 ### Find all editor windows
+
+Match several editor names at once with a single regex lookup:
 
 ```python
 >>> # Create sample windows
@@ -235,6 +265,9 @@ True
 ```
 
 ### Find windows by naming convention
+
+If you name windows by convention, a prefix match pulls the whole group, and
+`.get()` plucks one out by name:
 
 ```python
 >>> # Create windows following a naming convention
@@ -260,13 +293,16 @@ True
 
 (native-filtering)=
 
-## tmux-native Filtering with `search_*()`
+## tmux-native filtering with `search_*()`
 
-`QueryList.filter()` runs in Python *after* tmux has returned every
-row. For large servers, or when you only need a handful of matches,
-ask tmux to apply the filter before libtmux builds objects. Every level
-of the hierarchy ships a `search_*()` method that passes a format
-expression to tmux:
+Everything above runs in Python, *after* tmux has already returned every row.
+That's fine for the handful of sessions and windows most servers carry. But on
+a large server — hundreds or thousands of panes, where you want only a few —
+you pay to build objects you immediately discard.
+
+The `search_*()` methods push the filtering down to tmux itself: tmux applies a
+format expression and hands back only the matching rows, so libtmux builds
+objects for the matches alone. Every level of the hierarchy ships one:
 
 | Caller | Method | Underlying tmux |
 |--------|--------|-----------------|
@@ -374,7 +410,7 @@ Use `.filter()` when:
 - you're chaining multiple filters and prefer composing in Python,
 - you want predictable, version-independent semantics.
 
-## API Reference
+## API reference
 
 See {class}`~libtmux._internal.query_list.QueryList` for the complete
 QueryList API, and each `search_*()` method for the tmux-native filter

--- a/docs/topics/filtering.md
+++ b/docs/topics/filtering.md
@@ -331,7 +331,7 @@ fan-out.
 | Filter language | libtmux's lookup operators (`__contains`, `__regex`, etc.) | tmux's [FORMATS](https://man.openbsd.org/tmux.1#FORMATS) grammar |
 | Round trips | one (full list, then filter in memory) | one (tmux returns only matches) |
 | Best for | rich Python checks, set membership, post-fetch composition | exact/glob matches over many rows |
-| Stability | every libtmux version supports it | requires tmux ≥ 3.2 (≥ 3.4 for `list-clients -f`) |
+| Stability | every libtmux version supports it | requires tmux ≥ 3.2 |
 
 Both are valid; pick based on data volume and the filter language you want.
 

--- a/docs/topics/floating_panes.md
+++ b/docs/topics/floating_panes.md
@@ -1,6 +1,20 @@
 (floating-panes)=
 
-# Floating Panes
+# Floating panes
+
+You can create floating panes — non-modal panes that hover above the tiled
+layout like a popup, but with full escape-sequence support and all the regular
+pane operations (capture, send-keys, and so on). You create them with
+{meth}`Window.new_pane() <libtmux.Window.new_pane>` or
+{meth}`Pane.new_pane() <libtmux.Pane.new_pane>`, the same way you reach for
+{meth}`Window.split() <libtmux.Window.split>` to add a tiled pane.
+
+Most workflows never need one — tiled panes cover the everyday cases, and you
+can stop reading here unless you want a transient overlay (a quick log tail, a
+scratch shell, a status readout) sitting on top of your layout without
+rearranging it. Because a floating pane behaves like any other
+{class}`~libtmux.Pane`, everything you already do — capturing output, sending
+keys, querying state — works on it unchanged.
 
 ```{note}
 Floating panes require **tmux 3.7+**
@@ -9,18 +23,12 @@ Floating panes require **tmux 3.7+**
 {exc}`~libtmux.exc.LibTmuxException` on older tmux).
 ```
 
-tmux 3.7 introduced *floating panes* — panes that sit above the tiled layout
-like a popup, but unlike a popup are not modal and behave like ordinary panes
-(full escape-sequence support, capture, send-keys, and so on). libtmux exposes
-them through {meth}`Window.new_pane() <libtmux.Window.new_pane>` and
-{meth}`Pane.new_pane() <libtmux.Pane.new_pane>`, which wrap tmux's `new-pane`
-command.
-
 ## Creating a floating pane
 
-{meth}`Window.new_pane() <libtmux.Window.new_pane>` returns the new
-{class}`~libtmux.Pane`, just like {meth}`Window.split() <libtmux.Window.split>`.
-The returned pane reports `pane_floating_flag == "1"`:
+When you call {meth}`Window.new_pane() <libtmux.Window.new_pane>`, you get back
+the new {class}`~libtmux.Pane`, exactly as {meth}`Window.split()
+<libtmux.Window.split>` hands you a tiled one. You can confirm a pane is
+floating by reading its `pane_floating_flag`, which is `"1"` when it floats:
 
 ```python
 >>> from libtmux.common import has_gte_version
@@ -36,9 +44,10 @@ The returned pane reports `pane_floating_flag == "1"`:
 
 ## Sizing and positioning
 
-`width` and `height` set the pane's **size** (tmux's `-x` / `-y`); `x` and `y`
-set its **position** in cells from the top-left of the window (tmux's `-X` /
-`-Y`). The placement is reported back by the `pane_x` / `pane_y` fields:
+You set the pane's **size** with `width` and `height` (tmux's `-x` / `-y`), and
+its **position** with `x` and `y` — cells measured from the top-left of the
+window (tmux's `-X` / `-Y`). tmux reports the placement back through the
+`pane_x` / `pane_y` fields:
 
 ```python
 >>> from libtmux.common import has_gte_version
@@ -54,17 +63,23 @@ set its **position** in cells from the top-left of the window (tmux's `-X` /
 
 ## Styling
 
-Floating panes accept the same overlay styling as tmux's `new-pane`: `style`
-(the pane body), `active_border_style`, and `inactive_border_style`. Each takes
-a tmux style string, e.g. `style="bg=black"` or
-`active_border_style="fg=green"`.
+For the rarer cases where appearance matters, you can style a floating pane with
+the same overlay options tmux's `new-pane` accepts: `style` (the pane body),
+`active_border_style`, and `inactive_border_style`. Each takes a tmux style
+string, for example `style="bg=black"` or `active_border_style="fg=green"`. The
+defaults read fine on most terminals, so reach for these only when you want a
+float to stand out.
 
 ## Keeping a pane open
 
-By default a floating pane closes when its command exits. Pass `keep=True` to
-hold it open until a key is pressed (tmux's `-k`), or `message="..."` to hold
-it open showing a custom `remain-on-exit-format` line (tmux's `-m`); both set
-the pane's `remain-on-exit` option to `key`:
+By default a floating pane closes the moment its command exits — fine for a
+fire-and-forget command, but you lose whatever it printed. When you want the
+output to linger, pass `keep=True` to hold the pane open until you press a key
+(tmux's `-k`), or `message="..."` to hold it open showing a custom
+`remain-on-exit-format` line (tmux's `-m`). The cost is explicit and small:
+both flip the pane's `remain-on-exit` option to `key`, which buys you a pane
+that stays on screen and waits for you after the command finishes instead of
+vanishing:
 
 ```python
 >>> from libtmux.common import has_gte_version
@@ -80,9 +95,10 @@ the pane's `remain-on-exit` option to `key`:
 
 ## Identifying floating panes
 
-Every pane carries the tmux 3.7 `pane_floating_flag` field, so floating panes
-can be told apart from tiled panes anywhere a {class}`~libtmux.Pane` is
-available — including filtering a window's {attr}`~libtmux.Window.panes`:
+When you need to tell floating panes from tiled ones in code, reach for the
+tmux 3.7 `pane_floating_flag` field. Every {class}`~libtmux.Pane` carries it, so
+you can branch on it anywhere you hold a pane — including filtering a window's
+{attr}`~libtmux.Window.panes` down to just the floats:
 
 ```python
 >>> from libtmux.common import has_gte_version

--- a/docs/topics/format-tokens.md
+++ b/docs/topics/format-tokens.md
@@ -1,17 +1,22 @@
 (format-tokens)=
 
-# Format-Token Fields
+# Format-token fields
 
-Every libtmux object — {class}`~libtmux.Server`,
+When you work with a libtmux object — {class}`~libtmux.Server`,
 {class}`~libtmux.Session`, {class}`~libtmux.Window`,
-{class}`~libtmux.Pane`, {class}`~libtmux.Client` — exposes a flat set
-of typed string attributes named after tmux's
-[FORMATS](https://man.openbsd.org/tmux.1#FORMATS) tokens
-(`pane_id`, `window_zoomed_flag`, `client_theme`, etc.). This is why a
-single {class}`~libtmux.Pane` can expose `pane.pane_id`, `pane.window_id`,
-and `pane.session_id`.
+{class}`~libtmux.Pane`, or {class}`~libtmux.Client` — you get a flat set
+of typed string attributes that report the object's current state
+straight from tmux, mirroring tmux's built-in
+[FORMATS](https://man.openbsd.org/tmux.1#FORMATS) tokens (`pane_id`,
+`window_zoomed_flag`, `session_name`, etc.). This is why a single
+{class}`~libtmux.Pane` can hand you `pane.pane_id`, `pane.window_id`,
+and `pane.session_id` without you writing a raw tmux command.
 
-Two gates decide which fields actually hold a value on a given object:
+Most of the time you just read these attributes and move on. Not every
+field holds a value on every object, though: the object's type and your
+tmux version decide which fields are populated and which stay `None`.
+
+Which fields hold a value comes down to two gates:
 
 1. **Scope** — which kind of tmux object can provide the token. A `pane_*`
    token needs pane context, a `session_*` token needs session context, and
@@ -20,7 +25,9 @@ Two gates decide which fields actually hold a value on a given object:
    `format.c`'s static table.
 
 If either gate excludes a token, libtmux leaves the field at `None`
-rather than risking a server-side fault on an older tmux.
+rather than risking a server-side fault on an older tmux. You trade an
+occasional `None` check for attribute access that stays safe on every
+supported version.
 
 ## Why a field is `None`
 
@@ -49,11 +56,12 @@ Everything not listed above is safe on every supported tmux (≥ 3.2a).
 Fields for newer tmux tokens will be added as each supported version is
 validated.
 
-## Active Child Fields
+## Active child fields
 
-When tmux lists a parent object, it can also report fields from that parent's
-active child. That's why pane fields have meaningful values on a session row:
-they describe the active pane in the session's current window.
+Reach for `session.pane_id` and you get a real pane id back, not an
+error. When tmux lists a parent object, it also reports fields from that
+parent's active child — so the pane fields on a session row describe the
+active pane in the session's current window.
 
 ```python
 >>> session = server.new_session()
@@ -70,14 +78,17 @@ infer one attached client from a session row. The `client_*` tokens only
 appear on {class}`~libtmux.Client` rows returned by
 {attr}`~libtmux.Server.clients`.
 
-If you treat `session.pane_id` as "the session's pane id" (rather
-than "the active pane of the session's current window") you will be
-surprised when the active window changes.
+So read `session.pane_id` as "the active pane of the session's current
+window," not "the session's pane id." Treat it as the latter and the
+value will surprise you the moment the {attr}`~libtmux.Session.active_window`
+changes.
 
 ## Inspecting which fields apply
 
-Use {func}`libtmux.neo.get_output_format` to ask, for a given
-`list-*` subcommand and tmux version, which tokens libtmux will request:
+For the rarer cases — contributors, or code that introspects libtmux's
+own queries — you can ask, for a given `list-*` subcommand and tmux
+version, which tokens libtmux will request. Use
+{func}`libtmux.neo.get_output_format`:
 
 ```python
 >>> from libtmux.neo import get_output_format
@@ -102,9 +113,10 @@ True
 
 The result is cached per `(list_cmd, tmux_version)` pair.
 
-## Tmux version detection
+## tmux version detection
 
-libtmux detects the live tmux version via
+You never call this directly, but it's worth knowing how the version
+gate gets its answer. libtmux detects the live tmux version via
 {func}`libtmux.common.get_version` and passes it through to
 `get_output_format` whenever it builds a `-F` template. The result
 is cached for the process lifetime; if you're swapping the `tmux`

--- a/docs/topics/options_and_hooks.md
+++ b/docs/topics/options_and_hooks.md
@@ -1,14 +1,24 @@
 (options-and-hooks)=
 
-# Options and Hooks
+# Options and hooks
 
-libtmux provides a unified API for managing tmux options and hooks across all
-object types (Server, Session, Window, Pane).
+You shape how tmux sessions, windows, and panes behave by setting *options* —
+values like `automatic-rename` or the status-bar format — and by registering
+*hooks*, commands that tmux runs when an event fires, such as `session-renamed`
+or `after-split-window`. libtmux gives you one consistent Python API to read,
+set, and remove both, and it works the same way on every object in the
+hierarchy: {class}`~libtmux.Server`, {class}`~libtmux.Session`,
+{class}`~libtmux.Window`, and {class}`~libtmux.Pane`.
+
+Most scripts run happily on tmux's defaults and never open this page — reaching
+for options and hooks is entirely optional. Read on only when you need to tweak
+how a session behaves or react to something that happens inside it.
 
 ## Options
 
-tmux options control the behavior and appearance of sessions, windows, and
-panes. libtmux provides a consistent interface through
+Options are the knobs that control tmux's behavior and appearance, from whether
+a window renames itself to how the status line looks. Whatever object you hold,
+you read and change its options through the same four methods on
 {class}`~libtmux.options.OptionsMixin`.
 
 ### Getting options
@@ -29,7 +39,9 @@ Use {meth}`~libtmux.options.OptionsMixin.show_option` to get a single option:
 
 ### Setting options
 
-Use {meth}`~libtmux.options.OptionsMixin.set_option` to set an option:
+Use {meth}`~libtmux.options.OptionsMixin.set_option` to set an option. The call
+returns the object you set it on, so the change is live the moment it returns —
+no {meth}`~libtmux.window.Window.refresh` needed:
 
 ```python
 >>> window.set_option('automatic-rename', False)  # doctest: +ELLIPSIS
@@ -41,8 +53,9 @@ False
 
 ### Unsetting options
 
-Use {meth}`~libtmux.options.OptionsMixin.unset_option` to revert an option to
-its default:
+Once you've overridden an option, you put it back the way tmux shipped it. Use
+{meth}`~libtmux.options.OptionsMixin.unset_option` to revert an option to its
+default:
 
 ```python
 >>> window.unset_option('automatic-rename')  # doctest: +ELLIPSIS
@@ -51,7 +64,11 @@ Window(@... ...)
 
 ### Option scopes
 
-tmux options exist at different scopes. Use the `scope` parameter to specify:
+By default a call reads or writes the option for the object you're holding — a
+window's `set_option` touches that window. But tmux options live at distinct
+scopes (server, session, window, pane), and sometimes you want to reach a
+different level than the object in hand. Pass the `scope` parameter, drawn from
+{class}`~libtmux.constants.OptionScope`, to say which one:
 
 ```python
 >>> from libtmux.constants import OptionScope
@@ -63,7 +80,9 @@ tmux options exist at different scopes. Use the `scope` parameter to specify:
 
 ### Global options
 
-Use `global_=True` to work with global options:
+Each scope also has a global layer — the fallback tmux uses when an object
+hasn't set its own value. Reach it with `global_=True` when you want the
+server-wide default rather than what one session or window happens to override:
 
 ```python
 >>> server.show_option('buffer-limit', global_=True)
@@ -72,13 +91,17 @@ Use `global_=True` to work with global options:
 
 ## Hooks
 
-tmux hooks allow you to run commands when specific events occur. libtmux
-provides hook management through {class}`~libtmux.hooks.HooksMixin`.
+Hooks let you attach tmux commands to events, so something runs automatically
+whenever, say, a session is renamed or a window is split. You manage them
+through {class}`~libtmux.hooks.HooksMixin`, which mirrors the options API: set,
+show, and unset, on any object.
 
 ### Setting and getting hooks
 
 Use {meth}`~libtmux.hooks.HooksMixin.set_hook` to set a hook and
-{meth}`~libtmux.hooks.HooksMixin.show_hook` to get its value:
+{meth}`~libtmux.hooks.HooksMixin.show_hook` to read it back. The hook is
+registered with tmux the instant `set_hook` returns — there's no refresh step
+before it starts firing:
 
 ```python
 >>> session.set_hook('session-renamed', 'display-message "Session renamed"')  # doctest: +ELLIPSIS
@@ -91,8 +114,11 @@ Session(...)
 {...}
 ```
 
-Note that hooks are stored as indexed arrays in tmux, so `show_hook()` returns a
-{class}`~libtmux._internal.sparse_array.SparseArray` (dict-like) with index keys.
+A single hook reads back as a dict keyed by index rather than a bare string,
+because tmux stores hooks as arrays (more on that under indexed hooks,
+below). `show_hook()` returns a
+{class}`~libtmux._internal.sparse_array.SparseArray`, a dict-like type whose
+keys are those array indices.
 
 ### Removing hooks
 
@@ -105,8 +131,9 @@ Session(...)
 
 ### Indexed hooks
 
-tmux hooks support multiple values via indices (e.g., `session-renamed[0]`,
-`session-renamed[1]`). This allows multiple commands to run for the same event:
+A single event can fire more than one command. tmux models this by indexing
+each hook (`session-renamed[0]`, `session-renamed[1]`, …), so you register
+several commands against the same event and they all run:
 
 ```python
 >>> session.set_hook('after-split-window[0]', 'display-message "Split 0"')  # doctest: +ELLIPSIS
@@ -120,12 +147,19 @@ Session(...)
 [0, 1]
 ```
 
-The return value is a {class}`~libtmux._internal.sparse_array.SparseArray`,
-which preserves sparse indices (e.g., indices 0 and 5 with no 1-4).
+This is why a hook comes back as a dict-like object: the index *is* part of the
+data, and those indices can be sparse. If you set index 0 and index 5 but
+nothing in between, tmux keeps the gap, and so does the
+{class}`~libtmux._internal.sparse_array.SparseArray` you get back — its keys
+stay exactly the indices tmux holds (0 and 5, with no 1–4), rather than
+collapsing into a contiguous list.
 
 ### Bulk hook operations
 
-Use {meth}`~libtmux.hooks.HooksMixin.set_hooks` to set multiple indexed hooks:
+When you're setting several indices at once, you don't have to call
+{meth}`~libtmux.hooks.HooksMixin.set_hook` per index. Use
+{meth}`~libtmux.hooks.HooksMixin.set_hooks` to set multiple indexed hooks in one
+call, passing the index-to-command mapping directly:
 
 ```python
 >>> session.set_hooks('window-linked', {
@@ -146,6 +180,9 @@ Session(...)
 ```
 
 ## tmux version compatibility
+
+Options and hooks need a reasonably recent tmux, and a few specific hooks
+arrived later still. The floor for everything on this page is tmux 3.2:
 
 | Feature | Minimum tmux |
 |---------|-------------|

--- a/docs/topics/options_and_hooks.md
+++ b/docs/topics/options_and_hooks.md
@@ -41,7 +41,7 @@ Use {meth}`~libtmux.options.OptionsMixin.show_option` to get a single option:
 
 Use {meth}`~libtmux.options.OptionsMixin.set_option` to set an option. The call
 returns the object you set it on, so the change is live the moment it returns —
-no {meth}`~libtmux.window.Window.refresh` needed:
+no {meth}`~libtmux.Window.refresh` needed:
 
 ```python
 >>> window.set_option('automatic-rename', False)  # doctest: +ELLIPSIS

--- a/docs/topics/pane_interaction.md
+++ b/docs/topics/pane_interaction.md
@@ -422,7 +422,8 @@ Pane(%... Window(@... ..., Session($... ...)))
 ## Clearing the pane
 
 {meth}`~libtmux.Pane.clear` wipes the pane's visible screen, leaving a clean
-prompt — the programmatic equivalent of running `clear` in the shell:
+prompt — it runs `reset` in the pane, so it restores terminal state, not just
+the screen:
 
 ```python
 >>> pane.clear()  # doctest: +ELLIPSIS

--- a/docs/topics/pane_interaction.md
+++ b/docs/topics/pane_interaction.md
@@ -1,29 +1,39 @@
 (pane-interaction)=
 
-# Pane Interaction
+# Pane interaction
 
-libtmux provides powerful methods for interacting with tmux panes programmatically.
-This is especially useful for automation, testing, and orchestrating terminal-based
-workflows.
+A {class}`~libtmux.Pane` is a live terminal you drive from Python: you type into
+it, read back what it printed, resize it, and tear it down when you're finished.
+That makes the pane the unit you reach for when automating a shell, testing a
+CLI, or orchestrating a terminal workflow.
 
-Open two terminals:
+Most of that work is two methods — {meth}`~libtmux.Pane.send_keys` to type and
+{meth}`~libtmux.Pane.capture_pane` to read the screen back. If those two cover
+you, you can stop after the first two sections; everything below is for the
+rarer cases — waiting on output, querying a pane's state, resizing, and cleanup.
 
-Terminal one: start tmux in a separate terminal:
+To follow along live, open two terminals.
+
+In the first, start tmux:
 
 ```console
 $ tmux
 ```
 
-Terminal two, `python` or `ptpython` if you have it:
+In the second, start `python` (or `ptpython`, if you have it):
 
 ```console
 $ python
 ```
 
-## Sending Commands
+## Sending commands
 
-The {meth}`~libtmux.Pane.send_keys` method sends text to a pane, optionally pressing
-Enter to execute it.
+{meth}`~libtmux.Pane.send_keys` types text into the pane exactly as if you had
+typed it at the keyboard, and by default presses Enter so the shell runs it.
+That default is what you want most of the time: hand it a command string and it
+executes. The arguments below come into play only when you need to type without
+running, send characters tmux would otherwise interpret, or invoke send-keys
+purely for its flags.
 
 ### Basic command execution
 
@@ -41,7 +51,9 @@ True
 
 ### Send without pressing Enter
 
-Use `enter=False` to type text without executing:
+Sometimes you want the text sitting at the prompt without running it — to stage
+a command, or to feed a keystroke a running program is waiting on. Pass
+`enter=False` to type without pressing Enter:
 
 ```python
 >>> pane.send_keys('echo "waiting"', enter=False)
@@ -52,7 +64,8 @@ Use `enter=False` to type text without executing:
 True
 ```
 
-Press Enter separately with {meth}`~libtmux.Pane.enter`:
+When you're ready to run it, press Enter on its own with
+{meth}`~libtmux.Pane.enter`:
 
 ```python
 >>> import time
@@ -72,7 +85,9 @@ True
 
 ### Literal mode for special characters
 
-Use `literal=True` to send special characters without interpretation:
+Both tmux and your shell interpret certain characters. Pass `literal=True` to
+send them through untouched, so a tab or escape arrives as the literal byte
+rather than a key tmux acts on:
 
 ```python
 >>> import time
@@ -84,8 +99,9 @@ Use `literal=True` to send special characters without interpretation:
 
 ### Suppress shell history
 
-Use `suppress_history=True` to prepend a space (prevents command from being
-saved in shell history):
+Pass `suppress_history=True` to prepend a space before the command. In a shell
+configured to ignore space-prefixed lines, that keeps the command out of your
+history — useful when the command carries a secret:
 
 ```python
 >>> import time
@@ -97,8 +113,9 @@ saved in shell history):
 
 ### Flag-only invocation
 
-When you want to invoke `send-keys` only for its flags — resetting the
-pane or repeating a key — pass `cmd=None`:
+Sometimes you want send-keys only for its side effects — resetting the pane or
+repeating the last key — and have no text to type. Pass `cmd=None` to invoke it
+for the flags alone:
 
 ```python
 >>> # Repeat the last key 5 times (-N 5)
@@ -112,9 +129,13 @@ pane or repeating a key — pass `cmd=None`:
 `copy_mode_cmd=...`; calling it with no flag raises `ValueError` to
 prevent silent no-ops.
 
-## Capturing Output
+## Capturing output
 
-The {meth}`~libtmux.Pane.capture_pane` method captures text from a pane's buffer.
+{meth}`~libtmux.Pane.capture_pane` reads the pane's screen back to you as a list
+of lines — one string per row, top to bottom. With no arguments you get the
+visible screen, which is what most reads want. The parameters below extend that
+reach: into scrollback, keeping color, stitching wrapped lines, or preserving
+spacing. Reach for them only when a plain capture drops something you need.
 
 ### Basic capture
 
@@ -134,7 +155,9 @@ True
 
 ### Capture with line ranges
 
-Capture specific line ranges using `start` and `end` parameters:
+By default you read the visible screen. Pass `start` and `end` to widen or
+narrow that window — negative numbers count back from the visible region, and
+`'-'` reaches the start of history or the current line:
 
 ```python
 >>> # Capture last 5 lines of visible pane
@@ -150,7 +173,9 @@ True
 
 ### Capture with ANSI escape sequences
 
-Capture colored output with escape sequences preserved using `escape_sequences=True`:
+A plain capture strips color and formatting, handing you clean text. When you
+need the styling instead — to assert a prompt really printed in red — pass
+`escape_sequences=True` to keep the ANSI codes intact:
 
 ```python
 >>> import time
@@ -171,7 +196,9 @@ True
 
 ### Join wrapped lines
 
-Long lines that wrap in the terminal can be joined back together:
+A line longer than the pane wraps onto several rows, and a plain capture returns
+it as several strings. Pass `join_wrapped=True` to stitch those rows back into
+one logical line:
 
 ```python
 >>> import time
@@ -204,6 +231,8 @@ True
 
 ### Capture flags summary
 
+The full set of capture flags, and the tmux flag each one maps to:
+
 | Parameter | tmux Flag | Description |
 |-----------|-----------|-------------|
 | `escape_sequences` | `-e` | Include ANSI escape sequences (colors, attributes) |
@@ -220,10 +249,11 @@ a warning is issued and the flag is ignored.
 
 ### Capturing the pending input buffer
 
-Use `pending=True` to dump bytes tmux has buffered in its parser but
+For the rarer case where you need what tmux has read but not yet drawn, pass
+`pending=True`. It dumps bytes tmux has buffered in its parser but
 not yet committed to the pane's terminal — input the tmux process read
 from the pane's PTY but hasn't fed through its escape-sequence parser
-into the visible screen. Use to inspect partial control sequences
+into the visible screen. Use it to inspect partial control sequences
 mid-write.
 
 ```python
@@ -236,9 +266,17 @@ True
 flags (`start`, `end`, `escape_sequences`, etc.) — tmux ignores them when
 `-P` is set.
 
-## Waiting for Output
+## Waiting for output
 
-A common pattern in automation is waiting for a command to complete.
+tmux runs commands asynchronously: {meth}`~libtmux.Pane.send_keys` returns the
+moment the keystrokes are sent, not when the command finishes. So when a later
+step depends on a command completing, you wait for proof in the output rather
+than guessing at a fixed delay.
+
+The honest cost is that this means polling — capturing the pane on a short
+interval until a marker you control appears. It's a busy wait, not an event, but
+it's reliable across shells and commands because you're checking the one thing
+that matters: what actually printed.
 
 ### Polling for completion marker
 
@@ -260,6 +298,9 @@ True
 
 ### Helper function for waiting
 
+Wrapping that loop in a helper keeps the pattern out of the way of your actual
+logic:
+
 ```python
 >>> import time
 
@@ -278,9 +319,17 @@ True
 True
 ```
 
-## Querying Pane State
+## Querying pane state
 
-The {meth}`~libtmux.Pane.display_message` method queries tmux format variables.
+{meth}`~libtmux.Pane.display_message` asks tmux to evaluate a format string
+against the pane and hand back the result — its size, working directory, process
+id, and the rest of tmux's `#{pane_*}` variables. Pass `get_text=True` to get
+the answer as a list of strings.
+
+Each call is a round-trip to tmux, which is exactly what you want for state that
+moves as you watch it — dimensions during a resize, the working directory after
+a `cd` — since you get a fresh reading rather than a value cached when the object
+was built.
 
 ### Get pane dimensions
 
@@ -310,6 +359,8 @@ True
 
 ### Common format variables
 
+A few of the format variables you'll reach for most often:
+
 | Variable | Description |
 |----------|-------------|
 | `#{pane_width}` | Pane width in characters |
@@ -319,9 +370,13 @@ True
 | `#{pane_id}` | Unique pane ID (e.g., `%0`) |
 | `#{pane_index}` | Pane index in window |
 
-## Resizing Panes
+## Resizing panes
 
-The {meth}`~libtmux.Pane.resize` method adjusts pane dimensions.
+{meth}`~libtmux.Pane.resize` changes how much of the window a pane occupies. It
+covers three needs through one method: set an exact size, nudge a dimension by a
+relative amount, or toggle zoom to make the pane fill the window and back. The
+result is bounded by the window and the pane's neighbors — tmux grants the space
+it can, so treat a resize as a request, not a guarantee.
 
 ### Resize by specific dimensions
 
@@ -332,6 +387,9 @@ Pane(%... Window(@... ..., Session($... ...)))
 ```
 
 ### Resize by adjustment
+
+To grow or shrink a pane relative to its current size, name a direction from
+{class}`~libtmux.constants.ResizeAdjustmentDirection` and how far to move:
 
 ```python
 >>> from libtmux.constants import ResizeAdjustmentDirection
@@ -347,6 +405,10 @@ Pane(%... Window(@... ..., Session($... ...)))
 
 ### Zoom toggle
 
+Zoom blows a pane up to fill the whole window so you can focus on it, then
+restores the layout on the next call. It's a toggle, so the same call both
+zooms and unzooms:
+
 ```python
 >>> # Zoom pane to fill window
 >>> pane.resize(zoom=True)  # doctest: +ELLIPSIS
@@ -357,18 +419,21 @@ Pane(%... Window(@... ..., Session($... ...)))
 Pane(%... Window(@... ..., Session($... ...)))
 ```
 
-## Clearing the Pane
+## Clearing the pane
 
-The {meth}`~libtmux.Pane.clear` method clears the pane's screen:
+{meth}`~libtmux.Pane.clear` wipes the pane's visible screen, leaving a clean
+prompt — the programmatic equivalent of running `clear` in the shell:
 
 ```python
 >>> pane.clear()  # doctest: +ELLIPSIS
 Pane(%... Window(@... ..., Session($... ...)))
 ```
 
-## Killing Panes
+## Killing panes
 
-The {meth}`~libtmux.Pane.kill` method destroys a pane:
+{meth}`~libtmux.Pane.kill` destroys a pane and the process running inside it.
+Once killed, the pane is gone from its window, and any {class}`~libtmux.Pane`
+object still pointing at it is stale — drop the reference rather than reusing it.
 
 ```python
 >>> # Create a temporary pane
@@ -383,6 +448,10 @@ True
 ```
 
 ### Kill all except current
+
+Pass `all_except=True` to invert the target — kill every other pane in the
+window and keep this one. It's the quick way to collapse a window back to a
+single pane:
 
 ```python
 >>> # Setup: create multiple panes
@@ -407,9 +476,15 @@ True
 >>> keep_pane.kill()
 ```
 
-## Practical Recipes
+## Practical recipes
 
-### Recipe: Run command and capture output
+These tie the pieces together into the patterns you'll actually reach for:
+running a command and collecting its output, and scanning output for trouble.
+Lift them as-is or adapt them — both lean only on the
+{meth}`~libtmux.Pane.send_keys` and {meth}`~libtmux.Pane.capture_pane` methods
+you've already met.
+
+### Recipe: run command and capture output
 
 ```python
 >>> import time
@@ -431,7 +506,7 @@ True
 True
 ```
 
-### Recipe: Check for error patterns
+### Recipe: check for error patterns
 
 ```python
 >>> import time

--- a/docs/topics/public-vs-internal.md
+++ b/docs/topics/public-vs-internal.md
@@ -1,8 +1,11 @@
 # Public vs internal API
 
 You can import anything from the `libtmux` namespace and build on it: those
-names are public API, they hold still across releases, and they're covered by
-libtmux's {doc}`deprecation policy </project/public-api>`. Anything with a
+names are the public API — documented, and changed only through a deprecation
+process announced ahead of time. (libtmux is pre-1.0, so a minor version can
+still carry a breaking change; pin a version when you need to lock things
+down.) See the {doc}`public API reference </project/public-api>` for the
+stability policy. Anything with a
 leading underscore in its module path — `libtmux._internal.*`,
 `libtmux._vendor.*` — is implementation detail that can change without warning.
 If you only reach for the public API, that's the whole story, and you can stop
@@ -25,12 +28,14 @@ The authoritative list of what's stable lives in
 
 ## Why the split
 
-Staying on the public API buys you forward compatibility: when a public name has
-to change, it goes through a deprecation cycle first, so your code keeps working
-while you migrate. Reaching into an internal module buys you nothing the public
-API can promise — a refactor of `libtmux._internal.query_list` ships with no
-deprecation cycle, so an import that works today can break on the very next
-release. That freedom is the point: internal modules let the library iterate on
+Staying on the public API buys you a predictable migration path: when a public
+name changes, it goes through a deprecation process first — a warning for at
+least one release, documented in the changelog — rather than vanishing without
+notice. (libtmux is pre-1.0, so a minor version can still carry a breaking
+change; pin a version when you need to lock things down.) Reaching into an
+internal module buys you none of that — a refactor of
+`libtmux._internal.query_list` ships with no deprecation cycle, so an import
+that works today can break on the very next release. That freedom is the point: internal modules let the library iterate on
 implementation details without dragging downstream users through a migration for
 each one.
 
@@ -46,7 +51,7 @@ implementation details you never need to understand to use libtmux:
 - **`query_list`** — the filtering engine behind `.filter()` and `.get()` on collections
 - **`dataclasses`** — base dataclass utilities used by the ORM objects
 - **`constants`** — internal constants not meaningful to end users
-- **`types`** — type aliases used across the codebase
+- **`sparse_array`** — the sparse-index mapping behind indexed hooks and options
 
 These are documented in {ref}`internals` for contributors, but downstream
 projects should not import from them.

--- a/docs/topics/public-vs-internal.md
+++ b/docs/topics/public-vs-internal.md
@@ -1,8 +1,18 @@
-# Public vs Internal API
+# Public vs internal API
 
-## The Boundary
+You can import anything from the `libtmux` namespace and build on it: those
+names are public API, they hold still across releases, and they're covered by
+libtmux's {doc}`deprecation policy </project/public-api>`. Anything with a
+leading underscore in its module path — `libtmux._internal.*`,
+`libtmux._vendor.*` — is implementation detail that can change without warning.
+If you only reach for the public API, that's the whole story, and you can stop
+reading here.
 
-libtmux draws a clear line between public and internal code:
+## The boundary
+
+The rule is mechanical: if you can import a name without a leading underscore
+anywhere in its module path, it's public. The table maps each import prefix to
+exactly what you can count on.
 
 | Import path | Status | Stability |
 |-------------|--------|-----------|
@@ -10,39 +20,60 @@ libtmux draws a clear line between public and internal code:
 | `libtmux._internal.*` | Internal | No guarantee — may break between any release |
 | `libtmux._vendor.*` | Vendored | Not part of the API at all |
 
-If you can import it without a leading underscore in the module path, it's public.
+The authoritative list of what's stable lives in
+{doc}`Public API </project/public-api>`.
 
-## Why the Split
+## Why the split
 
-Internal modules exist so the library can iterate freely on implementation details without breaking downstream users. A refactor of `libtmux._internal.query_list` doesn't require a deprecation cycle — it's explicitly not part of the contract.
+Staying on the public API buys you forward compatibility: when a public name has
+to change, it goes through a deprecation cycle first, so your code keeps working
+while you migrate. Reaching into an internal module buys you nothing the public
+API can promise — a refactor of `libtmux._internal.query_list` ships with no
+deprecation cycle, so an import that works today can break on the very next
+release. That freedom is the point: internal modules let the library iterate on
+implementation details without dragging downstream users through a migration for
+each one.
 
-This separation also keeps the public API surface intentionally small. Every public module is a commitment to maintain. Internal modules earn promotion through proven stability and user demand.
+The same line keeps the public surface intentionally small. Every public module
+is a commitment to maintain, so internal modules earn promotion only through
+proven stability and real user demand.
 
-## What `_internal/` Contains
+## What `_internal/` contains
 
-The `_internal` package holds implementation details that support the public API:
+The `_internal/` package holds the machinery the public objects run on —
+implementation details you never need to understand to use libtmux:
 
 - **`query_list`** — the filtering engine behind `.filter()` and `.get()` on collections
 - **`dataclasses`** — base dataclass utilities used by the ORM objects
 - **`constants`** — internal constants not meaningful to end users
 - **`types`** — type aliases used across the codebase
 
-These are documented in [Internals](../internals/index.md) for contributors, but downstream projects should not import from them.
+These are documented in {ref}`internals` for contributors, but downstream
+projects should not import from them.
 
-## What `_vendor/` Contains
+## What `_vendor/` contains
 
-The `_vendor` package holds vendored third-party code — copies of external libraries included directly to avoid adding dependencies. This code is not written by the libtmux authors and is not part of the API.
+The `_vendor/` package holds vendored third-party code — copies of external
+libraries bundled directly so libtmux can avoid adding dependencies. You're not
+meant to import from it; it isn't written by the libtmux authors and isn't part
+of the API.
 
-## How Internal APIs Get Promoted
+## How internal APIs get promoted
+
+Most readers never need this section — it's for contributors and for anyone
+tempted to depend on an internal name. An API travels three stages on its way to
+the public contract:
 
 1. **Internal**: lives in `_internal/`, no stability promise
 2. **Experimental**: documented, usable, but explicitly marked as subject to change
 3. **Public**: moved to a top-level module, covered by the deprecation policy
 
-Promotion happens when an internal API proves stable across multiple releases and users request it. If you depend on an internal API, [file an issue](https://github.com/tmux-python/libtmux/issues) — that signal helps prioritize promotion.
+Promotion happens when an internal API proves stable across multiple releases and
+users ask for it. If you depend on an internal API, [file an
+issue](https://github.com/tmux-python/libtmux/issues) — that signal helps
+prioritize promotion.
 
-## Reference
-
-- [Public API](../project/public-api.md) — the authoritative list of what's stable
-- [Compatibility](../project/compatibility.md) — platform and version support
-- [Deprecations](../project/deprecations.md) — what's changing
+Once a name is public and later has to change, it doesn't vanish quietly; it
+moves through {doc}`a deprecation cycle </project/deprecations>` first. For the
+platforms and tmux versions that stability is promised against, see
+{doc}`Compatibility </project/compatibility>`.

--- a/docs/topics/traversal.md
+++ b/docs/topics/traversal.md
@@ -2,11 +2,23 @@
 
 # Traversal
 
-libtmux provides convenient access to move around the hierarchy of sessions,
-windows and panes in tmux.
+When you navigate a tmux server with libtmux, you move through a hierarchy of
+related objects: a {class}`~libtmux.Server` holds {class}`~libtmux.Session`
+objects, each session holds {class}`~libtmux.Window` objects, and each window
+holds {class}`~libtmux.Pane` objects. Every object knows both its parents and
+its children, so you can traverse in either direction — reach for
+`session.windows` to list the windows under a session, or `pane.session` to jump
+from a pane back up to the session that contains it.
 
-This is done by libtmux's object abstraction of {term}`target`s (the `-t`
-argument) and the permanent internal ID's tmux gives to objects.
+Most of the time you call a handful of properties like `session.windows` and
+`pane.session` and never look further. This works out of the box, with no setup.
+The filtering and relationship checks later on the page are there for the rarer
+cases where you need to find a specific object by name or pattern, or confirm
+how two objects relate.
+
+Under the hood this all rides on libtmux's object abstraction of {term}`target`s
+(the `-t` argument) and the permanent internal IDs tmux assigns to each object,
+but you rarely have to think about that layer to move around.
 
 Open two terminals:
 
@@ -30,9 +42,10 @@ First, create a test session:
 >>> session = server.new_session()  # Create a test session using existing server
 ```
 
-## Server Level
+## Server level
 
-View the server's representation:
+The {class}`~libtmux.Server` sits at the top of the hierarchy. Start by viewing
+its representation:
 
 ```python
 >>> server  # doctest: +ELLIPSIS
@@ -60,9 +73,15 @@ Get all panes across all windows:
 [Pane(%... Window(@... ..., Session($... ...)))]
 ```
 
-## Session Level
+Each of these properties queries tmux fresh every time you access it, so the
+result always reflects the server's current state. That freshness costs a tmux
+round-trip per access — worth it for correctness, but if you iterate over the
+same collection repeatedly, bind it to a variable once instead of re-reading the
+property inside a loop.
 
-Get first session:
+## Session level
+
+A {class}`~libtmux.Session` groups windows. Get the first one:
 
 ```python
 >>> session = server.sessions[0]
@@ -87,9 +106,9 @@ Window(@... ..., Session($... ...))
 Pane(%... Window(@... ..., Session($... ...)))
 ```
 
-## Window Level
+## Window level
 
-Get a window and inspect its properties:
+A {class}`~libtmux.Window` groups panes. Get one and inspect its properties:
 
 ```python
 >>> window = session.windows[0]
@@ -97,7 +116,7 @@ Get a window and inspect its properties:
 '...'
 ```
 
-Access the window's parent session:
+Traverse upward to the window's parent session:
 
 ```python
 >>> window.session  # doctest: +ELLIPSIS
@@ -120,9 +139,10 @@ Get active pane:
 Pane(%... Window(@... ..., Session($... ...)))
 ```
 
-## Pane Level
+## Pane level
 
-Get a pane and traverse upwards:
+A {class}`~libtmux.Pane` is the leaf of the hierarchy. From a pane you can walk
+all the way back up to its window, session, and server:
 
 ```python
 >>> pane = window.panes[0]
@@ -134,14 +154,23 @@ True
 True
 ```
 
-## Filtering and Finding Objects
+## Filtering and finding objects
 
-libtmux collections support Django-style filtering with `filter()` and `get()`.
-For comprehensive coverage of all lookup operators, see {ref}`querylist-filtering`.
-For tmux-native filters that return only matching rows on large servers, see
-{ref}`native-filtering`.
+Sometimes a property like `session.windows` hands you more objects than you
+want, and you need the one — or the few — matching a name, an index, or a
+pattern. Every libtmux collection lets you narrow it down: call
+{meth}`~libtmux._internal.query_list.QueryList.filter` to keep the objects that
+match a condition, or {meth}`~libtmux._internal.query_list.QueryList.get` to
+pull out a single object (it raises if it finds zero or more than one). You match
+on the same attributes the objects already expose — `window_name`,
+`window_index`, `pane_id`, and so on.
 
-### Basic Filtering
+This is the opt-in part of the page. If the plain properties above already get
+you to the object you want, you can stop here. For comprehensive coverage of all
+lookup operators, see {ref}`querylist-filtering`. For tmux-native filters that
+return only matching rows on large servers, see {ref}`native-filtering`.
+
+### Basic filtering
 
 Find windows by exact attribute match:
 
@@ -157,7 +186,7 @@ Get a specific pane by ID:
 Pane(%... Window(@... ..., Session($... ...)))
 ```
 
-### Partial Matching
+### Partial matching
 
 Use lookup suffixes like `__contains`, `__startswith`, `__endswith`:
 
@@ -181,7 +210,7 @@ Use lookup suffixes like `__contains`, `__startswith`, `__endswith`:
 >>> w3.kill()
 ```
 
-### Case-Insensitive Matching
+### Case-insensitive matching
 
 Prefix any lookup with `i` for case-insensitive matching:
 
@@ -199,7 +228,7 @@ Prefix any lookup with `i` for case-insensitive matching:
 >>> w2.kill()
 ```
 
-### Regex Filtering
+### Regex filtering
 
 For complex patterns, use `__regex` or `__iregex`:
 
@@ -219,7 +248,7 @@ For complex patterns, use `__regex` or `__iregex`:
 >>> w3.kill()
 ```
 
-### Chaining Filters
+### Chaining filters
 
 Multiple conditions can be combined:
 
@@ -250,7 +279,7 @@ Multiple conditions can be combined:
 >>> w3.kill()
 ```
 
-### Get with Default
+### Get with default
 
 Avoid exceptions when an object might not exist:
 
@@ -260,9 +289,11 @@ Avoid exceptions when an object might not exist:
 True
 ```
 
-## Checking Relationships
+## Checking relationships
 
-Check if objects are related:
+Two questions come up often: does an object belong to a collection (membership),
+and do two handles point at the same tmux entity (identity)? Python's `in`
+operator answers the first — whether an object is part of a collection:
 
 ```python
 >>> window in session.windows
@@ -273,14 +304,15 @@ True
 True
 ```
 
-Check if a window is active:
+Comparing IDs answers the second — here, whether the window you hold is the
+session's active window:
 
 ```python
 >>> window.window_id == session.active_window.window_id
 True
 ```
 
-Check if a pane is active:
+And whether the pane you hold is the window's active pane:
 
 ```python
 >>> pane.pane_id == window.active_pane.pane_id

--- a/docs/topics/workspace_setup.md
+++ b/docs/topics/workspace_setup.md
@@ -1,30 +1,46 @@
 (workspace-setup)=
 
-# Workspace Setup
+# Workspace setup
 
-libtmux makes it easy to create and configure multi-pane workspaces programmatically.
-This is useful for setting up development environments, running parallel tasks,
-and orchestrating terminal-based workflows.
+A workspace is a single window carved into panes, each running its own
+program: an editor in one, a dev server in another, a log tail in a third.
+With libtmux you build that layout from Python instead of arranging it by
+hand — you open a window, split it into panes, arrange them with a layout,
+and send commands into each.
 
-Open two terminals:
+You will reach for four methods more than any others:
+{meth}`~libtmux.Session.new_window` to open a window,
+{meth}`~libtmux.Window.split` to carve it into panes,
+{meth}`~libtmux.Window.select_layout` to arrange them, and
+{meth}`~libtmux.Pane.send_keys` to drive a command into one. The defaults
+are sensible, so most of what you build needs nothing more — the recipes
+near the end are ready-made patterns you can copy whole and adapt.
 
-Terminal one: start tmux in a separate terminal:
+To follow along you need two terminals: one running a live tmux server, one
+running a Python prompt to drive it.
+
+In the first terminal, start tmux:
 
 ```console
 $ tmux
 ```
 
-Terminal two, `python` or `ptpython` if you have it:
+In the second, start Python (`ptpython` if you have it):
 
 ```console
 $ python
 ```
 
-## Creating Windows
+## Creating windows
 
-The {meth}`~libtmux.Session.new_window` method creates new windows within a session.
+Every workspace begins with a window. {meth}`~libtmux.Session.new_window`
+opens one inside a session and hands you back a {class}`~libtmux.Window` you
+can split, rename, and fill with panes.
 
 ### Basic window creation
+
+By default the new window becomes the active one, and it joins the session's
+window list right away:
 
 ```python
 >>> new_window = session.new_window(window_name='workspace')
@@ -38,7 +54,10 @@ True
 
 ### Create without attaching
 
-Use `attach=False` to create a window in the background:
+When you are assembling a workspace you usually don't want focus to jump to
+each window as it appears. Build it in the background instead, then switch to
+it once everything is in place. You trade the immediate view for a
+flicker-free build:
 
 ```python
 >>> background_window = session.new_window(
@@ -54,6 +73,10 @@ Window(@... ...:background-task, Session($... ...))
 
 ### Create with specific shell
 
+You can also choose what runs inside the window instead of the default shell
+— handy when a pane should boot straight into a REPL, a server, or a one-off
+script:
+
 ```python
 >>> shell_window = session.new_window(
 ...     window_name='shell-test',
@@ -67,11 +90,19 @@ Window(@... ...:shell-test, Session($... ...))
 >>> shell_window.kill()
 ```
 
-## Splitting Panes
+## Splitting panes
 
-The {meth}`~libtmux.Window.split` method divides windows into multiple panes.
+A window with one pane is just a terminal. Splitting is what turns it into a
+workspace: {meth}`~libtmux.Window.split` (or the same method on a specific
+{meth}`~libtmux.Pane.split`) divides the available space and returns the new
+{class}`~libtmux.Pane`. Each split and {meth}`~libtmux.Window.resize` is a
+round-trip to the tmux server; the resize calls below buy a window large
+enough that the splits have room to land on a small terminal.
 
 ### Vertical split (top/bottom)
+
+Splitting top-and-bottom is the default — the new pane opens below the one
+you split:
 
 ```python
 >>> import time
@@ -97,6 +128,10 @@ Pane(%... Window(@... ..., Session($... ...)))
 
 ### Horizontal split (left/right)
 
+Pass a direction to split side-by-side instead.
+{class}`~libtmux.constants.PaneDirection` names where the new pane goes —
+here, to the right of the one you split:
+
 ```python
 >>> from libtmux.constants import PaneDirection
 
@@ -119,6 +154,9 @@ Pane(%... Window(@... ..., Session($... ...)))
 
 ### Split with specific size
 
+By default tmux halves the space. Ask for a specific share — a percentage or
+a cell count — when one pane should be smaller than the rest:
+
 ```python
 >>> # Create a fresh window for size demo
 >>> size_window = session.new_window(window_name='size-demo', attach=False)
@@ -135,9 +173,11 @@ Pane(%... Window(@... ..., Session($... ...)))
 >>> size_window.kill()
 ```
 
-## Layout Management
+## Layout management
 
-The {meth}`~libtmux.Window.select_layout` method arranges panes using built-in layouts.
+Once a window holds several panes, a layout decides how they share the
+screen. {meth}`~libtmux.Window.select_layout` applies one of tmux's built-in
+arrangements so you don't have to size each pane by hand.
 
 ### Available layouts
 
@@ -152,6 +192,10 @@ tmux provides five built-in layouts:
 | `tiled` | Panes spread evenly in rows and columns |
 
 ### Applying layouts
+
+Pass a layout name and tmux re-tiles every pane in the window. You can switch
+layouts as often as you like — the panes and their contents stay put, only
+their geometry changes:
 
 ```python
 >>> # Create window with multiple panes
@@ -180,9 +224,12 @@ Window(@... ...)
 >>> layout_window.kill()
 ```
 
-## Renaming and Organizing
+## Renaming and organizing
 
 ### Rename windows
+
+A window's name is how you find it later, so give each one a label that says
+what it's for. {meth}`~libtmux.Window.rename_window` updates it in place:
 
 ```python
 >>> rename_window = session.new_window(window_name='old-name', attach=False)
@@ -197,6 +244,11 @@ Window(@... ...:new-name, Session($... ...))
 ```
 
 ### Access window properties
+
+A {class}`~libtmux.Window` object reflects tmux's state at the moment you ask:
+its index in the session, its stable id, and the {class}`~libtmux.Session` it
+belongs to are all available as attributes. If something changes the window
+externally, read the attribute again for the current value:
 
 ```python
 >>> demo_window = session.new_window(window_name='props-demo', attach=False)
@@ -217,9 +269,17 @@ Session($... ...)
 >>> demo_window.kill()
 ```
 
-## Practical Recipes
+## Practical recipes
 
-### Recipe: Create a development workspace
+The methods above are enough to build any workspace. The recipes below stitch
+them into patterns worth keeping — lift one and adapt it, or read them as
+worked examples of how the pieces fit together.
+
+### Recipe: create a development workspace
+
+A common shape: one large editing pane, a smaller terminal beneath it, and a
+log pane beside the terminal. This helper wires that up and returns the panes
+keyed by role, so the caller can drive each one by name:
 
 ```python
 >>> import time
@@ -254,7 +314,11 @@ Session($... ...)
 >>> workspace['window'].kill()
 ```
 
-### Recipe: Create a grid of panes
+### Recipe: create a grid of panes
+
+Need a uniform grid — four panes, nine, sixteen — for watching parallel jobs?
+Split a row across, repeat down the rows, then let the `tiled`
+{meth}`~libtmux.Window.select_layout` even everything out:
 
 ```python
 >>> from libtmux.constants import PaneDirection
@@ -295,7 +359,13 @@ True
 >>> grid_window.kill()
 ```
 
-### Recipe: Run commands in multiple panes
+### Recipe: run commands in multiple panes
+
+Sending keys is how you put work into a pane.
+{meth}`~libtmux.Pane.send_keys` returns as soon as the keystrokes are
+delivered — the command itself runs asynchronously — so when you need to read
+its output back with {meth}`~libtmux.Pane.capture_pane`, give it a beat to
+finish first:
 
 ```python
 >>> import time
@@ -329,9 +399,12 @@ True
 >>> multi_window.kill()
 ```
 
-## Window Context Managers
+## Window context managers
 
-Windows can be used as context managers for automatic cleanup:
+When a window is only meant to live for the span of a task — a test run, a
+quick capture — let a `with` block own it. The window is created on entry and
+killed on exit, so you never leak a stray window even if something raises
+midway through:
 
 ```python
 >>> with session.new_window(window_name='temp-window') as temp_win:

--- a/docs/topics/workspace_setup.md
+++ b/docs/topics/workspace_setup.md
@@ -39,8 +39,10 @@ can split, rename, and fill with panes.
 
 ### Basic window creation
 
-By default the new window becomes the active one, and it joins the session's
-window list right away:
+Hand {meth}`~libtmux.Session.new_window` a name and you get a
+{class}`~libtmux.Window` back, added to the session's window list. By
+default the window is created in the background — it doesn't pull your
+focus from the window you're already on:
 
 ```python
 >>> new_window = session.new_window(window_name='workspace')
@@ -54,10 +56,10 @@ True
 
 ### Create without attaching
 
-When you are assembling a workspace you usually don't want focus to jump to
-each window as it appears. Build it in the background instead, then switch to
-it once everything is in place. You trade the immediate view for a
-flicker-free build:
+Because `attach=False` is the default, the windows you build stay in the
+background while you assemble a workspace — focus never jumps to each one as
+it appears. Pass it explicitly when you want that intent on the page, and
+reach for `attach=True` only when a window should take focus as it's created:
 
 ```python
 >>> background_window = session.new_window(
@@ -247,8 +249,10 @@ Window(@... ...:new-name, Session($... ...))
 
 A {class}`~libtmux.Window` object reflects tmux's state at the moment you ask:
 its index in the session, its stable id, and the {class}`~libtmux.Session` it
-belongs to are all available as attributes. If something changes the window
-externally, read the attribute again for the current value:
+belongs to are all available as attributes. libtmux reads them once when it
+builds the object, so if something changes the window externally, call
+{meth}`~libtmux.Window.refresh` to re-fetch from tmux before you read them
+again:
 
 ```python
 >>> demo_window = session.new_window(window_name='props-demo', attach=False)


### PR DESCRIPTION
The topics documentation now leads with the concept — what each object
or method is and does for the reader — before its API surface, with
reassurances that let a reader stop early and honest trade-offs where a
call costs something. A new docs-scoped voice guide codifies that voice
so future pages stay consistent.

- **Documentation voice guide**: docs/AGENTS.md describes the prose
  voice for docs/ — a Python-writing reader, concept before API
  surface, executable doctest examples, and MyST cross-references —
  complementing the repository-root AGENTS.md. docs/CLAUDE.md symlinks
  to it, and both are excluded from the Sphinx build so neither becomes
  an orphan page.
- **Concept-first topic pages**: every page under docs/topics now opens
  with the idea before the signature, marks advanced and lower-level
  material opt-in, names trade-offs (tmux round-trips, stale objects
  needing refresh(), polling waits), and links classes and methods at
  the point of curiosity. docs/topics/pane_interaction.md is the worked
  example the guide points to.
- **Accuracy pass**: corrected prose to match the library — new_window()
  creates a window in the background by default, clear() runs reset,
  libtmux does read LIBTMUX_TMUX_FORMAT_SEPARATOR, the public API's
  pre-1.0 stability story is stated honestly, and references to base
  classes removed in 0.17 are gone.
- **Examples left runnable**: the sweep reshaped prose, headings, and
  cross-references only; every doctest code block stayed byte-identical,
  so the page examples still execute under pytest and the docs build
  stays clean.
