### PR TITLE
Fix break_pane forcing 'libtmux' window name on tmux 3.7a/3.7b

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -45,6 +45,16 @@ $ uvx --from 'libtmux' --prerelease allow python
 _Notes on the upcoming release will go here._
 <!-- END PLACEHOLDER - ADD NEW CHANGELOG ENTRIES BELOW THIS LINE -->
 
+### What's new
+
+#### New helper: `get_version_str()` (#699)
+
+{func}`libtmux.common.get_version_str` returns the running tmux version
+verbatim, keeping the point-release suffix (`"3.7a"`) that
+{func}`~libtmux.common.get_version` strips for numeric comparison. Reach
+for it to distinguish patch releases whose behavior differs -- for
+example telling tmux `3.7` from `3.7a`.
+
 ### Fixes
 
 #### `break_pane()` keeps tmux's default window name on 3.7a/3.7b (#699)

--- a/CHANGES
+++ b/CHANGES
@@ -45,6 +45,15 @@ $ uvx --from 'libtmux' --prerelease allow python
 _Notes on the upcoming release will go here._
 <!-- END PLACEHOLDER - ADD NEW CHANGELOG ENTRIES BELOW THIS LINE -->
 
+### Fixes
+
+#### `break_pane()` keeps tmux's default window name on 3.7a/3.7b (#699)
+
+On tmux 3.7a/3.7b, breaking a pane into a new window without an explicit
+`window_name` left it named `libtmux` instead of tmux's own default
+(typically the running command). {meth}`~libtmux.Pane.break_pane` now
+keeps that natural name; passing `window_name` is unaffected.
+
 ### Development
 
 #### tmux 3.7a/3.7b test compatibility (#698)

--- a/docs/topics/format-tokens.md
+++ b/docs/topics/format-tokens.md
@@ -121,10 +121,12 @@ The result is cached per `(list_cmd, tmux_version)` pair.
 You never call this directly, but it's worth knowing how the version
 gate gets its answer. libtmux detects the live tmux version via
 {func}`libtmux.common.get_version` and passes it through to
-`get_output_format` whenever it builds a `-F` template. The result
-is cached for the process lifetime; if you're swapping the `tmux`
-binary mid-test, call
-`libtmux.common.get_version.cache_clear()` to invalidate.
+`get_output_format` whenever it builds a `-F` template. That lookup is
+memoized for the process lifetime, as is the raw-string
+{func}`libtmux.common.get_version_str`; the two cache independently, so
+if you're swapping the `tmux` binary mid-test, clear both with
+`libtmux.common.get_version.cache_clear()` and
+`get_version_str.cache_clear()`.
 
 The {ref}`project` page tracks the project's minimum tmux version
 (currently 3.2a); see {doc}`/project/compatibility` for the full

--- a/src/libtmux/common.py
+++ b/src/libtmux/common.py
@@ -378,12 +378,31 @@ class tmux_cmd:
             )
 
 
+class _TmuxVersionUnavailable(Exception):
+    """Internal signal: this tmux predates the ``-V`` flag (pre-1.7)."""
+
+
+def _no_version_flag_fallback() -> str:
+    """Return a synthetic version string when tmux lacks ``-V``.
+
+    OpenBSD ships a ``-V``-less base tmux, so assume the maximum supported
+    version; any other platform is genuinely too old.
+    """
+    if sys.platform.startswith("openbsd"):  # openbsd has no tmux -V
+        return f"{TMUX_MAX_VERSION}-openbsd"
+    msg = (
+        f"libtmux supports tmux {TMUX_MIN_VERSION} and greater. This system"
+        " does not meet the minimum tmux version requirement."
+    )
+    raise exc.LibTmuxException(msg)
+
+
 def _query_version(tmux_bin: str | None = None) -> str:
     """Return the raw ``tmux -V`` version token, letter suffix intact.
 
     Runs ``tmux -V`` and extracts the version token (e.g. ``"3.7a"``,
     ``"master"``, ``"next-3.8"``). Not memoized -- :func:`get_version` and
-    :func:`get_version_str` layer caching on top of this single query.
+    :func:`get_version_str` each cache their own result on top of this query.
 
     Parameters
     ----------
@@ -393,21 +412,20 @@ def _query_version(tmux_bin: str | None = None) -> str:
     Returns
     -------
     str
-        Raw version token from ``tmux -V``. OpenBSD base tmux (no ``-V``)
-        yields the synthetic ``"<max>-openbsd"``.
+        Raw version token from ``tmux -V``.
+
+    Raises
+    ------
+    _TmuxVersionUnavailable
+        tmux predates the ``-V`` flag; callers apply
+        :func:`_no_version_flag_fallback`.
+    :exc:`~libtmux.exc.VersionTooLow`
+        tmux reported another error on ``-V``.
     """
     proc = tmux_cmd("-V", tmux_bin=tmux_bin)
     if proc.stderr:
         if proc.stderr[0] == "tmux: unknown option -- V":
-            if sys.platform.startswith("openbsd"):  # openbsd has no tmux -V
-                return f"{TMUX_MAX_VERSION}-openbsd"
-            msg = (
-                f"libtmux supports tmux {TMUX_MIN_VERSION} and greater. This system"
-                " does not meet the minimum tmux version requirement."
-            )
-            raise exc.LibTmuxException(
-                msg,
-            )
+            raise _TmuxVersionUnavailable
         raise exc.VersionTooLow(proc.stderr)
 
     return proc.stdout[0].split("tmux ")[1]
@@ -433,12 +451,21 @@ def get_version_str(tmux_bin: str | None = None) -> str:
         Raw tmux version, e.g. ``"3.7a"``. Git builds return ``"master"``;
         OpenBSD base tmux returns ``"<max>-openbsd"``.
 
+    Examples
+    --------
+    >>> isinstance(get_version_str(), str)
+    True
+
     Notes
     -----
-    Memoized via :func:`functools.cache` like :func:`get_version`; call
-    ``get_version_str.cache_clear()`` after swapping the tmux binary.
+    Memoized via :func:`functools.cache`, keyed on *tmux_bin*, independently of
+    :func:`get_version`. Call ``get_version_str.cache_clear()`` after swapping
+    the tmux binary.
     """
-    return _query_version(tmux_bin=tmux_bin)
+    try:
+        return _query_version(tmux_bin=tmux_bin)
+    except _TmuxVersionUnavailable:
+        return _no_version_flag_fallback()
 
 
 @functools.cache
@@ -466,17 +493,18 @@ def get_version(tmux_bin: str | None = None) -> LooseVersion:
     Notes
     -----
     Memoized via :func:`functools.cache`, keyed on the *tmux_bin* argument
-    (``None`` is a distinct key from any explicit path). The cache is sticky
-    across ``PATH`` changes and on-disk binary swaps when *tmux_bin* is
-    ``None`` or the same path string — call ``get_version.cache_clear()`` to
-    invalidate. Tests that monkey-patch :class:`tmux_cmd` should call
-    ``cache_clear()`` before asserting parsed-version behavior.
+    (``None`` is a distinct key from any explicit path), independently of
+    :func:`get_version_str`. The cache is sticky across ``PATH`` changes and
+    on-disk binary swaps when *tmux_bin* is ``None`` or the same path string --
+    call ``get_version.cache_clear()`` to invalidate. Tests that monkey-patch
+    :class:`tmux_cmd` should call ``cache_clear()`` before asserting
+    parsed-version behavior.
     """
-    version = _query_version(tmux_bin=tmux_bin)
-
-    # OpenBSD base tmux has no -V; _query_version returns a synthetic string.
-    if version == f"{TMUX_MAX_VERSION}-openbsd":
-        return LooseVersion(version)
+    try:
+        version = _query_version(tmux_bin=tmux_bin)
+    except _TmuxVersionUnavailable:
+        # OpenBSD base tmux lacks ``-V``; skip letter-stripping on the synthetic.
+        return LooseVersion(_no_version_flag_fallback())
 
     # Allow latest tmux HEAD
     if version == "master":

--- a/src/libtmux/common.py
+++ b/src/libtmux/common.py
@@ -378,6 +378,69 @@ class tmux_cmd:
             )
 
 
+def _query_version(tmux_bin: str | None = None) -> str:
+    """Return the raw ``tmux -V`` version token, letter suffix intact.
+
+    Runs ``tmux -V`` and extracts the version token (e.g. ``"3.7a"``,
+    ``"master"``, ``"next-3.8"``). Not memoized -- :func:`get_version` and
+    :func:`get_version_str` layer caching on top of this single query.
+
+    Parameters
+    ----------
+    tmux_bin : str, optional
+        Path to tmux binary. If *None*, uses the system tmux.
+
+    Returns
+    -------
+    str
+        Raw version token from ``tmux -V``. OpenBSD base tmux (no ``-V``)
+        yields the synthetic ``"<max>-openbsd"``.
+    """
+    proc = tmux_cmd("-V", tmux_bin=tmux_bin)
+    if proc.stderr:
+        if proc.stderr[0] == "tmux: unknown option -- V":
+            if sys.platform.startswith("openbsd"):  # openbsd has no tmux -V
+                return f"{TMUX_MAX_VERSION}-openbsd"
+            msg = (
+                f"libtmux supports tmux {TMUX_MIN_VERSION} and greater. This system"
+                " does not meet the minimum tmux version requirement."
+            )
+            raise exc.LibTmuxException(
+                msg,
+            )
+        raise exc.VersionTooLow(proc.stderr)
+
+    return proc.stdout[0].split("tmux ")[1]
+
+
+@functools.cache
+def get_version_str(tmux_bin: str | None = None) -> str:
+    """Return the tmux version string verbatim, preserving letter suffixes.
+
+    :func:`get_version` normalizes point releases for numeric comparison
+    (``"3.7a"`` becomes ``LooseVersion("3.7")``). This helper keeps the raw
+    suffix, so callers can distinguish patch releases whose behavior differs
+    -- for example the tmux 3.7 break-pane crash, reverted in 3.7a.
+
+    Parameters
+    ----------
+    tmux_bin : str, optional
+        Path to tmux binary. If *None*, uses the system tmux.
+
+    Returns
+    -------
+    str
+        Raw tmux version, e.g. ``"3.7a"``. Git builds return ``"master"``;
+        OpenBSD base tmux returns ``"<max>-openbsd"``.
+
+    Notes
+    -----
+    Memoized via :func:`functools.cache` like :func:`get_version`; call
+    ``get_version_str.cache_clear()`` after swapping the tmux binary.
+    """
+    return _query_version(tmux_bin=tmux_bin)
+
+
 @functools.cache
 def get_version(tmux_bin: str | None = None) -> LooseVersion:
     """Return tmux version.
@@ -409,21 +472,11 @@ def get_version(tmux_bin: str | None = None) -> LooseVersion:
     invalidate. Tests that monkey-patch :class:`tmux_cmd` should call
     ``cache_clear()`` before asserting parsed-version behavior.
     """
-    proc = tmux_cmd("-V", tmux_bin=tmux_bin)
-    if proc.stderr:
-        if proc.stderr[0] == "tmux: unknown option -- V":
-            if sys.platform.startswith("openbsd"):  # openbsd has no tmux -V
-                return LooseVersion(f"{TMUX_MAX_VERSION}-openbsd")
-            msg = (
-                f"libtmux supports tmux {TMUX_MIN_VERSION} and greater. This system"
-                " does not meet the minimum tmux version requirement."
-            )
-            raise exc.LibTmuxException(
-                msg,
-            )
-        raise exc.VersionTooLow(proc.stderr)
+    version = _query_version(tmux_bin=tmux_bin)
 
-    version = proc.stdout[0].split("tmux ")[1]
+    # OpenBSD base tmux has no -V; _query_version returns a synthetic string.
+    if version == f"{TMUX_MAX_VERSION}-openbsd":
+        return LooseVersion(version)
 
     # Allow latest tmux HEAD
     if version == "master":

--- a/src/libtmux/pane.py
+++ b/src/libtmux/pane.py
@@ -2340,10 +2340,20 @@ class Pane(
         'broken'
         """
         # tmux 3.7 segfaults break-pane when -n is absent and ignores -n when
-        # given (NULL-deref, fixed upstream after 3.7). Always pass -n -- the
-        # requested name or a placeholder -- then set the real name via
-        # rename-window below. Gated on exactly 3.7; other builds are unaffected.
+        # given (NULL-deref); 3.7a reverted it. Pass -n -- the requested name
+        # or a placeholder -- then set the real name via rename-window below.
+        # get_version() strips the letter suffix, so has_version("3.7") also
+        # matches the already-fixed 3.7a/3.7b; narrow with the raw version
+        # string so the workaround only fires on the literal 3.7 release.
         breaks_without_name = has_version("3.7", tmux_bin=self.server.tmux_bin)
+        if breaks_without_name:
+            raw_version = (
+                tmux_cmd("-V", tmux_bin=self.server.tmux_bin)
+                .stdout[0]
+                .split("tmux ", 1)[1]
+                .strip()
+            )
+            breaks_without_name = raw_version == "3.7"
 
         tmux_args: tuple[str, ...] = ("-P", "-F#{window_id}")
 

--- a/src/libtmux/pane.py
+++ b/src/libtmux/pane.py
@@ -14,7 +14,7 @@ import typing as t
 import warnings
 
 from libtmux import exc
-from libtmux.common import has_gte_version, has_version, raise_if_stderr, tmux_cmd
+from libtmux.common import get_version_str, has_gte_version, raise_if_stderr, tmux_cmd
 from libtmux.constants import (
     PANE_DIRECTION_FLAG_MAP,
     RESIZE_ADJUSTMENT_DIRECTION_FLAG_MAP,
@@ -2340,20 +2340,11 @@ class Pane(
         'broken'
         """
         # tmux 3.7 segfaults break-pane when -n is absent and ignores -n when
-        # given (NULL-deref); 3.7a reverted it. Pass -n -- the requested name
-        # or a placeholder -- then set the real name via rename-window below.
-        # get_version() strips the letter suffix, so has_version("3.7") also
-        # matches the already-fixed 3.7a/3.7b; narrow with the raw version
-        # string so the workaround only fires on the literal 3.7 release.
-        breaks_without_name = has_version("3.7", tmux_bin=self.server.tmux_bin)
-        if breaks_without_name:
-            raw_version = (
-                tmux_cmd("-V", tmux_bin=self.server.tmux_bin)
-                .stdout[0]
-                .split("tmux ", 1)[1]
-                .strip()
-            )
-            breaks_without_name = raw_version == "3.7"
+        # given (NULL-deref); 3.7a reverted it. When needed, pass a placeholder
+        # -n then set the real name via rename-window below. get_version()
+        # strips the letter suffix, so compare the raw (memoized) version
+        # string to gate the workaround on the literal 3.7 release only.
+        breaks_without_name = get_version_str(tmux_bin=self.server.tmux_bin) == "3.7"
 
         tmux_args: tuple[str, ...] = ("-P", "-F#{window_id}")
 

--- a/src/libtmux/pane.py
+++ b/src/libtmux/pane.py
@@ -2341,9 +2341,8 @@ class Pane(
         """
         # tmux 3.7 segfaults break-pane when -n is absent and ignores -n when
         # given (NULL-deref); 3.7a reverted it. When needed, pass a placeholder
-        # -n then set the real name via rename-window below. get_version()
-        # strips the letter suffix, so compare the raw (memoized) version
-        # string to gate the workaround on the literal 3.7 release only.
+        # -n then set the real name via rename-window below. Compare the raw
+        # version string to gate the workaround on the literal 3.7 release only.
         breaks_without_name = get_version_str(tmux_bin=self.server.tmux_bin) == "3.7"
 
         tmux_args: tuple[str, ...] = ("-P", "-F#{window_id}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,17 +4,19 @@ from __future__ import annotations
 
 import pytest
 
-from libtmux.common import get_version
+from libtmux.common import get_version, get_version_str
 
 
 @pytest.fixture(autouse=True)
 def _clear_get_version_cache() -> None:
-    """Flush get_version's @functools.cache before each test.
+    """Flush the tmux-version @functools.cache before each test.
 
     Several tests in test_common.py and legacy_api/test_common.py
     monkey-patch libtmux.common.tmux_cmd then call get_version() to
     assert parsed-version behavior. With memoization, a prior test's
     cached result would mask the mock — this fixture guarantees a
-    fresh subprocess lookup per test.
+    fresh subprocess lookup per test. get_version_str shares the same
+    concern, so flush it too.
     """
     get_version.cache_clear()
+    get_version_str.cache_clear()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,14 +9,14 @@ from libtmux.common import get_version, get_version_str
 
 @pytest.fixture(autouse=True)
 def _clear_get_version_cache() -> None:
-    """Flush the tmux-version @functools.cache before each test.
+    """Flush the tmux-version caches before each test.
 
     Several tests in test_common.py and legacy_api/test_common.py
     monkey-patch libtmux.common.tmux_cmd then call get_version() to
     assert parsed-version behavior. With memoization, a prior test's
-    cached result would mask the mock — this fixture guarantees a
-    fresh subprocess lookup per test. get_version_str shares the same
-    concern, so flush it too.
+    cached result would mask the mock — this fixture guarantees a fresh
+    subprocess lookup per test. get_version and get_version_str cache
+    independently, so flush both.
     """
     get_version.cache_clear()
     get_version_str.cache_clear()

--- a/tests/test_pane.py
+++ b/tests/test_pane.py
@@ -10,7 +10,7 @@ import typing as t
 import pytest
 
 from libtmux import exc
-from libtmux.common import has_gte_version
+from libtmux.common import has_gte_version, has_version
 from libtmux.constants import PaneDirection, ResizeAdjustmentDirection
 from libtmux.test.retry import retry_until
 
@@ -1344,6 +1344,32 @@ def test_break_pane_with_name(session: Session) -> None:
     new_pane = pane.split(shell="sleep 1m")
     new_window = new_pane.break_pane(window_name="my_broken")
     assert new_window.window_name == "my_broken"
+
+
+@pytest.mark.xfail(
+    has_version("3.7"),
+    reason=(
+        "break_pane() without window_name forces the 'libtmux' placeholder "
+        "on the tmux 3.7 family; the underlying crash was reverted in 3.7a "
+        "but get_version() strips the suffix, so the workaround still fires"
+    ),
+    strict=True,
+)
+def test_break_pane_no_name_uses_natural_name(session: Session) -> None:
+    """Pane.break_pane() without a name keeps tmux's default window name.
+
+    The tmux 3.7 break-pane crash workaround injects a placeholder ``-n``
+    when no ``window_name`` is given. On tmux 3.7a/3.7b, where the crash is
+    already fixed, that placeholder must not leak as the window name -- the
+    broken window should keep tmux's own auto-name (here ``sleep``).
+    """
+    window = session.new_window(window_name="test_break_natural")
+    pane = window.active_pane
+    assert pane is not None
+
+    new_pane = pane.split(shell="sleep 123")
+    broken = new_pane.break_pane()
+    assert broken.window_name == "sleep"
 
 
 def test_swap_pane(session: Session) -> None:

--- a/tests/test_pane.py
+++ b/tests/test_pane.py
@@ -10,7 +10,7 @@ import typing as t
 import pytest
 
 from libtmux import exc
-from libtmux.common import has_gte_version, has_version
+from libtmux.common import has_gte_version
 from libtmux.constants import PaneDirection, ResizeAdjustmentDirection
 from libtmux.test.retry import retry_until
 
@@ -1346,15 +1346,6 @@ def test_break_pane_with_name(session: Session) -> None:
     assert new_window.window_name == "my_broken"
 
 
-@pytest.mark.xfail(
-    has_version("3.7"),
-    reason=(
-        "break_pane() without window_name forces the 'libtmux' placeholder "
-        "on the tmux 3.7 family; the underlying crash was reverted in 3.7a "
-        "but get_version() strips the suffix, so the workaround still fires"
-    ),
-    strict=True,
-)
 def test_break_pane_no_name_uses_natural_name(session: Session) -> None:
     """Pane.break_pane() without a name keeps tmux's default window name.
 


### PR DESCRIPTION
## Summary

- **Fix** `Pane.break_pane()` forcing the window name to `libtmux` on tmux **3.7a**/**3.7b** when called without an explicit `window_name` — it now keeps tmux's natural auto-name.
- **Add** `libtmux.common.get_version_str()` — the raw tmux version string with its point-release suffix intact (`"3.7a"`), for telling patch releases apart where `get_version()` can't.
- **Refactor** tmux-version detection into two plain, typed `@functools.cache` helpers; `get_version` output stays byte-identical.

## The bug

`break_pane()` works around a tmux 3.7 NULL-deref (break-pane with no `-n` crashes the server) by injecting a placeholder `-n libtmux` and renaming afterward. The gate was `has_version("3.7")` — but `get_version()` strips the letter suffix for numeric comparison, so it also matched **3.7a/3.7b**, where the crash was already reverted upstream ([tmux `166267c8`](https://github.com/tmux/tmux/commit/166267c8), shipped in 3.7a). With no explicit name, the placeholder leaked as the window name.

Shipped in v0.59.0/v0.60.0. Reproduced on tmux 3.7b: an unnamed `break_pane()` produced a window named `libtmux` instead of the running command's name.

## The fix

Gate the workaround on the *raw* version string being exactly `"3.7"` — which the numeric `get_version()` can't express. `get_version_str()` exposes that raw token, and `break_pane` now compares `get_version_str(...) == "3.7"`, so 3.7a/3.7b (and master, and older tmux) keep tmux's natural window naming.

## Version-cache design

`get_version` and `get_version_str` are two plain `@functools.cache` functions deriving from a shared uncached `_query_version`, each with native `.cache_clear()`/`.cache_info()` — no shared-cache machinery, no `object.__setattr__`, no callable-class wrapper. `get_version` stays byte-identical across every `tmux -V` variation (real releases, `master`, `next-3.8`, OpenBSD, and both error paths); the OpenBSD/no-`-V` synthetic is distinguished by control flow (an internal exception), not a value sentinel that could collide.

## Test plan

- [x] `test_break_pane_no_name_uses_natural_name` — regression test, added as a strict `xfail` then un-xfail'd once the fix landed (the fix commit's CI went red on exactly the 3.7a/3.7b cells, proving it)
- [x] `get_version` verified byte-identical to the prior implementation across all `tmux -V` variations
- [x] `uv run mypy src tests` clean (zero `# type: ignore`); `ruff` clean
- [x] `get_version` / `get_version_str` render in the API docs with signatures
- [x] CI grid green on tmux 3.7a/3.7b (added to the matrix in #698)