### PR TITLE
Fix window-name test for tmux 3.7a/3.7b and add them to CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.14']
-        tmux-version: ['3.2a', '3.3a', '3.4', '3.5', '3.6', '3.7', 'master']
+        tmux-version: ['3.2a', '3.3a', '3.4', '3.5', '3.6', '3.7a', '3.7b', 'master']
     steps:
       - uses: actions/checkout@v6
 

--- a/CHANGES
+++ b/CHANGES
@@ -45,6 +45,15 @@ $ uvx --from 'libtmux' --prerelease allow python
 _Notes on the upcoming release will go here._
 <!-- END PLACEHOLDER - ADD NEW CHANGELOG ENTRIES BELOW THIS LINE -->
 
+### Development
+
+#### tmux 3.7a/3.7b test compatibility (#698)
+
+libtmux's test suite now passes against tmux 3.7a and 3.7b, which CI also
+exercises. A window-name test had assumed the `:`/`.` rejection tmux
+introduced in 3.7, but tmux reverted it in 3.7a as "overly pernickety" — so
+the test now checks these names are accepted.
+
 ## libtmux 0.60.0 (2026-06-28)
 
 libtmux 0.60.0 completes tmux 3.7 feature parity. Building on the 3.7

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -257,46 +257,44 @@ def test_window_rename(
     assert window.window_name == window_name_after
 
 
-class WindowNameValidationFixture(t.NamedTuple):
-    """Test fixture for tmux 3.7 window-name validation."""
+class WindowNameSpecialCharFixture(t.NamedTuple):
+    """Test fixture for ':'/'.' window names across tmux versions."""
 
     test_id: str
     window_name: str
 
 
-# tmux 3.7+ rejects ':' and '.' in window names server-side; tmux 3.2a-3.6
-# accept them. See https://github.com/tmux/tmux/issues/4999.
-WINDOW_NAME_INVALID_ON_3_7_FIXTURES: list[WindowNameValidationFixture] = [
-    WindowNameValidationFixture(test_id="colon", window_name="project:frontend"),
-    WindowNameValidationFixture(test_id="period", window_name="app-v1.0"),
+# The tmux 3.7 point release briefly rejected ':' and '.' in window names,
+# then reverted it in 3.7a as "overly pernickety" (tmux commit 166267c8).
+# Every tmux libtmux supports -- 3.2a-3.6 and 3.7a onward -- accepts them.
+WINDOW_NAME_SPECIAL_CHAR_FIXTURES: list[WindowNameSpecialCharFixture] = [
+    WindowNameSpecialCharFixture(test_id="colon", window_name="project:frontend"),
+    WindowNameSpecialCharFixture(test_id="period", window_name="app-v1.0"),
 ]
 
 
 @pytest.mark.parametrize(
-    list(WindowNameValidationFixture._fields),
-    WINDOW_NAME_INVALID_ON_3_7_FIXTURES,
-    ids=[tc.test_id for tc in WINDOW_NAME_INVALID_ON_3_7_FIXTURES],
+    list(WindowNameSpecialCharFixture._fields),
+    WINDOW_NAME_SPECIAL_CHAR_FIXTURES,
+    ids=[tc.test_id for tc in WINDOW_NAME_SPECIAL_CHAR_FIXTURES],
 )
-def test_new_window_name_invalid_on_3_7(
+def test_new_window_name_colon_period_accepted(
     session: Session,
     test_id: str,
     window_name: str,
 ) -> None:
-    """Tmux 3.7+ rejects ':'/'.' in window names; older tmux accepts them.
+    """Window names with ':' and '.' are accepted verbatim.
 
-    The rejection is enforced by tmux itself (no client-side validation),
-    so it surfaces as a :class:`~libtmux.exc.LibTmuxException`. On tmux
-    3.2a-3.6 the same names are accepted verbatim.
+    The lone tmux 3.7 point release briefly rejected these characters before
+    3.7a reverted the restriction (tmux commit 166267c8, "overly
+    pernickety"). libtmux's version helpers strip the letter suffix, so
+    :func:`~libtmux.common.get_version` cannot tell 3.7 from 3.7a -- both
+    report ``3.7`` -- so CI exercises 3.7a/3.7b rather than the superseded
+    3.7 release.
     """
-    from libtmux.common import has_gte_version
-
-    if has_gte_version("3.7"):
-        with pytest.raises(exc.LibTmuxException, match="invalid window name"):
-            session.new_window(window_name=window_name)
-    else:
-        window = session.new_window(window_name=window_name)
-        assert window.window_name == window_name
-        window.kill()
+    window = session.new_window(window_name=window_name)
+    assert window.window_name == window_name
+    window.kill()
 
 
 def test_kill_window(session: Session) -> None:


### PR DESCRIPTION
## Summary

- **Fix** the window-name test to assert that `:` and `.` in window names are **accepted**. The old test expected tmux to *reject* them, which only the tmux **3.7** point release ever did — so it fails on tmux **3.7a**/**3.7b**.
- **Add** tmux **3.7a** and **3.7b** to the CI matrix so the grid exercises the 3.7 line's shipped patch releases.
- **Drop** the superseded tmux **3.7** from the matrix — it is the lone release that rejects `:`/`.`, which a pure acceptance assertion can't accommodate.

## Root cause

tmux's window-name sanitization changed around the 3.7 release:

| tmux version | `:` / `.` in window names |
|---|---|
| 3.2a – 3.6 | accepted |
| **3.7** (point release) | **rejected** (`invalid window name`) |
| 3.7a, 3.7b, master | accepted again |

The rejection was introduced just before 3.7 and reverted in 3.7a — upstream tmux commit [`166267c8`](https://github.com/tmux/tmux/commit/166267c8), *"Allow :. in names again, forbidding them is overly pernickety."* So it existed in exactly one release. Verified empirically on tmux 3.7b: `project:frontend` and `app-v1.0` are accepted.

The test gated on `has_gte_version("3.7")`, expecting rejection for all `>= 3.7`. But libtmux's `get_version()` strips letter suffixes (`re.sub(r"[a-z-]", "", version)`), so **3.7, 3.7a, and 3.7b all compare equal to `3.7`**. libtmux cannot distinguish the point release from its patches, so on 3.7a/3.7b the test took the reject-expecting branch and failed with `DID NOT RAISE`.

## Design decisions

- **Assert acceptance, not rejection.** `:`/`.` names work on every tmux libtmux supports except the single superseded 3.7 release. Since `get_version()` can't detect literal 3.7 anyway, an unconditional acceptance assertion is both correct and the most the version API can express.
- **Represent the 3.7 line by 3.7a/3.7b, not 3.7.** A pure acceptance test only stays green if no grid version rejects the names. 3.7a/3.7b are the patch releases users actually run (3.7 was superseded within days) and exercise the same 3.7-family gates (`has_gte_version("3.7")`, `has_version("3.7")`) identically.

## Test plan

- [x] New `test_new_window_name_colon_period_accepted[colon]`/`[period]` pass on local tmux 3.7b
- [x] Full suite green locally (`uv run pytest --reruns 0`) — the only failures were pre-existing capture/timing flakes that pass when re-run serially
- [x] `uv run ruff check .` and `ruff format . --check` clean; `uv run mypy src tests` clean; `just build-docs` succeeds
- [x] CI grid exercises the new tmux 3.7a and 3.7b cells