### PR TITLE
Complete the from_env family: know which pane, window, session and server you're running in

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -45,6 +45,31 @@ $ uvx --from 'libtmux' --prerelease allow python
 _Notes on the upcoming release will go here._
 <!-- END PLACEHOLDER - ADD NEW CHANGELOG ENTRIES BELOW THIS LINE -->
 
+### What's new
+
+#### Find where you are running (#705)
+
+A program started inside tmux can now ask where it is.
+{meth}`Server.from_env() <libtmux.Server.from_env>`, {meth}`Session.from_env()
+<libtmux.Session.from_env>`, {meth}`Window.from_env() <libtmux.Window.from_env>`
+and {meth}`Pane.from_env() <libtmux.Pane.from_env>` each return the object the
+current process is running inside, so a script, a hook, or an agent can pick up
+the hierarchy from wherever it happens to be. Outside tmux they raise
+{exc}`~libtmux.exc.NotInsideTmux` rather than guess, and each accepts an
+environment mapping in place of the process environment, which keeps them
+straightforward to test. See {ref}`self-location`.
+
+They report what *contains* the caller, not what is focused — a pane running in
+the background gets its own window back, not the one someone happens to be
+looking at. And the server gives the answer, not the environment: the session id
+tmux writes into `TMUX` goes stale the moment a window is moved, so resolution
+anchors on the pane, which tmux keeps answering for live.
+
+There is no `Client.from_env()`. A tmux client is an attached terminal, and a
+pane is not owned by one — none may be attached, or several may be, each with
+its own view. tmux exports no client id into a pane, so there is nothing to read
+back.
+
 ## libtmux 0.61.0 (2026-07-04)
 
 libtmux 0.61.0 hardens support for the tmux 3.7 patch line. It fixes

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ libtmux is a typed Python API over [tmux], the terminal multiplexer. Stop shelli
 
 - Typed, object-oriented control of tmux state
 - Query and [traverse](https://libtmux.git-pull.com/topics/traversal/) live sessions, windows, and panes
+- [Locate yourself](https://libtmux.git-pull.com/topics/self_location/) from inside a pane with `from_env()`
 - Raw escape hatch via `.cmd(...)` on any object
 - Works with multiple tmux sockets and servers
 - [Context managers](https://libtmux.git-pull.com/topics/context_managers/) for automatic cleanup
@@ -225,6 +226,27 @@ Window(@... ...:..., Session($... ...))
 >>> pane.window.session
 Session($... ...)
 ```
+
+### Know where you're running
+
+[**Learn more about Locating yourself**](https://libtmux.git-pull.com/topics/self_location/)
+
+Code *running inside* a pane — a script in a split, a tmux hook, an agent — can ask where it is. tmux writes `TMUX` and `TMUX_PANE` into every pane it spawns, and `Server`, `Session`, `Window`, and `Pane` each read them back:
+
+```python
+>>> socket_path = server.cmd(
+...     "display-message", "-p", "-t", session.session_id, "#{socket_path}"
+... ).stdout[0]
+>>> monkeypatch.setenv("TMUX", f"{socket_path},1,{session.session_id}")
+>>> monkeypatch.setenv("TMUX_PANE", pane.pane_id)
+
+>>> Pane.from_env()
+Pane(%... ...)
+>>> Session.from_env().session_name == session.session_name
+True
+```
+
+In a real pane tmux has already set those two variables, so `from_env()` takes no arguments and there is nothing to arrange — this README is not running in a pane, so the example sets them first. Outside tmux there is no pane to return, and `from_env()` raises `NotInsideTmux`.
 
 ## Core concepts
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -63,17 +63,30 @@ requires them to actually execute — `testpaths` includes `docs/`, so
 pytest runs every one. Lead with a small, runnable example early rather
 than after paragraphs of prose; libtmux is code-first.
 
-- Use the `doctest_namespace` fixtures — `server`, `session`, `window`,
-  `pane` (and `Server` / `Session` / `Window` / `Pane` / `Client`) —
-  instead of building a server by hand.
+- Use the `doctest_namespace` fixtures instead of building a server by
+  hand. `conftest.py` seeds the namespace with `server`, `session`,
+  `window`, `pane`, the `Server` / `Session` / `Window` / `Pane` /
+  `Client` classes, `ControlMode` and `control_mode`, `monkeypatch`,
+  and `request`.
 - Fence a `>>>` session as a ```` ```python ```` block, and reach for
   `# doctest: +ELLIPSIS` when output varies (ids like `@1`, `$2`,
   socket names). Use a ```` ```console ```` block for shell commands at
   a `$` prompt.
-- The code blocks on a page share one doctest session, so a later
-  block can use a `pane` an earlier block created. That makes their
-  **order load-bearing**: never reorder, add, or drop a code block when
-  you reshape the prose around it.
+- **Every code block on a page is an independent doctest.** Blocks do
+  not share a session: each one gets a fresh copy of the namespace *and*
+  a fresh tmux server. A later block cannot use a `pane` an earlier
+  block created — the name is simply not defined there. So **write every
+  block self-contained**. The fixtures above are re-seeded for each
+  block, which makes that cheap: no block needs an import or a setup
+  preamble to get a `server`, a `session`, or a `pane`. Order is
+  load-bearing for the reader's narrative, not for state — reorder, add,
+  or drop a block as the prose demands, and keep the story coherent.
+- Two of those names are not quite what they look like. `Server` is a
+  `TestServer` partial, not the real class; write
+  `>>> from libtmux.server import Server` when an example needs the
+  class itself. And the fixture server is created with a socket *name*,
+  so `server.socket_path` is `None` — an example that needs the path
+  must ask tmux for it with `display-message -p '#{socket_path}'`.
 
 ## What stays precise
 
@@ -109,8 +122,8 @@ another link useful.
 Do not rely on a later reference section to satisfy the first-mention rule. If
 the first occurrence would be a heading, grid-card teaser, or introductory
 sentence, link that occurrence or retitle the heading so the first prose mention
-can carry the link. Leave command examples, code blocks, Mermaid node labels,
-and literal configuration values as code; link the surrounding prose instead.
+can carry the link. Leave command examples, code blocks, and literal
+configuration values as code; link the surrounding prose instead.
 
 ## A page that does this
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -61,4 +61,25 @@ Pane
 Target
     A target, cited in the manual as ``[-t target]`` can be a session,
     window or pane.
+
+TMUX
+    Environment variable tmux exports into every {term}`Pane` it spawns.
+
+    Holds ``socket_path,server_pid,session_id`` for the {term}`Server`
+    the pane belongs to. The session id is spelled bare, e.g. ``47``, or
+    ``-1`` for a pane spawned without a session.
+
+    Written once, when the pane is spawned, and never revised — so its
+    session id goes stale if the pane's {term}`Window` later moves.
+
+    Read back by libtmux in {ref}`self-location`.
+
+TMUX_PANE
+    Environment variable tmux exports into every {term}`Pane` it spawns.
+
+    Holds that pane's ``pane_id``, e.g. ``%1``. Unlike ``TMUX`` it always
+    names the pane the process is really in, so it is the id libtmux
+    anchors on to answer where a process is running.
+
+    Read back by libtmux in {ref}`self-location`.
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -77,6 +77,31 @@ Python object with traversal, filtering, and command execution.
 | {class}`~libtmux.window.Window` | tmux window |
 | {class}`~libtmux.pane.Pane` | tmux pane |
 
+## Know where you're running
+
+Sometimes you hold no handle at all, because your code is *running inside* a
+pane. You don't have to search the server for yourself — tmux writes `TMUX` and
+`TMUX_PANE` into every pane it spawns, and each level of the hierarchy reads
+them back:
+
+```python
+>>> socket_path = server.cmd(
+...     "display-message", "-p", "-t", session.session_id, "#{socket_path}"
+... ).stdout[0]
+>>> monkeypatch.setenv("TMUX", f"{socket_path},1,{session.session_id}")
+>>> monkeypatch.setenv("TMUX_PANE", pane.pane_id)
+
+>>> Pane.from_env().pane_id == pane.pane_id
+True
+>>> Session.from_env().session_name == session.session_name
+True
+```
+
+Inside a pane tmux has already set those two variables, so {meth}`Pane.from_env()
+<libtmux.Pane.from_env>` takes no arguments; these docs are not running in a
+pane, so the example sets them first. Outside tmux there is no pane to return and
+{exc}`~libtmux.exc.NotInsideTmux` is raised instead. See {ref}`self-location`.
+
 ## Testing
 
 libtmux ships a [pytest plugin](api/testing/pytest-plugin/index.md) with

--- a/docs/topics/clients.md
+++ b/docs/topics/clients.md
@@ -35,6 +35,17 @@ stable for the lifetime of the attachment.
 | `client_session` | session name of the same attached view | No — snapshot |
 | `client_pid` / `client_tty` / `client_user` | terminal-level facts | Yes — identity-adjacent |
 
+:::{seealso}
+**Why there is no `Client.from_env()`.** A pane can name the
+{class}`~libtmux.Session`, {class}`~libtmux.Window`, and
+{class}`~libtmux.Pane` it is running in, because tmux writes those ids into
+its environment. A client is the one thing it cannot name. Viewing is not
+owning: no client may be attached at all — a detached session, a CI job, a
+`send-keys` script — or several may be, each looking somewhere else. tmux
+exports no client id into a pane because there is no single right answer to
+export. See {ref}`self-location` for what a pane *can* resolve about itself.
+:::
+
 ## Live attachment lookup
 
 When you want the *current* attachment — not the snapshot — use the

--- a/docs/topics/configuration.md
+++ b/docs/topics/configuration.md
@@ -8,23 +8,51 @@ tmux through the standard object API, you're already configured correctly
 and can stop reading here.
 
 The rest of this page is for the rarer cases. It documents two lower
-layers you can reach for when the defaults aren't enough: the tmux
-environment variables that decide which server you connect to, and the
-format-string system libtmux uses internally to read tmux state.
+layers you can reach for when the defaults aren't enough: the
+environment variables libtmux reads, and the format-string system
+libtmux uses internally to read tmux state.
 
 ## Environment variables
 
-libtmux reads almost nothing from the environment, so in normal use
-there's nothing to set here. The one knob it does read is
-`LIBTMUX_TMUX_FORMAT_SEPARATOR`, an advanced override for the separator
-(default `␞`) libtmux uses internally to parse tmux's format output — you'd
-touch it only if that character ever collided with your own data. What more
-often matters is the tmux *server* you connect to: the standard tmux
-variables `TMUX` (the address of an
-existing server) and `TMUX_TMPDIR` (where tmux keeps its socket) shape
-which server a fresh {class}`~libtmux.Server` finds. If you run several
-servers, or point tmux at a custom socket directory, those two variables
-decide which one you land on — otherwise you can ignore them.
+You set almost nothing here. The two variables that matter most, tmux
+writes for you and libtmux only reads back, so a normal Python process
+driving tmux has nothing to arrange in this section.
+
+tmux exports both into every pane it spawns:
+
+| Variable | What tmux puts in it |
+|---|---|
+| `TMUX` | the server that pane belongs to, as `socket_path,server_pid,session_id` |
+| `TMUX_PANE` | the id of the pane itself, e.g. `%1` |
+
+Code running *inside* a pane — a script you started in a split, a hook, a
+test harness — reads them back to get a handle on itself, rather than
+searching the server for a pane it already is. That is the `from_env`
+family: {meth}`Server.from_env() <libtmux.Server.from_env>`,
+{meth}`Session.from_env() <libtmux.Session.from_env>`,
+{meth}`Window.from_env() <libtmux.Window.from_env>`, and
+{meth}`Pane.from_env() <libtmux.Pane.from_env>`. Outside a pane neither
+variable is set, and all four raise {exc}`~libtmux.exc.NotInsideTmux`.
+You never write them yourself: {ref}`self-location` covers what each call
+does with them, why the session id in `TMUX` goes stale, and the `env`
+mapping you hand `from_env` in tests instead of touching the real
+environment.
+
+tmux reads `TMUX` too — it is how tmux notices you are already inside a
+session and guards against nesting one. {meth}`Server.new_session()
+<libtmux.Server.new_session>` unsets it for the length of that one call
+and restores it afterward, so creating a session from inside a pane works
+without you arranging anything.
+
+That leaves the two variables that *are* yours to set, and most people
+set neither. `TMUX_TMPDIR` is tmux's own — the directory it keeps sockets
+in. libtmux never reads it, but the tmux binary it shells out to does, so
+it shapes which server a bare {class}`~libtmux.Server` lands on; pass
+`socket_name` or `socket_path` when you would rather name the server
+outright. `LIBTMUX_TMUX_FORMAT_SEPARATOR` is the one variable libtmux
+itself defines: an advanced override for the separator (default `␞`) it
+uses internally to parse tmux's format output — you'd touch it only if
+that character ever collided with your own data.
 
 ## Format strings
 

--- a/docs/topics/index.md
+++ b/docs/topics/index.md
@@ -18,6 +18,13 @@ Navigate the {class}`~libtmux.Server`, {class}`~libtmux.Session`,
 {class}`~libtmux.Window`, {class}`~libtmux.Pane` hierarchy.
 :::
 
+:::{grid-item-card} Locating Yourself
+:link: self_location
+:link-type: doc
+Code running inside a pane asking which pane, window, session, and server
+it is in.
+:::
+
 :::{grid-item-card} Filtering
 :link: filtering
 :link-type: doc
@@ -82,6 +89,7 @@ configuration
 design-decisions
 public-vs-internal
 traversal
+self_location
 filtering
 pane_interaction
 floating_panes

--- a/docs/topics/self_location.md
+++ b/docs/topics/self_location.md
@@ -1,0 +1,250 @@
+(self-location)=
+
+# Locating yourself
+
+Most libtmux code starts from a handle you already hold — you make a
+{class}`~libtmux.Server`, you find a {class}`~libtmux.Session`, you walk down.
+Sometimes you hold nothing, because your code is *running inside* a pane: a
+script you launched in a split, a tmux hook, a test harness, an agent. Before it
+can do anything useful it has to answer one question — **where am I?**
+
+You don't have to search the server for yourself. tmux already told you. It
+writes two variables into every pane it spawns, and each level of the hierarchy
+reads them back:
+
+| | |
+|---|---|
+| {meth}`Server.from_env() <libtmux.Server.from_env>` | the tmux server you are running on |
+| {meth}`Session.from_env() <libtmux.Session.from_env>` | the session that holds you |
+| {meth}`Window.from_env() <libtmux.Window.from_env>` | the window that contains you |
+| {meth}`Pane.from_env() <libtmux.Pane.from_env>` | the pane you are running in |
+
+If all you need is a handle on yourself, the first section is the whole story.
+The rest is for the rarer cases: outside tmux, background panes, and the session
+question when it has more than one true answer.
+
+To follow along live, start tmux, then run `python` *inside* a pane — that is
+the situation this page is about:
+
+```console
+$ tmux
+```
+
+```console
+$ python
+```
+
+## Ask where you are
+
+Inside a pane each call takes no arguments. It reads {data}`os.environ`, which is
+where tmux put the answer:
+
+```python
+>>> socket_path = server.cmd(
+...     "display-message", "-p", "-t", session.session_id, "#{socket_path}"
+... ).stdout[0]
+>>> monkeypatch.setenv("TMUX", f"{socket_path},1,{session.session_id}")
+>>> monkeypatch.setenv("TMUX_PANE", pane.pane_id)
+
+>>> Pane.from_env().pane_id == pane.pane_id
+True
+>>> Window.from_env().window_id == window.window_id
+True
+>>> Session.from_env().session_id == session.session_id
+True
+```
+
+That is the whole call — in a real pane tmux has already set those two variables
+for you, and there is nothing to arrange. These docs are not running in a pane,
+so the example sets them first.
+
+Once you hold any of the four you are back on the hierarchy, and everything in
+{ref}`traversal` applies.
+
+Each call also accepts an environment *mapping* in place of {data}`os.environ`.
+The examples below pass one explicitly, and it is the seam your own tests can use
+— see {ref}`self-location-testing`.
+
+```python
+>>> socket_path = server.cmd(
+...     "display-message", "-p", "-t", session.session_id, "#{socket_path}"
+... ).stdout[0]
+>>> env = {
+...     "TMUX": f"{socket_path},1,{session.session_id}",
+...     "TMUX_PANE": pane.pane_id,
+... }
+
+>>> Session.from_env(env).session_id == session.session_id
+True
+```
+
+## When you are not in tmux
+
+There is no pane to return, and answering with somebody else's would be worse
+than not answering, so all four raise {exc}`~libtmux.exc.NotInsideTmux`. Catch it
+when your program is meant to run inside a pane *and* out:
+
+```python
+>>> from libtmux import exc
+
+>>> try:
+...     here = Pane.from_env({})
+... except exc.NotInsideTmux:
+...     here = None
+
+>>> here is None
+True
+```
+
+## The window that contains you, not the one in front
+
+A background pane is still somewhere. {meth}`Window.from_env()
+<libtmux.Window.from_env>` returns the window that *contains* you, which is not
+the window someone happens to be looking at:
+
+```python
+>>> socket_path = server.cmd(
+...     "display-message", "-p", "-t", session.session_id, "#{socket_path}"
+... ).stdout[0]
+>>> worker_window = session.new_window(window_name="worker", attach=False)
+>>> worker = worker_window.active_pane
+>>> env = {
+...     "TMUX": f"{socket_path},1,{session.session_id}",
+...     "TMUX_PANE": worker.pane_id,
+... }
+
+>>> session.active_window.window_id == worker_window.window_id
+False
+
+>>> Window.from_env(env).window_id == worker_window.window_id
+True
+```
+
+{attr}`session.active_window <libtmux.Session.active_window>` answers a different
+question — *what is focused*.
+
+## The server answers, not the environment
+
+`TMUX` looks like it settles the session question on its own. Its three fields are
+`socket_path,server_pid,session_id`, and that last one is a session id.
+
+Don't reach for it. tmux writes these variables into a pane's environment *once*,
+when it spawns the pane, and never revises them — a running process's environment
+is not something tmux can rewrite. Move the pane's window to another session and
+the pane really is somewhere else, while `TMUX` still names the session it was
+born in.
+
+So `from_env` anchors on `TMUX_PANE`, the one id tmux keeps answering for live,
+and asks the server where that pane is *now*:
+
+```python
+>>> socket_path = server.cmd(
+...     "display-message", "-p", "-t", session.session_id, "#{socket_path}"
+... ).stdout[0]
+>>> worker_window = session.new_window(window_name="worker", attach=False)
+>>> worker = worker_window.active_pane
+>>> env = {
+...     "TMUX": f"{socket_path},1,{session.session_id}",  # names *this* session
+...     "TMUX_PANE": worker.pane_id,
+... }
+
+>>> elsewhere = server.new_session(session_name="elsewhere")
+>>> _ = worker_window.move_window(session=elsewhere.session_id, no_select=True)
+
+>>> Session.from_env(env).session_name  # where the pane is, not where TMUX says
+'elsewhere'
+```
+
+The same staleness is why {attr}`pane.session <libtmux.Pane.session>` resolves
+through {attr}`pane.window <libtmux.Pane.window>` instead of reading the
+`session_id` it is already carrying: a {class}`~libtmux.Pane` you fetched earlier
+remembers the session it was in *then*. The extra round-trip is what keeps the
+answer current. If you read it in a loop, bind it to a variable once.
+
+## When a window belongs to two sessions
+
+`TMUX` is not useless, though. It settles the one question the server cannot.
+
+`link-window` puts a single window in several sessions at once, and then the pane
+genuinely belongs to all of them — tmux lists it once per session, ordered by
+session *name*. Asked "which session am I in?", the server holds two equally true
+answers and no way to choose between them. `TMUX` remembers which one the process
+was **spawned** under, and that is the one you can claim:
+
+```python
+>>> socket_path = server.cmd(
+...     "display-message", "-p", "-t", session.session_id, "#{socket_path}"
+... ).stdout[0]
+>>> home = server.new_session(session_name="aaa-home")
+>>> shared = home.new_window(window_name="shared", attach=False)
+>>> worker = shared.active_pane
+>>> env = {
+...     "TMUX": f"{socket_path},1,{home.session_id}",
+...     "TMUX_PANE": worker.pane_id,
+... }
+
+>>> guest = server.new_session(session_name="zzz-guest")
+>>> linked = server.cmd(
+...     "link-window", "-s", shared.window_id, "-t", f"{guest.session_id}:"
+... )
+
+>>> holders = {p.session_name for p in server.panes.filter(pane_id=worker.pane_id)}
+>>> holders == {"aaa-home", "zzz-guest"}
+True
+
+>>> Session.from_env(env).session_name
+'aaa-home'
+```
+
+So the rule, in full: the session holding your pane is the answer; where several
+hold it, the one `TMUX` names wins. When `TMUX` names none of them — because the
+window has since moved on, or because it carries nothing usable — the server
+answers instead.
+
+"Nothing usable" is ignored, never raised: a session that has since been killed,
+a field that is not a number, and `-1`, which is what tmux writes for a pane
+spawned without a
+session. The id is spelled *bare* there — `1`, not `$1` — and either form is
+understood.
+
+## There is no `Client.from_env()`
+
+A {class}`~libtmux.Client` is an attached terminal, and a pane is not owned by
+one. No client may be attached at all — a detached session, a CI job, a
+`send-keys` script all run with a perfectly good `TMUX_PANE` and nobody watching
+— or several may be, each with its own view. tmux exports no client id into a
+pane, so there is nothing to read back. See {ref}`clients` for the
+view-versus-identity model this follows from.
+
+(self-location-testing)=
+
+## Testing code that locates itself
+
+Every `from_env` takes an optional `env` mapping. Passing one is how you test a
+function that locates itself without running your test suite inside a pane:
+
+```python
+>>> def announce(env=None):
+...     """Report the session this code is running in."""
+...     return Session.from_env(env).session_name
+
+>>> socket_path = server.cmd(
+...     "display-message", "-p", "-t", session.session_id, "#{socket_path}"
+... ).stdout[0]
+>>> env = {
+...     "TMUX": f"{socket_path},1,{session.session_id}",
+...     "TMUX_PANE": pane.pane_id,
+... }
+
+>>> announce(env) == session.session_name
+True
+```
+
+In production `announce()` takes no argument and reads the real environment.
+
+:::{seealso}
+- {ref}`traversal` — walking the hierarchy once you hold a handle
+- {ref}`clients` — why an attached terminal is a view, not an identity
+- {class}`~libtmux.Server`, {class}`~libtmux.Session`, {class}`~libtmux.Window`,
+  {class}`~libtmux.Pane` for the full API
+:::

--- a/docs/topics/traversal.md
+++ b/docs/topics/traversal.md
@@ -159,78 +159,15 @@ True
 ## Locating yourself
 
 Everything above starts from a handle you already hold. Sometimes you hold
-nothing: your code is *running inside* a pane — a script you launched in a
-split, a tmux hook, an agent — and the first thing it needs to know is where it
-is. You don't have to search the server for yourself. tmux already told you: it
-exports `TMUX` and `TMUX_PANE` into every pane it spawns, and each level of the
-hierarchy reads them back — {meth}`Server.from_env()
-<libtmux.Server.from_env>`, {meth}`Session.from_env()
-<libtmux.Session.from_env>`, {meth}`Window.from_env()
-<libtmux.Window.from_env>`, {meth}`Pane.from_env() <libtmux.Pane.from_env>`.
+nothing, because your code is *running inside* a pane — and tmux has already told
+it where it is. {meth}`Pane.from_env() <libtmux.Pane.from_env>`, and its siblings
+on {class}`~libtmux.Server`, {class}`~libtmux.Session` and
+{class}`~libtmux.Window`, read that back, so you can pick up the hierarchy from
+wherever you happen to be running.
 
-Inside a real pane each is the whole call — `Session.from_env()`, no arguments;
-it reads {data}`os.environ`. These docs run outside a pane, so the examples hand
-it an explicit environment instead.
-
-```python
->>> socket_path = server.cmd(
-...     "display-message", "-p", "-t", session.session_id, "#{socket_path}"
-... ).stdout[0]
->>> env = {
-...     "TMUX": f"{socket_path},1,{session.session_id}",
-...     "TMUX_PANE": pane.pane_id,
-... }
-
->>> Pane.from_env(env).pane_id == pane.pane_id  # inside a pane: Pane.from_env()
-True
->>> Window.from_env(env).window_id == window.window_id
-True
->>> Session.from_env(env).session_id == session.session_id
-True
-```
-
-There is no `Client.from_env()`. A client is an attached terminal, and a pane
-isn't owned by one — no client may be attached at all, or several may be, each
-with its own view. tmux exports no client id into a pane, so there is nothing to
-read back.
-
-### The server answers, not the environment
-
-`$TMUX` looks like it answers the session question on its own — its third field
-is a session id. It isn't the answer. tmux writes these variables into a pane's
-environment once, when it spawns the pane, and never revises them. Move the
-pane's window to another session and the pane really is somewhere else, while
-`$TMUX` still names the session it was born in.
-
-So `from_env` anchors on `TMUX_PANE` — the one id tmux keeps answering for
-live — and asks the server where that pane is *now*:
-
-```python
->>> socket_path = server.cmd(
-...     "display-message", "-p", "-t", session.session_id, "#{socket_path}"
-... ).stdout[0]
->>> worker_window = session.new_window(window_name="worker", attach=False)
->>> worker = worker_window.active_pane
->>> env = {
-...     "TMUX": f"{socket_path},1,{session.session_id}",  # names *this* session
-...     "TMUX_PANE": worker.pane_id,
-... }
-
->>> elsewhere = server.new_session(session_name="elsewhere")
->>> _ = worker_window.move_window(session=elsewhere.session_id, no_select=True)
-
->>> Session.from_env(env).session_name  # where the pane is, not where $TMUX says
-'elsewhere'
-```
-
-`$TMUX` is not useless, though — it settles the one question the server cannot.
-`link-window` puts a single window in several sessions at once, and then the
-pane genuinely belongs to all of them; tmux lists it once per session, ordered
-by session *name*. Asked "which session am I in?", the server has two equally
-true answers and no way to choose between them. `$TMUX` remembers which one the
-process was *spawned* under, so that is the one {meth}`Session.from_env()
-<libtmux.Session.from_env>` returns — as long as it still holds the pane.
-Otherwise the window has moved on, and the server's answer wins.
+See {ref}`self-location` for the whole story, including the window that
+*contains* you versus the one in front of you, and what to do when a window
+belongs to two sessions at once.
 
 ## Filtering and finding objects
 

--- a/docs/topics/traversal.md
+++ b/docs/topics/traversal.md
@@ -156,6 +156,82 @@ True
 True
 ```
 
+## Locating yourself
+
+Everything above starts from a handle you already hold. Sometimes you hold
+nothing: your code is *running inside* a pane — a script you launched in a
+split, a tmux hook, an agent — and the first thing it needs to know is where it
+is. You don't have to search the server for yourself. tmux already told you: it
+exports `TMUX` and `TMUX_PANE` into every pane it spawns, and each level of the
+hierarchy reads them back — {meth}`Server.from_env()
+<libtmux.Server.from_env>`, {meth}`Session.from_env()
+<libtmux.Session.from_env>`, {meth}`Window.from_env()
+<libtmux.Window.from_env>`, {meth}`Pane.from_env() <libtmux.Pane.from_env>`.
+
+Inside a real pane each is the whole call — `Session.from_env()`, no arguments;
+it reads {data}`os.environ`. These docs run outside a pane, so the examples hand
+it an explicit environment instead.
+
+```python
+>>> socket_path = server.cmd(
+...     "display-message", "-p", "-t", session.session_id, "#{socket_path}"
+... ).stdout[0]
+>>> env = {
+...     "TMUX": f"{socket_path},1,{session.session_id}",
+...     "TMUX_PANE": pane.pane_id,
+... }
+
+>>> Pane.from_env(env).pane_id == pane.pane_id  # inside a pane: Pane.from_env()
+True
+>>> Window.from_env(env).window_id == window.window_id
+True
+>>> Session.from_env(env).session_id == session.session_id
+True
+```
+
+There is no `Client.from_env()`. A client is an attached terminal, and a pane
+isn't owned by one — no client may be attached at all, or several may be, each
+with its own view. tmux exports no client id into a pane, so there is nothing to
+read back.
+
+### The server answers, not the environment
+
+`$TMUX` looks like it answers the session question on its own — its third field
+is a session id. It isn't the answer. tmux writes these variables into a pane's
+environment once, when it spawns the pane, and never revises them. Move the
+pane's window to another session and the pane really is somewhere else, while
+`$TMUX` still names the session it was born in.
+
+So `from_env` anchors on `TMUX_PANE` — the one id tmux keeps answering for
+live — and asks the server where that pane is *now*:
+
+```python
+>>> socket_path = server.cmd(
+...     "display-message", "-p", "-t", session.session_id, "#{socket_path}"
+... ).stdout[0]
+>>> worker_window = session.new_window(window_name="worker", attach=False)
+>>> worker = worker_window.active_pane
+>>> env = {
+...     "TMUX": f"{socket_path},1,{session.session_id}",  # names *this* session
+...     "TMUX_PANE": worker.pane_id,
+... }
+
+>>> elsewhere = server.new_session(session_name="elsewhere")
+>>> _ = worker_window.move_window(session=elsewhere.session_id, no_select=True)
+
+>>> Session.from_env(env).session_name  # where the pane is, not where $TMUX says
+'elsewhere'
+```
+
+`$TMUX` is not useless, though — it settles the one question the server cannot.
+`link-window` puts a single window in several sessions at once, and then the
+pane genuinely belongs to all of them; tmux lists it once per session, ordered
+by session *name*. Asked "which session am I in?", the server has two equally
+true answers and no way to choose between them. `$TMUX` remembers which one the
+process was *spawned* under, so that is the one {meth}`Session.from_env()
+<libtmux.Session.from_env>` returns — as long as it still holds the pane.
+Otherwise the window has moved on, and the server's answer wins.
+
 ## Filtering and finding objects
 
 Sometimes a property like {attr}`session.windows <libtmux.Session.windows>`

--- a/src/libtmux/exc.py
+++ b/src/libtmux/exc.py
@@ -88,8 +88,12 @@ class NotInsideTmux(LibTmuxException):
 
     tmux exports ``TMUX`` and ``TMUX_PANE`` into the environment of every
     process it spawns inside a pane. When either is absent there is no pane to
-    resolve, so :meth:`Server.from_env` and :meth:`Pane.from_env` raise rather
-    than guess a server or pane the caller does not belong to.
+    resolve, so the ``from_env`` constructors --
+    :meth:`Server.from_env() <libtmux.Server.from_env>`,
+    :meth:`Session.from_env() <libtmux.Session.from_env>`,
+    :meth:`Window.from_env() <libtmux.Window.from_env>` and
+    :meth:`Pane.from_env() <libtmux.Pane.from_env>` -- raise rather than guess
+    a server or pane the caller does not belong to.
 
     .. versionadded:: 0.62
     """
@@ -216,7 +220,7 @@ class WindowAdjustmentDirectionRequiresAdjustment(
     WindowError,
     AdjustmentDirectionRequiresAdjustment,
 ):
-    """ValueError for :meth:`libtmux.Window.resize_window`."""
+    """ValueError for :meth:`libtmux.Window.resize`."""
 
 
 class PaneAdjustmentDirectionRequiresAdjustment(

--- a/src/libtmux/exc.py
+++ b/src/libtmux/exc.py
@@ -87,13 +87,12 @@ class NotInsideTmux(LibTmuxException):
     """Raised when this process is not running inside a :term:`tmux(1)` pane.
 
     tmux exports ``TMUX`` and ``TMUX_PANE`` into the environment of every
-    process it spawns inside a pane. When either is absent there is no pane to
-    resolve, so the ``from_env`` constructors --
-    :meth:`Server.from_env() <libtmux.Server.from_env>`,
-    :meth:`Session.from_env() <libtmux.Session.from_env>`,
+    process it spawns inside a pane. The ``from_env`` constructors read them
+    back, and raise rather than guess a server or pane the caller does not
+    belong to. :meth:`Server.from_env() <libtmux.Server.from_env>` needs only
+    ``TMUX``; :meth:`Session.from_env() <libtmux.Session.from_env>`,
     :meth:`Window.from_env() <libtmux.Window.from_env>` and
-    :meth:`Pane.from_env() <libtmux.Pane.from_env>` -- raise rather than guess
-    a server or pane the caller does not belong to.
+    :meth:`Pane.from_env() <libtmux.Pane.from_env>` need ``TMUX_PANE`` as well.
 
     .. versionadded:: 0.62
     """

--- a/src/libtmux/exc.py
+++ b/src/libtmux/exc.py
@@ -83,6 +83,18 @@ class TmuxCommandNotFound(LibTmuxException):
     """Application binary for tmux not found."""
 
 
+class NotInsideTmux(LibTmuxException):
+    """Raised when this process is not running inside a :term:`tmux(1)` pane.
+
+    tmux exports ``TMUX`` and ``TMUX_PANE`` into the environment of every
+    process it spawns inside a pane. When either is absent there is no pane to
+    resolve, so :meth:`Server.from_env` and :meth:`Pane.from_env` raise rather
+    than guess a server or pane the caller does not belong to.
+
+    .. versionadded:: 0.62
+    """
+
+
 class TmuxObjectDoesNotExist(ObjectDoesNotExist):
     """The query returned multiple objects when only one was expected."""
 

--- a/src/libtmux/pane.py
+++ b/src/libtmux/pane.py
@@ -258,7 +258,15 @@ class Pane(
 
     @property
     def session(self) -> Session:
-        """Parent session of pane."""
+        """Parent session of pane.
+
+        Notes
+        -----
+        Resolved through :attr:`window` — two tmux round-trips — rather than
+        from this pane's ``session_id``. A pane's ``session_id`` goes stale the
+        moment its window moves to another session, so the window is looked up
+        live and asked which session holds it *now*.
+        """
         return self.window.session
 
     """

--- a/src/libtmux/pane.py
+++ b/src/libtmux/pane.py
@@ -277,9 +277,8 @@ class Pane(
         Notes
         -----
         Resolved through :attr:`window` — two tmux round-trips — rather than
-        from this pane's ``session_id``. A pane's ``session_id`` goes stale the
-        moment its window moves to another session, so the window is looked up
-        live and asked which session holds it *now*.
+        from this pane's ``session_id``, which goes stale the moment its window
+        moves to another session.
         """
         return self.window.session
 

--- a/src/libtmux/pane.py
+++ b/src/libtmux/pane.py
@@ -46,6 +46,34 @@ if t.TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _caller_pane_id(environ: t.Mapping[str, str]) -> str:
+    """Return the pane id tmux gave this process, from ``TMUX_PANE``.
+
+    Shared by the ``from_env`` constructors, which all anchor on the caller's
+    pane: it is the one identifier tmux keeps answering for live.
+
+    Parameters
+    ----------
+    environ : Mapping[str, str]
+        Environment to read.
+
+    Returns
+    -------
+    str
+        The pane id, e.g. ``"%1"``.
+
+    Raises
+    ------
+    :exc:`libtmux.exc.NotInsideTmux`
+        When ``TMUX_PANE`` is unset.
+    """
+    pane_id = environ.get("TMUX_PANE")
+    if not pane_id:
+        msg = "Not inside a tmux pane: TMUX_PANE is unset"
+        raise exc.NotInsideTmux(msg)
+    return pane_id
+
+
 @dataclasses.dataclass()
 class Pane(
     Obj,
@@ -215,12 +243,7 @@ class Pane(
         environ: t.Mapping[str, str] = os.environ if env is None else env
         server = Server.from_env(environ)
 
-        pane_id = environ.get("TMUX_PANE")
-        if not pane_id:
-            msg = "Not inside a tmux pane: TMUX_PANE is unset"
-            raise exc.NotInsideTmux(msg)
-
-        return cls.from_pane_id(server=server, pane_id=pane_id)
+        return cls.from_pane_id(server=server, pane_id=_caller_pane_id(environ))
 
     #
     # Relations

--- a/src/libtmux/pane.py
+++ b/src/libtmux/pane.py
@@ -212,6 +212,20 @@ class Pane(
         :exc:`libtmux.exc.NotInsideTmux`
             When ``TMUX`` or ``TMUX_PANE`` is unset, i.e. this process is not
             inside a pane.
+        :exc:`libtmux.exc.TmuxObjectDoesNotExist`
+            When the server has no pane named by ``TMUX_PANE``, i.e. the
+            caller's pane is gone.
+
+        See Also
+        --------
+        :meth:`Window.from_env` : the window containing this pane.
+        :meth:`Session.from_env` : the session containing this pane.
+
+        Notes
+        -----
+        The server comes from :meth:`Server.from_env`, with no keyword arguments.
+        For ``config_file`` or ``colors``, build it and pass it to
+        :meth:`Pane.from_pane_id`.
 
         Examples
         --------

--- a/src/libtmux/pane.py
+++ b/src/libtmux/pane.py
@@ -66,6 +66,16 @@ def _caller_pane_id(environ: t.Mapping[str, str]) -> str:
     ------
     :exc:`libtmux.exc.NotInsideTmux`
         When ``TMUX_PANE`` is unset.
+
+    Examples
+    --------
+    >>> _caller_pane_id({"TMUX_PANE": "%1"})
+    '%1'
+
+    >>> _caller_pane_id({})
+    Traceback (most recent call last):
+    ...
+    libtmux.exc.NotInsideTmux: Not inside a tmux pane: TMUX_PANE is unset
     """
     pane_id = environ.get("TMUX_PANE")
     if not pane_id:

--- a/src/libtmux/pane.py
+++ b/src/libtmux/pane.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import dataclasses
 import logging
+import os
 import pathlib
 import typing as t
 import warnings
@@ -159,6 +160,67 @@ class Pane(
             list_extra_args=("-a",),
         )
         return cls(server=server, **pane)
+
+    @classmethod
+    def from_env(cls, env: t.Mapping[str, str] | None = None) -> Pane:
+        """Return the :class:`Pane` this process is running inside.
+
+        tmux exports ``TMUX_PANE`` into every pane it spawns, alongside the
+        ``TMUX`` variable that names the server. Together they identify the
+        caller's own pane without searching for it.
+
+        Parameters
+        ----------
+        env : Mapping[str, str], optional
+            Environment to read. Defaults to :data:`os.environ`.
+
+        Returns
+        -------
+        :class:`Pane`
+            The pane named by ``TMUX_PANE``, on the server named by ``TMUX``.
+
+        Raises
+        ------
+        :exc:`libtmux.exc.NotInsideTmux`
+            When ``TMUX`` or ``TMUX_PANE`` is unset, i.e. this process is not
+            inside a pane.
+
+        Examples
+        --------
+        A pane can recognize itself from the environment tmux gave it:
+
+        >>> socket_path = server.cmd(
+        ...     "display-message", "-p", "-t", session.session_id, "#{socket_path}"
+        ... ).stdout[0]
+        >>> caller = Pane.from_env(
+        ...     {
+        ...         "TMUX": f"{socket_path},1,{session.session_id}",
+        ...         "TMUX_PANE": pane.pane_id,
+        ...     }
+        ... )
+        >>> caller.pane_id == pane.pane_id
+        True
+
+        Outside of tmux there is no pane to resolve:
+
+        >>> Pane.from_env({})
+        Traceback (most recent call last):
+        ...
+        libtmux.exc.NotInsideTmux: Not inside a tmux pane: TMUX is unset
+
+        .. versionadded:: 0.62
+        """
+        from libtmux.server import Server
+
+        environ: t.Mapping[str, str] = os.environ if env is None else env
+        server = Server.from_env(environ)
+
+        pane_id = environ.get("TMUX_PANE")
+        if not pane_id:
+            msg = "Not inside a tmux pane: TMUX_PANE is unset"
+            raise exc.NotInsideTmux(msg)
+
+        return cls.from_pane_id(server=server, pane_id=pane_id)
 
     #
     # Relations

--- a/src/libtmux/server.py
+++ b/src/libtmux/server.py
@@ -218,7 +218,8 @@ class Server(
         env : Mapping[str, str], optional
             Environment to read. Defaults to :data:`os.environ`.
         **kwargs : Any
-            Passed through to :class:`Server`.
+            Passed through to :class:`Server`, e.g. ``config_file`` or
+            ``colors``. ``socket_path`` is taken from ``TMUX``.
 
         Returns
         -------
@@ -229,6 +230,21 @@ class Server(
         ------
         :exc:`libtmux.exc.NotInsideTmux`
             When ``TMUX`` is unset, i.e. this process is not inside a pane.
+
+        See Also
+        --------
+        :meth:`Pane.from_env` : the pane on this server the caller is in.
+        :meth:`Window.from_env` : the window the caller is in.
+        :meth:`Session.from_env` : the session the caller is in.
+
+        Notes
+        -----
+        :meth:`Session.from_env`, :meth:`Window.from_env` and
+        :meth:`Pane.from_env` resolve their server by calling this with the
+        environment alone, so there is no way to inject server keyword
+        arguments through them. When they are needed, build the server here and
+        hand it to :meth:`Pane.from_pane_id`, :meth:`Window.from_window_id` or
+        :meth:`Session.from_session_id`.
 
         Examples
         --------

--- a/src/libtmux/server.py
+++ b/src/libtmux/server.py
@@ -198,6 +198,63 @@ class Server(
         if on_init is not None:
             on_init(self)
 
+    @classmethod
+    def from_env(
+        cls,
+        env: t.Mapping[str, str] | None = None,
+        **kwargs: t.Any,
+    ) -> Server:
+        """Return the :class:`Server` this process is running inside.
+
+        tmux exports ``TMUX`` into every pane it spawns, formatted as
+        ``socket_path,server_pid,session_id``. The socket path is
+        authoritative: it names the server directly, so it sidesteps ``-L``
+        name resolution and the ``TMUX_TMPDIR`` differences between platforms.
+
+        Runs no tmux command.
+
+        Parameters
+        ----------
+        env : Mapping[str, str], optional
+            Environment to read. Defaults to :data:`os.environ`.
+        **kwargs : Any
+            Passed through to :class:`Server`.
+
+        Returns
+        -------
+        :class:`Server`
+            Bound to the socket named by ``TMUX``.
+
+        Raises
+        ------
+        :exc:`libtmux.exc.NotInsideTmux`
+            When ``TMUX`` is unset, i.e. this process is not inside a pane.
+
+        Examples
+        --------
+        >>> from libtmux.server import Server
+
+        >>> Server.from_env({"TMUX": "/tmp/tmux-1000/default,123,$0"})
+        Server(socket_path=/tmp/tmux-1000/default)
+
+        Outside of tmux there is no server to resolve:
+
+        >>> Server.from_env({})
+        Traceback (most recent call last):
+        ...
+        libtmux.exc.NotInsideTmux: Not inside a tmux pane: TMUX is unset
+
+        .. versionadded:: 0.62
+        """
+        environ: t.Mapping[str, str] = os.environ if env is None else env
+        tmux = environ.get("TMUX")
+        if not tmux:
+            msg = "Not inside a tmux pane: TMUX is unset"
+            raise exc.NotInsideTmux(msg)
+
+        socket_path = tmux.split(",", 1)[0]
+        return cls(socket_path=socket_path, **kwargs)
+
     def __enter__(self) -> Self:
         """Enter the context, returning self.
 

--- a/src/libtmux/server.py
+++ b/src/libtmux/server.py
@@ -268,7 +268,9 @@ class Server(
             msg = "Not inside a tmux pane: TMUX is unset"
             raise exc.NotInsideTmux(msg)
 
-        socket_path = tmux.split(",", 1)[0]
+        # Split from the right: the pid and session id are integers, so a comma
+        # in ``TMUX`` can only ever belong to the socket path.
+        socket_path = tmux.rsplit(",", 2)[0]
         return cls(socket_path=socket_path, **kwargs)
 
     def __enter__(self) -> Self:

--- a/src/libtmux/server.py
+++ b/src/libtmux/server.py
@@ -189,16 +189,6 @@ class Server(
         elif socket_name_factory is not None:
             self.socket_name = socket_name_factory()
 
-        tmux_tmpdir = pathlib.Path(os.getenv("TMUX_TMPDIR", "/tmp"))
-        socket_name = self.socket_name or "default"
-        if (
-            tmux_tmpdir is not None
-            and self.socket_path is None
-            and self.socket_name is None
-            and socket_name != "default"
-        ):
-            self.socket_path = str(tmux_tmpdir / f"tmux-{os.geteuid()}" / socket_name)
-
         if config_file:
             self.config_file = config_file
 

--- a/src/libtmux/session.py
+++ b/src/libtmux/session.py
@@ -304,7 +304,11 @@ class Session(
         server = Server.from_env(environ)
         pane_id = _caller_pane_id(environ)
 
-        holding = server.panes.filter(pane_id=pane_id)
+        holding = [
+            pane.session_id
+            for pane in server.panes.filter(pane_id=pane_id)
+            if pane.session_id is not None
+        ]
         if not holding:
             raise exc.TmuxObjectDoesNotExist(
                 obj_key="pane_id",
@@ -313,10 +317,8 @@ class Session(
                 list_extra_args=("-a",),
             )
 
-        session_ids = [pane.session_id for pane in holding]
         spawned_in = _spawn_session_id(environ)
-        session_id = spawned_in if spawned_in in session_ids else session_ids[-1]
-        assert isinstance(session_id, str)
+        session_id = spawned_in if spawned_in in holding else holding[-1]
 
         return cls.from_session_id(server=server, session_id=session_id)
 

--- a/src/libtmux/session.py
+++ b/src/libtmux/session.py
@@ -75,7 +75,9 @@ def _spawn_session_id(environ: t.Mapping[str, str]) -> str | None:
     if not tmux:
         return None
 
-    fields = tmux.split(",")
+    # Split from the right: the pid and session id are integers, so a comma in
+    # ``TMUX`` can only ever belong to the socket path.
+    fields = tmux.rsplit(",", 2)
     if len(fields) < 3:
         return None
 

--- a/src/libtmux/session.py
+++ b/src/libtmux/session.py
@@ -76,9 +76,12 @@ def _spawn_session_id(environ: t.Mapping[str, str]) -> str | None:
     >>> _spawn_session_id({"TMUX": "/tmp/tmux-1000/default,123,47"})
     '$47'
 
-    A pane spawned without a session, and a process outside tmux entirely:
+    A pane spawned without a session, a truncated ``TMUX``, and a process
+    outside tmux entirely:
 
     >>> _spawn_session_id({"TMUX": "/tmp/tmux-1000/default,123,-1"}) is None
+    True
+    >>> _spawn_session_id({"TMUX": "/tmp/tmux-1000/default,123"}) is None
     True
     >>> _spawn_session_id({}) is None
     True

--- a/src/libtmux/session.py
+++ b/src/libtmux/session.py
@@ -261,6 +261,8 @@ class Session(
             When the server named by ``TMUX`` is no longer running. Its pane
             listing is empty either way, so it is asked whether it is alive
             rather than reporting the caller's pane as gone.
+        :exc:`libtmux.exc.TmuxCommandNotFound`
+            When that liveness check cannot run the tmux binary at all.
 
         See Also
         --------

--- a/src/libtmux/session.py
+++ b/src/libtmux/session.py
@@ -243,6 +243,10 @@ class Session(
             When the server has no pane named by ``TMUX_PANE``, i.e. the
             caller's pane is gone. No pane means no session to claim; the stale
             id in ``TMUX`` is not a fallback.
+        :class:`subprocess.CalledProcessError`
+            When the server named by ``TMUX`` is no longer running. Its pane
+            listing is empty either way, so it is asked whether it is alive
+            rather than reporting the caller's pane as gone.
 
         See Also
         --------
@@ -310,6 +314,7 @@ class Session(
             if pane.session_id is not None
         ]
         if not holding:
+            server.raise_if_dead()  # a dead server is not a missing pane
             raise exc.TmuxObjectDoesNotExist(
                 obj_key="pane_id",
                 obj_id=pane_id,

--- a/src/libtmux/session.py
+++ b/src/libtmux/session.py
@@ -70,6 +70,18 @@ def _spawn_session_id(environ: t.Mapping[str, str]) -> str | None:
     str or None
         The session id as libtmux spells it, or None when ``TMUX`` is absent,
         malformed, or names no session.
+
+    Examples
+    --------
+    >>> _spawn_session_id({"TMUX": "/tmp/tmux-1000/default,123,47"})
+    '$47'
+
+    A pane spawned without a session, and a process outside tmux entirely:
+
+    >>> _spawn_session_id({"TMUX": "/tmp/tmux-1000/default,123,-1"}) is None
+    True
+    >>> _spawn_session_id({}) is None
+    True
     """
     tmux = environ.get("TMUX")
     if not tmux:

--- a/src/libtmux/session.py
+++ b/src/libtmux/session.py
@@ -239,6 +239,10 @@ class Session(
         :exc:`libtmux.exc.NotInsideTmux`
             When ``TMUX`` or ``TMUX_PANE`` is unset, i.e. this process is not
             inside a pane.
+        :exc:`libtmux.exc.TmuxObjectDoesNotExist`
+            When the server has no pane named by ``TMUX_PANE``, i.e. the
+            caller's pane is gone. No pane means no session to claim; the stale
+            id in ``TMUX`` is not a fallback.
 
         See Also
         --------
@@ -250,6 +254,10 @@ class Session(
         There is no ``Client.from_env``: tmux exports no client id into a pane's
         environment, and cannot -- a pane is not owned by a client. Zero clients
         may be attached, or several, each with its own view.
+
+        The server comes from :meth:`Server.from_env`, with no keyword arguments.
+        For ``config_file`` or ``colors``, build it and pass it to
+        :meth:`Session.from_session_id`.
 
         Examples
         --------

--- a/src/libtmux/session.py
+++ b/src/libtmux/session.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import dataclasses
 import logging
+import os
 import pathlib
 import typing as t
 import warnings
@@ -20,7 +21,7 @@ from libtmux.formats import FORMAT_SEPARATOR
 from libtmux.hooks import HooksMixin
 from libtmux.neo import Obj, fetch_obj, fetch_objs
 from libtmux.options import OptionsMixin
-from libtmux.pane import Pane
+from libtmux.pane import Pane, _caller_pane_id
 from libtmux.window import Window
 
 from . import exc
@@ -46,6 +47,47 @@ if t.TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
+
+
+def _spawn_session_id(environ: t.Mapping[str, str]) -> str | None:
+    """Return the session id frozen into ``TMUX`` when the pane was spawned.
+
+    tmux writes ``TMUX`` as ``socket_path,server_pid,session_id`` and spells the
+    session id bare -- ``47``, where libtmux spells the same session ``$47``. A
+    pane spawned without a session carries ``-1``.
+
+    This is *provenance*, not location: tmux never rewrites a live process's
+    environment, so the id goes stale the moment the pane's window is moved. It
+    is only good for choosing between sessions that genuinely hold the pane.
+
+    Parameters
+    ----------
+    environ : Mapping[str, str]
+        Environment to read.
+
+    Returns
+    -------
+    str or None
+        The session id as libtmux spells it, or None when ``TMUX`` is absent,
+        malformed, or names no session.
+    """
+    tmux = environ.get("TMUX")
+    if not tmux:
+        return None
+
+    fields = tmux.split(",")
+    if len(fields) < 3:
+        return None
+
+    try:
+        session_number = int(fields[2].removeprefix("$"))
+    except ValueError:
+        return None
+
+    if session_number < 0:  # tmux writes -1 when there is no session
+        return None
+
+    return f"${session_number}"
 
 
 @dataclasses.dataclass()
@@ -159,6 +201,116 @@ class Session(
             server=server,
         )
         return cls(server=server, **session)
+
+    @classmethod
+    def from_env(cls, env: t.Mapping[str, str] | None = None) -> Session:
+        """Return the :class:`Session` this process is running inside.
+
+        The live server decides, and ``TMUX`` only breaks ties.
+
+        tmux writes ``TMUX`` and ``TMUX_PANE`` into a pane's environment when it
+        spawns the pane, and never rewrites them. So the session id inside
+        ``TMUX`` goes stale the moment the pane's window is moved elsewhere
+        (``move-window``), and asking the server which session holds
+        ``TMUX_PANE`` is the only way to stay right.
+
+        That answer is not always unique. ``link-window`` puts one window in
+        several sessions at once, and then the pane genuinely belongs to all of
+        them -- tmux lists it once per session, ordered by session *name*, so
+        picking from the listing alone would answer with whichever session
+        happens to sort last. Here the stale id earns its keep: it records the
+        session the process was *spawned* under, so when that session still
+        holds the pane, it is the one the caller can claim. Otherwise the window
+        has moved on, and the server's answer wins.
+
+        Parameters
+        ----------
+        env : Mapping[str, str], optional
+            Environment to read. Defaults to :data:`os.environ`.
+
+        Returns
+        -------
+        :class:`Session`
+            The session holding the pane named by ``TMUX_PANE``; where several
+            do, the one named by ``TMUX``.
+
+        Raises
+        ------
+        :exc:`libtmux.exc.NotInsideTmux`
+            When ``TMUX`` or ``TMUX_PANE`` is unset, i.e. this process is not
+            inside a pane.
+
+        See Also
+        --------
+        :meth:`Pane.from_env` : the pane this session is resolved from.
+        :meth:`Window.from_env` : the window between the two.
+
+        Notes
+        -----
+        There is no ``Client.from_env``: tmux exports no client id into a pane's
+        environment, and cannot -- a pane is not owned by a client. Zero clients
+        may be attached, or several, each with its own view.
+
+        Examples
+        --------
+        A process can name the session it is running in:
+
+        >>> socket_path = server.cmd(
+        ...     "display-message", "-p", "-t", session.session_id, "#{socket_path}"
+        ... ).stdout[0]
+        >>> env = {
+        ...     "TMUX": f"{socket_path},1,{session.session_id}",
+        ...     "TMUX_PANE": pane.pane_id,
+        ... }
+        >>> Session.from_env(env).session_id == session.session_id
+        True
+
+        tmux spells that id bare in ``TMUX`` -- ``1``, not ``$1`` -- and either
+        is understood:
+
+        >>> bare = session.session_id.removeprefix("$")
+        >>> env["TMUX"] = f"{socket_path},1,{bare}"
+        >>> Session.from_env(env).session_id == session.session_id
+        True
+
+        A session id in ``TMUX`` that no longer holds the pane is ignored; the
+        server is what knows:
+
+        >>> env["TMUX"] = f"{socket_path},1,999"
+        >>> Session.from_env(env).session_id == session.session_id
+        True
+
+        Outside of tmux there is no session to resolve:
+
+        >>> Session.from_env({})
+        Traceback (most recent call last):
+        ...
+        libtmux.exc.NotInsideTmux: Not inside a tmux pane: TMUX is unset
+
+        .. versionadded:: 0.62
+        """
+        environ: t.Mapping[str, str] = os.environ if env is None else env
+
+        from libtmux.server import Server
+
+        server = Server.from_env(environ)
+        pane_id = _caller_pane_id(environ)
+
+        holding = server.panes.filter(pane_id=pane_id)
+        if not holding:
+            raise exc.TmuxObjectDoesNotExist(
+                obj_key="pane_id",
+                obj_id=pane_id,
+                list_cmd="list-panes",
+                list_extra_args=("-a",),
+            )
+
+        session_ids = [pane.session_id for pane in holding]
+        spawned_in = _spawn_session_id(environ)
+        session_id = spawned_in if spawned_in in session_ids else session_ids[-1]
+        assert isinstance(session_id, str)
+
+        return cls.from_session_id(server=server, session_id=session_id)
 
     #
     # Relations

--- a/src/libtmux/window.py
+++ b/src/libtmux/window.py
@@ -251,10 +251,7 @@ class Window(
 
         .. versionadded:: 0.62
         """
-        pane = Pane.from_env(env)
-        assert isinstance(pane.window_id, str)
-
-        return cls.from_window_id(server=pane.server, window_id=pane.window_id)
+        return Pane.from_env(env).window
 
     @property
     def session(self) -> Session:

--- a/src/libtmux/window.py
+++ b/src/libtmux/window.py
@@ -202,11 +202,21 @@ class Window(
         :exc:`libtmux.exc.NotInsideTmux`
             When ``TMUX`` or ``TMUX_PANE`` is unset, i.e. this process is not
             inside a pane.
+        :exc:`libtmux.exc.TmuxObjectDoesNotExist`
+            When the server has no pane named by ``TMUX_PANE``, i.e. the
+            caller's pane is gone. The window is resolved through that pane, so
+            a pane that is gone takes its window with it.
 
         See Also
         --------
         :meth:`Pane.from_env` : the pane this window is resolved from.
         :meth:`Session.from_env` : the session containing this window.
+
+        Notes
+        -----
+        The server comes from :meth:`Server.from_env`, with no keyword arguments.
+        For ``config_file`` or ``colors``, build it and pass it to
+        :meth:`Window.from_window_id`.
 
         Examples
         --------

--- a/src/libtmux/window.py
+++ b/src/libtmux/window.py
@@ -206,6 +206,9 @@ class Window(
             When the server has no pane named by ``TMUX_PANE``, i.e. the
             caller's pane is gone. The window is resolved through that pane, so
             a pane that is gone takes its window with it.
+        ValueError
+            When the resolved pane carries no ``window_id``. Surfaces a clear
+            error under ``python -O``, where an ``assert`` would be stripped.
 
         See Also
         --------
@@ -251,7 +254,11 @@ class Window(
 
         .. versionadded:: 0.62
         """
-        return Pane.from_env(env).window
+        pane = Pane.from_env(env)
+        if pane.window_id is None:
+            msg = "Pane must have a window_id to resolve its window"
+            raise ValueError(msg)
+        return cls.from_window_id(server=pane.server, window_id=pane.window_id)
 
     @property
     def session(self) -> Session:

--- a/src/libtmux/window.py
+++ b/src/libtmux/window.py
@@ -178,6 +178,74 @@ class Window(
         )
         return cls(server=server, **window)
 
+    @classmethod
+    def from_env(cls, env: t.Mapping[str, str] | None = None) -> Window:
+        """Return the :class:`Window` this process is running inside.
+
+        The window *containing* the caller's pane, resolved through
+        ``TMUX_PANE`` -- not ``session.active_window``, which names whatever
+        window is focused, often somebody else's. Stays correct after the
+        window moves between sessions.
+
+        Parameters
+        ----------
+        env : Mapping[str, str], optional
+            Environment to read. Defaults to :data:`os.environ`.
+
+        Returns
+        -------
+        :class:`Window`
+            The window containing the pane named by ``TMUX_PANE``.
+
+        Raises
+        ------
+        :exc:`libtmux.exc.NotInsideTmux`
+            When ``TMUX`` or ``TMUX_PANE`` is unset, i.e. this process is not
+            inside a pane.
+
+        See Also
+        --------
+        :meth:`Pane.from_env` : the pane this window is resolved from.
+        :meth:`Session.from_env` : the session containing this window.
+
+        Examples
+        --------
+        A process can name the window it is running in:
+
+        >>> socket_path = server.cmd(
+        ...     "display-message", "-p", "-t", session.session_id, "#{socket_path}"
+        ... ).stdout[0]
+        >>> env = {
+        ...     "TMUX": f"{socket_path},1,{session.session_id}",
+        ...     "TMUX_PANE": pane.pane_id,
+        ... }
+        >>> Window.from_env(env).window_id == window.window_id
+        True
+
+        Focus is irrelevant. Push the caller's window into the background and
+        it still resolves to itself, not to whatever is active:
+
+        >>> session.new_window(attach=True)
+        Window(@... ...:..., Session($... ...))
+        >>> session.active_window.window_id == window.window_id
+        False
+        >>> Window.from_env(env).window_id == window.window_id
+        True
+
+        Outside of tmux there is no window to resolve:
+
+        >>> Window.from_env({})
+        Traceback (most recent call last):
+        ...
+        libtmux.exc.NotInsideTmux: Not inside a tmux pane: TMUX is unset
+
+        .. versionadded:: 0.62
+        """
+        pane = Pane.from_env(env)
+        assert isinstance(pane.window_id, str)
+
+        return cls.from_window_id(server=pane.server, window_id=pane.window_id)
+
     @property
     def session(self) -> Session:
         """Parent session of window."""

--- a/tests/test_pane.py
+++ b/tests/test_pane.py
@@ -12,11 +12,12 @@ import pytest
 from libtmux import exc
 from libtmux.common import has_gte_version
 from libtmux.constants import PaneDirection, ResizeAdjustmentDirection
+from libtmux.pane import Pane
 from libtmux.test.retry import retry_until
 
 if t.TYPE_CHECKING:
     from libtmux._internal.types import StrPath
-    from libtmux.pane import Pane
+    from libtmux.server import Server
     from libtmux.session import Session
 
 logger = logging.getLogger(__name__)
@@ -1878,3 +1879,49 @@ def test_new_pane_error_tags_subcommand(session: Session) -> None:
     else:
         with pytest.raises(exc.LibTmuxException, match=r"requires tmux 3.7"):
             pane.new_pane(target="%99999")
+
+
+def test_pane_from_env(server: Server, session: Session) -> None:
+    """:meth:`Pane.from_env` returns the pane named by ``$TMUX_PANE``."""
+    pane = session.active_window.active_pane
+    assert pane is not None
+
+    socket_path = server.cmd(
+        "display-message",
+        "-p",
+        "-t",
+        str(session.session_id),
+        "#{socket_path}",
+    ).stdout[0]
+    env = {
+        "TMUX": f"{socket_path},1,{session.session_id}",
+        "TMUX_PANE": str(pane.pane_id),
+    }
+
+    caller = Pane.from_env(env)
+
+    assert caller.pane_id == pane.pane_id
+    assert caller.window_id == pane.window_id
+    assert caller.session_id == pane.session_id
+
+
+def test_pane_from_env_outside_tmux(monkeypatch: pytest.MonkeyPatch) -> None:
+    """:meth:`Pane.from_env` raises when ``$TMUX`` is unset."""
+    monkeypatch.delenv("TMUX", raising=False)
+    monkeypatch.delenv("TMUX_PANE", raising=False)
+
+    with pytest.raises(exc.NotInsideTmux):
+        Pane.from_env()
+
+
+def test_pane_from_env_without_pane_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    """:meth:`Pane.from_env` raises when ``$TMUX_PANE`` is unset.
+
+    ``$TMUX`` alone identifies the server but not the pane: tmux only exports
+    ``TMUX_PANE`` into a pane's own process environment.
+    """
+    monkeypatch.setenv("TMUX", "/tmp/libtmux-test/default,1234,$0")
+    monkeypatch.delenv("TMUX_PANE", raising=False)
+
+    with pytest.raises(exc.NotInsideTmux):
+        Pane.from_env()

--- a/tests/test_pane.py
+++ b/tests/test_pane.py
@@ -1925,3 +1925,114 @@ def test_pane_from_env_without_pane_id(monkeypatch: pytest.MonkeyPatch) -> None:
 
     with pytest.raises(exc.NotInsideTmux):
         Pane.from_env()
+
+
+def _tmux_env(server: Server, session: Session, pane: Pane) -> dict[str, str]:
+    """Build the environment tmux exports into ``pane``.
+
+    ``$TMUX`` is ``socket_path,server_pid,session_id``. :meth:`Server.from_env`
+    reads only the socket path, so the trailing fields are inert here.
+    """
+    socket_path = server.cmd(
+        "display-message",
+        "-p",
+        "-t",
+        str(session.session_id),
+        "#{socket_path}",
+    ).stdout[0]
+    return {
+        "TMUX": f"{socket_path},1,{session.session_id}",
+        "TMUX_PANE": str(pane.pane_id),
+    }
+
+
+def test_pane_from_env_window_is_containing_window(
+    server: Server,
+    session: Session,
+) -> None:
+    """:attr:`Pane.window` off ``from_env()`` is the *containing* window.
+
+    Not the session's active window: the pane under test sits in a background
+    window, so an implementation that reached for ``session.active_window``
+    would resolve the wrong object.
+    """
+    original = session.active_window
+    background = session.new_window(window_name="background", attach=False)
+    original.select()  # keep the original window active
+
+    pane = background.active_pane
+    assert pane is not None
+
+    active_window = session.active_window
+    assert active_window.window_id != background.window_id, (
+        "precondition: the pane's window must not be the session's active window"
+    )
+
+    caller = Pane.from_env(_tmux_env(server, session, pane))
+
+    assert caller.window.window_id == background.window_id
+    assert caller.window.window_id != active_window.window_id
+    assert caller.session.session_id == session.session_id
+
+
+def test_pane_from_env_traversal_survives_move_window(
+    server: Server,
+    session: Session,
+) -> None:
+    """Traversal reads live containment, even when ``$TMUX`` has gone stale.
+
+    tmux freezes ``$TMUX`` into a pane's environment when it spawns the pane and
+    never updates it, so the session id inside ``$TMUX`` is stale the moment the
+    pane's window moves to another session. Walking up from the live pane is
+    immune to that: the pane, not the environment, is the source of truth.
+    """
+    window = session.new_window(window_name="from-env-mover", attach=False)
+    pane = window.active_pane
+    assert pane is not None
+
+    env = _tmux_env(server, session, pane)
+
+    destination = server.new_session(session_name="from-env-destination")
+    window.move_window(session=str(destination.session_id), no_select=True)
+
+    # The environment tmux handed the pane still names the *origin* session.
+    assert env["TMUX"].endswith(f",{session.session_id}")
+    assert session.session_id != destination.session_id
+
+    caller = Pane.from_env(env)
+
+    # Ground truth: the pane now lives under ``destination``.
+    assert caller.session.session_id == destination.session_id
+    assert caller.session.session_name == "from-env-destination"
+
+    # ...in the window it always lived in, which is *not* ``destination``'s
+    # active window (``no_select=True`` left the original one selected).
+    assert caller.window.window_id == window.window_id
+    assert destination.active_window.window_id != window.window_id
+
+
+def test_pane_session_resolves_through_live_window(
+    server: Server,
+    session: Session,
+) -> None:
+    """:attr:`Pane.session` resolves through the window, not a cached id.
+
+    A :class:`Pane` carries the ``session_id`` it held when it was fetched. Move
+    its window and that field goes stale, while ``pane.session`` — which re-reads
+    the window from tmux — still lands on the containing session. Resolving
+    :attr:`Pane.session` from ``self.session_id`` would save a subprocess and
+    return the wrong session here.
+    """
+    window = session.new_window(window_name="stale-holder", attach=False)
+    pane = window.active_pane
+    assert pane is not None
+    assert pane.session_id == session.session_id
+
+    destination = server.new_session(session_name="stale-destination")
+    window.move_window(session=str(destination.session_id), no_select=True)
+
+    # The already-fetched Pane still carries the origin session's id.
+    assert pane.session_id == session.session_id
+
+    assert pane.session.session_id == destination.session_id
+    assert pane.window.session_id == destination.session_id

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1766,3 +1766,38 @@ def test_socket_path_not_derived_from_socket_name() -> None:
     assert Server(socket_name="libtmux_test_no_derive").socket_name == (
         "libtmux_test_no_derive"
     )
+
+
+def test_server_from_env(server: Server, session: Session) -> None:
+    """:meth:`Server.from_env` targets the socket named by ``$TMUX``."""
+    socket_path = server.cmd(
+        "display-message",
+        "-p",
+        "-t",
+        str(session.session_id),
+        "#{socket_path}",
+    ).stdout[0]
+
+    caller = Server.from_env({"TMUX": f"{socket_path},1,{session.session_id}"})
+
+    assert caller.socket_path == socket_path
+    assert caller.is_alive()
+    assert session.session_id in [s.session_id for s in caller.sessions]
+
+
+def test_server_from_env_reads_os_environ(monkeypatch: pytest.MonkeyPatch) -> None:
+    """:meth:`Server.from_env` falls back to :data:`os.environ`."""
+    monkeypatch.setenv("TMUX", "/tmp/libtmux-test/default,1234,$0")
+
+    assert Server.from_env().socket_path == "/tmp/libtmux-test/default"
+
+
+def test_server_from_env_outside_tmux(monkeypatch: pytest.MonkeyPatch) -> None:
+    """:meth:`Server.from_env` raises when ``$TMUX`` is unset."""
+    monkeypatch.delenv("TMUX", raising=False)
+
+    with pytest.raises(exc.NotInsideTmux):
+        Server.from_env()
+
+    with pytest.raises(exc.NotInsideTmux):
+        Server.from_env({})

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1752,3 +1752,17 @@ def test_server_display_message_warns_on_tmux_error(
     """
     with pytest.warns(UserWarning, match="only one of -F or argument"):
         server.display_message("x", get_text=True, format_string="#{version}")
+
+
+def test_socket_path_not_derived_from_socket_name() -> None:
+    """``socket_path`` stays unset unless the caller supplies it.
+
+    tmux resolves a ``-L`` socket name on its own, so libtmux must not guess
+    a path for it: setting both would emit ``-L`` *and* ``-S``, targeting the
+    server twice.
+    """
+    assert Server().socket_path is None
+    assert Server(socket_name="libtmux_test_no_derive").socket_path is None
+    assert Server(socket_name="libtmux_test_no_derive").socket_name == (
+        "libtmux_test_no_derive"
+    )

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import pathlib
 import shutil
+import subprocess
 import typing as t
 from contextlib import nullcontext as does_not_raise
 
@@ -985,3 +986,41 @@ def test_session_from_env_unusable_spawn_id_defers_to_server(
     }
 
     assert Session.from_env(env).session_id == session.session_id
+
+
+def test_session_from_env_missing_pane(server: Server, session: Session) -> None:
+    """A pane that is not on the server is reported as missing.
+
+    The server is alive, so the liveness check passes through and the caller
+    learns the truth: there is no such pane, and therefore no session to claim.
+    """
+    socket_path = server.cmd(
+        "display-message",
+        "-p",
+        "-t",
+        str(session.session_id),
+        "#{socket_path}",
+    ).stdout[0]
+    env = {
+        "TMUX": f"{socket_path},1,{session.session_id}",
+        "TMUX_PANE": "%99999",
+    }
+
+    with pytest.raises(exc.TmuxObjectDoesNotExist):
+        Session.from_env(env)
+
+
+def test_session_from_env_dead_server(tmp_path: pathlib.Path) -> None:
+    """A dead server is reported as dead, not as a missing pane.
+
+    ``Server.panes`` is lenient and hands back an empty list whether the pane
+    is gone or the server is, so the empty result is not enough to answer with.
+    Asking the server whether it is alive is what keeps the two apart.
+    """
+    env = {
+        "TMUX": f"{tmp_path / 'no_server'},1,0",
+        "TMUX_PANE": "%1",
+    }
+
+    with pytest.raises(subprocess.CalledProcessError):
+        Session.from_env(env)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -946,3 +946,42 @@ def test_session_from_env_accepts_bare_session_id(
     }
 
     assert Session.from_env(env).session_id == session.session_id
+
+
+@pytest.mark.parametrize(
+    "spawn_field",
+    [
+        pytest.param("-1", id="no-session-at-spawn"),
+        pytest.param("999", id="session-since-killed"),
+        pytest.param("wat", id="not-a-number"),
+        pytest.param("", id="empty"),
+    ],
+)
+def test_session_from_env_unusable_spawn_id_defers_to_server(
+    server: Server,
+    session: Session,
+    spawn_field: str,
+) -> None:
+    """An unusable id in ``$TMUX`` is ignored; the server still knows.
+
+    ``TMUX`` only ever breaks a tie between sessions that genuinely hold the
+    pane. When it names nothing usable -- tmux writes ``-1`` for a pane spawned
+    without a session, and the id it does write goes stale -- there is no tie to
+    break, and the session holding the pane is the answer.
+    """
+    pane = session.active_window.active_pane
+    assert pane is not None
+
+    socket_path = server.cmd(
+        "display-message",
+        "-p",
+        "-t",
+        str(session.session_id),
+        "#{socket_path}",
+    ).stdout[0]
+    env = {
+        "TMUX": f"{socket_path},1,{spawn_field}",
+        "TMUX_PANE": str(pane.pane_id),
+    }
+
+    assert Session.from_env(env).session_id == session.session_id

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -782,3 +782,167 @@ def test_kill_session_group(server: Server) -> None:
     else:
         with pytest.warns(UserWarning, match="group requires tmux 3.7"):
             session.kill(group=True)
+
+
+def test_session_from_env(server: Server, session: Session) -> None:
+    """:meth:`Session.from_env` returns the session containing the caller's pane."""
+    pane = session.active_window.active_pane
+    assert pane is not None
+
+    socket_path = server.cmd(
+        "display-message",
+        "-p",
+        "-t",
+        str(session.session_id),
+        "#{socket_path}",
+    ).stdout[0]
+    env = {
+        "TMUX": f"{socket_path},1,{session.session_id}",
+        "TMUX_PANE": str(pane.pane_id),
+    }
+
+    caller = Session.from_env(env)
+
+    assert caller.session_id == session.session_id
+    assert caller.server.socket_path == socket_path
+
+
+def test_session_from_env_after_move_window(server: Server, session: Session) -> None:
+    """:meth:`Session.from_env` follows the pane, not the id frozen into ``$TMUX``.
+
+    tmux writes ``TMUX`` (``socket_path,server_pid,session_id``) into a pane's
+    environment when it spawns the pane and never rewrites it. Move the pane's
+    window to another session and ``$TMUX`` still names the old one. Resolving
+    through ``TMUX_PANE`` -- which tmux answers for live -- is what keeps the
+    answer right.
+    """
+    origin = session
+    pane = origin.active_window.active_pane
+    assert pane is not None
+    window = pane.window
+
+    socket_path = server.cmd(
+        "display-message",
+        "-p",
+        "-t",
+        str(origin.session_id),
+        "#{socket_path}",
+    ).stdout[0]
+    env = {
+        "TMUX": f"{socket_path},1,{origin.session_id}",
+        "TMUX_PANE": str(pane.pane_id),
+    }
+
+    # Keep ``origin`` alive past the move: a session with no windows is
+    # destroyed, and an implementation that trusted ``$TMUX`` would then fail
+    # loudly rather than answer wrongly. The dangerous case is the quiet one.
+    origin.new_window(window_name="from_env_origin_keepalive")
+
+    destination = server.new_session(session_name="from_env_destination")
+    window.move_window(session=str(destination.session_id), no_select=True)
+
+    # Ground truth: tmux says the pane now lives in ``destination``.
+    pane.refresh()
+    assert pane.session_id == destination.session_id
+    # ...while the environment the pane was spawned with still names ``origin``,
+    # which is alive and would be returned by anything that parsed ``$TMUX``.
+    assert env["TMUX"].endswith(f",{origin.session_id}")
+    assert server.has_session(str(origin.session_name))
+
+    assert Session.from_env(env).session_id == destination.session_id
+    assert Session.from_env(env).session_id != origin.session_id
+
+
+def test_session_from_env_outside_tmux(monkeypatch: pytest.MonkeyPatch) -> None:
+    """:meth:`Session.from_env` raises when ``$TMUX`` or ``$TMUX_PANE`` is unset."""
+    monkeypatch.delenv("TMUX", raising=False)
+    monkeypatch.delenv("TMUX_PANE", raising=False)
+
+    with pytest.raises(exc.NotInsideTmux):
+        Session.from_env()
+
+    with pytest.raises(exc.NotInsideTmux):
+        Session.from_env({})
+
+    monkeypatch.setenv("TMUX", "/tmp/libtmux-test/default,1234,$0")
+
+    with pytest.raises(exc.NotInsideTmux):
+        Session.from_env()
+
+
+def test_session_from_env_linked_window_prefers_spawn_session(
+    server: Server,
+) -> None:
+    """A linked window lives in several sessions; ``$TMUX`` breaks the tie.
+
+    ``link-window`` puts one window in more than one session at once, so
+    ``list-panes -a`` lists the caller's pane once per session and tmux holds
+    two equally true answers. The pane alone cannot choose between them: tmux
+    orders that listing by session *name*, so resolving from the pane answers
+    with whichever session happens to sort last -- rename the sessions and the
+    answer changes. ``TMUX`` can choose: it records the session the process was
+    spawned under, which is the one the caller can actually claim.
+
+    The names are deliberate. ``zzz_...`` sorts after ``aaa_...``, so the
+    pane's last row is the destination, and resolving from the pane alone would
+    answer with a session the caller was never spawned in.
+    """
+    origin = server.new_session(session_name="aaa_from_env_origin")
+    window = origin.new_window(window_name="from_env_linked", attach=False)
+    pane = window.active_pane
+    assert pane is not None
+
+    socket_path = server.cmd(
+        "display-message",
+        "-p",
+        "-t",
+        str(origin.session_id),
+        "#{socket_path}",
+    ).stdout[0]
+    env = {
+        "TMUX": f"{socket_path},1,{origin.session_id}",
+        "TMUX_PANE": str(pane.pane_id),
+    }
+
+    destination = server.new_session(session_name="zzz_from_env_link_target")
+    server.cmd(
+        "link-window",
+        "-s",
+        str(window.window_id),
+        "-t",
+        f"{destination.session_id}:",
+    )
+
+    resolved = [p.session_id for p in server.panes.filter(pane_id=pane.pane_id)]
+    assert set(resolved) == {origin.session_id, destination.session_id}
+    assert resolved[-1] == destination.session_id
+
+    assert Session.from_env(env).session_id == origin.session_id
+
+
+def test_session_from_env_accepts_bare_session_id(
+    server: Server,
+    session: Session,
+) -> None:
+    """Bare session ids in ``$TMUX`` resolve, because that is what tmux writes.
+
+    tmux formats the id with ``%d`` from ``s->id``, so a real pane sees
+    ``socket,pid,47`` where libtmux spells the same session ``$47``.
+    """
+    pane = session.active_window.active_pane
+    assert pane is not None
+    bare = str(session.session_id).removeprefix("$")
+
+    socket_path = server.cmd(
+        "display-message",
+        "-p",
+        "-t",
+        str(session.session_id),
+        "#{socket_path}",
+    ).stdout[0]
+    env = {
+        "TMUX": f"{socket_path},1,{bare}",
+        "TMUX_PANE": str(pane.pane_id),
+    }
+
+    assert Session.from_env(env).session_id == session.session_id

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -1332,3 +1332,116 @@ def test_new_pane(session: Session) -> None:
     else:
         with pytest.raises(exc.LibTmuxException, match=r"new_pane .*requires tmux 3.7"):
             window.new_pane(width=40, height=10)
+
+
+def test_window_from_env(server: Server, session: Session) -> None:
+    """:meth:`Window.from_env` returns the window containing the caller's pane."""
+    pane = session.active_window.active_pane
+    assert pane is not None
+
+    socket_path = server.cmd(
+        "display-message",
+        "-p",
+        "-t",
+        str(session.session_id),
+        "#{socket_path}",
+    ).stdout[0]
+    env = {
+        "TMUX": f"{socket_path},1,{session.session_id}",
+        "TMUX_PANE": str(pane.pane_id),
+    }
+
+    caller = Window.from_env(env)
+
+    assert caller.window_id == pane.window_id
+    assert caller.session_id == session.session_id
+
+
+def test_window_from_env_is_containing_not_active(
+    server: Server,
+    session: Session,
+) -> None:
+    """:meth:`Window.from_env` resolves the caller's window, focused or not.
+
+    ``session.active_window`` answers "what is the user looking at", which is a
+    different question. A pane running in the background must still be able to
+    name its own window.
+    """
+    pane = session.active_window.active_pane
+    assert pane is not None
+
+    socket_path = server.cmd(
+        "display-message",
+        "-p",
+        "-t",
+        str(session.session_id),
+        "#{socket_path}",
+    ).stdout[0]
+    env = {
+        "TMUX": f"{socket_path},1,{session.session_id}",
+        "TMUX_PANE": str(pane.pane_id),
+    }
+
+    # Focus elsewhere: the caller's window is now a background window.
+    foreground = session.new_window(window_name="from_env_foreground", attach=True)
+    assert session.active_window.window_id == foreground.window_id
+    assert session.active_window.window_id != pane.window_id
+
+    assert Window.from_env(env).window_id == pane.window_id
+
+
+def test_window_from_env_after_move_window(server: Server, session: Session) -> None:
+    """:meth:`Window.from_env` survives the window moving between sessions.
+
+    ``$TMUX`` is frozen at spawn time, so its session id is stale after
+    ``move-window``. ``TMUX_PANE`` is not: the pane still names a live window,
+    and the window still names a live session.
+    """
+    origin = session
+    pane = origin.active_window.active_pane
+    assert pane is not None
+    window = pane.window
+
+    socket_path = server.cmd(
+        "display-message",
+        "-p",
+        "-t",
+        str(origin.session_id),
+        "#{socket_path}",
+    ).stdout[0]
+    env = {
+        "TMUX": f"{socket_path},1,{origin.session_id}",
+        "TMUX_PANE": str(pane.pane_id),
+    }
+
+    origin.new_window(window_name="from_env_origin_keepalive")
+    destination = server.new_session(session_name="from_env_window_destination")
+    # ``no_select`` (-d) leaves the moved window unfocused in its new session,
+    # so "containing" and "active" are provably different windows.
+    window.move_window(session=str(destination.session_id), no_select=True)
+
+    caller = Window.from_env(env)
+
+    assert caller.window_id == window.window_id
+    assert caller.session_id == destination.session_id
+
+    active = destination.active_window
+    assert active.window_id != caller.window_id
+    assert caller.window_id in [w.window_id for w in destination.windows]
+
+
+def test_window_from_env_outside_tmux(monkeypatch: pytest.MonkeyPatch) -> None:
+    """:meth:`Window.from_env` raises when ``$TMUX`` or ``$TMUX_PANE`` is unset."""
+    monkeypatch.delenv("TMUX", raising=False)
+    monkeypatch.delenv("TMUX_PANE", raising=False)
+
+    with pytest.raises(exc.NotInsideTmux):
+        Window.from_env()
+
+    with pytest.raises(exc.NotInsideTmux):
+        Window.from_env({})
+
+    monkeypatch.setenv("TMUX", "/tmp/libtmux-test/default,1234,$0")
+
+    with pytest.raises(exc.NotInsideTmux):
+        Window.from_env()

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -1445,3 +1445,20 @@ def test_window_from_env_outside_tmux(monkeypatch: pytest.MonkeyPatch) -> None:
 
     with pytest.raises(exc.NotInsideTmux):
         Window.from_env()
+
+
+def test_window_from_env_pane_without_window_id(
+    server: Server,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A pane carrying no ``window_id`` raises rather than querying for None.
+
+    Surfaces a clear error under ``python -O``, where an ``assert`` would be
+    stripped and the None would reach tmux as a lookup for nothing.
+    """
+    orphan = Pane(server=server, pane_id="%1")
+    assert orphan.window_id is None
+    monkeypatch.setattr(Pane, "from_env", classmethod(lambda cls, env=None: orphan))
+
+    with pytest.raises(ValueError, match="window_id"):
+        Window.from_env({"TMUX": "/nowhere,1,0", "TMUX_PANE": "%1"})


### PR DESCRIPTION
Closes #704.

## Why

A process running inside tmux had no way to ask **where it is**. tmux hands every pane it spawns `TMUX` (`socket_path,server_pid,session_id`) and `TMUX_PANE`, but libtmux read neither — `TMUX_PANE` appeared nowhere in the package. Callers parsed the environment by hand and then reached for `Pane.from_pane_id()`, which lists every pane on the server and filters in Python.

## What

`Server.from_env()` · `Session.from_env()` · `Window.from_env()` · `Pane.from_env()` — each returns the object the current process is running inside. All accept an optional `env` mapping (defaulting to `os.environ`), which keeps them injectable and lets the doctests run deterministically inside *and* outside tmux.

```python
>>> Server.from_env({"TMUX": "/tmp/tmux-1000/default,123,$0"})
Server(socket_path=/tmp/tmux-1000/default)
```

`exc.NotInsideTmux` — all four raise rather than guess. Silently answering with someone else's pane is worse than failing.

**They report what _contains_ you, not what is focused.** Implementing `Window.from_env()` as `session.active_window` would be wrong for any background pane; there's a test with a deliberately non-active window pinning that.

**No `Client.from_env()`.** A tmux client is an attached terminal identified by its tty; a pane process owns the *pane's pty*, not the client's tty, and tmux exports no client id. The cardinality is 0..N with **0 as the default** (detached session, CI, a `send-keys` script). Even `ControlMode` — the one process that genuinely *is* a client — recovers its identity by PID-correlating `list-clients`, not from the environment. If the underlying need is real, the honest API is `Session.clients -> QueryList[Client]`.

## The server answers; `$TMUX` only breaks ties

`$TMUX` carries a session id and it is tempting to just read it. It is **wrong**: tmux freezes the variable into the pane's environ at spawn (`environ.c` / `spawn.c`) and never revises it, so after a `move-window` it still names the old session.

But resolving purely from the pane is *also* wrong — subtly. `link-window` puts one window in several sessions, and tmux then lists the pane **once per session, ordered by session name**. Resolving from the pane alone therefore answers with whichever session sorts last:

| origin / dest session names | resolved session |
|---|---|
| `aaa_origin` / `zzz_dest` | **dest** ✗ |
| `zzz_origin` / `aaa_dest` | origin ✓ *(by luck)* |

Same topology, different names, different answer. So: **the live server is ground truth; `$TMUX` breaks the tie** when several sessions genuinely hold the pane, because it alone records which one the process was *spawned* under. When it names a session that no longer holds the pane, the window moved and the server wins. An unusable id (`-1`, a killed session, anything unparseable) is simply ignored. Still 2 tmux calls.

## Also: a guard on `Pane.session`

`Pane.session` resolves through `Pane.window` — two round-trips — when the pane already carries a `session_id` that *looks* like it would do. That shortcut is a **correctness bug**: a pane's cached `session_id` goes stale when its window moves; its `window_id` does not. Verified — swapping the hop for the cached id turns the new test red. Documented and pinned so the next reader doesn't "optimize" it away.

## Fix: unreachable `socket_path` derivation

The `TMUX_TMPDIR` derivation in `Server.__init__` could never run: the local `socket_name` is rebound to `self.socket_name or "default"`, so `self.socket_name is None` implies it *equals* `"default"` — which the trailing `socket_name != "default"` guard rejects. Dead since `aa7a3ae2` ("fix launching default server"), and **reviving it would be wrong**: `Server.cmd` and `neo.fetch_objs` each emit `-L` *and* `-S`, so a `Server` with a `socket_name` plus a derived `socket_path` would target the server twice. Removed, with a test pinning the contract.

## Deliberately not in scope

#704 also floated routing `Server.sessions` through `_fetch_or_empty`. `AGENTS.md` documents the current behavior as an intentional contract ("list-shaped accessors are lenient by default… Empty-on-tmux-error stays the default; raise is opt-in"), so that suggestion is **withdrawn**.

## Testing

Written test-first. Covers: `$TMUX` parsing (including the bare id tmux actually writes — `47`, not `$47`), `os.environ` fallback, live-server round-trip, **move-window**, **link-window**, non-active windows, unusable spawn ids, and both not-inside-tmux paths. Doctests execute against live fixtures — no `+SKIP`.

`ruff format` · `ruff check` · `mypy src tests` · full `pytest` (**1371 passed**) · `just build-docs` — all clean.

> **Pre-existing, unrelated:** `docs/topics/automation_patterns.md[4]` is a timing-sensitive doctest that fails intermittently on clean `master` too (verified: 2 of 3 runs at `--reruns 0`, and with the default `--reruns 2`). Not introduced here — likely worth its own issue.