### PR TITLE
fix(Pane,Window): Resolve point lookups through tmux

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -45,6 +45,24 @@ $ uvx --from 'libtmux' --prerelease allow python
 _Notes on the upcoming release will go here._
 <!-- END PLACEHOLDER - ADD NEW CHANGELOG ENTRIES BELOW THIS LINE -->
 
+### Fixes
+
+#### Linked windows resolve to the session tmux would use (#713)
+
+A window can be linked into several sessions at once, and libtmux used to pick
+one of them by accident — whichever sorted last by name. So
+{meth}`Window.from_window_id() <libtmux.Window.from_window_id>`,
+{meth}`Pane.from_pane_id() <libtmux.Pane.from_pane_id>` and both `refresh()`
+methods could change their answer when you renamed a session.
+
+libtmux now lets tmux resolve the object, so a window reports the session tmux
+itself would act on. For a window in a single session — the ordinary case —
+nothing changes. For a linked or grouped window, note that tmux picks by
+*activity*: the session a window reports can change as focus moves between the
+sessions holding it, where before it was stable but arbitrary. The lookups also
+got cheaper: they list one window's panes or one session's windows instead of
+scanning the whole server.
+
 ## libtmux 0.61.0 (2026-07-04)
 
 libtmux 0.61.0 hardens support for the tmux 3.7 patch line. It fixes

--- a/src/libtmux/neo.py
+++ b/src/libtmux/neo.py
@@ -776,6 +776,53 @@ def fetch_objs(
     return outputs
 
 
+def _is_target_not_found_error(stderr_text: str) -> bool:
+    """Return True if tmux failed because the ``-t`` target does not exist.
+
+    A live tmux server rejects an unknown target with ``can't find <kind>:
+    <target>`` on stderr (``cmd_find_target`` in tmux's ``cmd-find.c``), for
+    every object kind and every supported tmux version. Every *other* failure
+    -- a stopped daemon, a missing socket, a permission error -- says something
+    else, and stays a :exc:`~libtmux.exc.LibTmuxException`.
+
+    This is the mirror image of :func:`libtmux.server._is_daemon_not_up_error`:
+    together they answer "is the object gone, or is the server gone?" from the
+    same stderr text.
+
+    Parameters
+    ----------
+    stderr_text : str
+        tmux's stderr, as carried by the raised
+        :exc:`~libtmux.exc.LibTmuxException`.
+
+    Returns
+    -------
+    bool
+        True when the object named by ``-t`` does not exist on a reachable
+        server.
+
+    Examples
+    --------
+    >>> from libtmux.neo import _is_target_not_found_error
+    >>> _is_target_not_found_error("can't find pane: %99")
+    True
+    >>> _is_target_not_found_error("can't find window: @99")
+    True
+    >>> _is_target_not_found_error("can't find session: $99")
+    True
+
+    A server that isn't there is a different answer:
+
+    >>> _is_target_not_found_error("no server running on /tmp/tmux-1000/default")
+    False
+    >>> _is_target_not_found_error(
+    ...     "error connecting to /tmp/tmux-1000/nope (No such file or directory)"
+    ... )
+    False
+    """
+    return "can't find " in stderr_text
+
+
 def fetch_obj(
     server: Server,
     obj_key: str,
@@ -783,12 +830,83 @@ def fetch_obj(
     list_cmd: ListCmd = "list-panes",
     list_extra_args: ListExtraArgs = None,
 ) -> OutputRaw:
-    """Fetch raw data from tmux command."""
-    obj_formatters_filtered = fetch_objs(
-        server=server,
-        list_cmd=list_cmd,
-        list_extra_args=list_extra_args,
-    )
+    """Fetch the single ``list-*`` row whose *obj_key* equals *obj_id*.
+
+    Parameters
+    ----------
+    server : :class:`~libtmux.server.Server`
+        The tmux server to query.
+    obj_key : str
+        Identity field to match, e.g. ``"pane_id"``.
+    obj_id : str
+        Value the identity field must equal, e.g. ``"%3"``.
+    list_cmd : ListCmd
+        tmux list subcommand to run.
+    list_extra_args : ListExtraArgs, optional
+        Extra arguments appended verbatim to the tmux command, e.g.
+        ``("-t", "%3")`` to scope the listing to one object's parent.
+
+    Returns
+    -------
+    OutputRaw
+        The matching row, as a dict of tmux format fields.
+
+    Raises
+    ------
+    :exc:`~libtmux.exc.TmuxObjectDoesNotExist`
+        When the object does not exist -- whether tmux said so on stderr
+        (``can't find pane: %99``, for a ``-t``-scoped listing) or the object
+        simply never appeared in the rows.
+    :exc:`~libtmux.exc.LibTmuxException`
+        For every other tmux failure, notably an unreachable server.
+
+    Examples
+    --------
+    >>> from libtmux.neo import fetch_obj
+    >>> fetch_obj(
+    ...     server=pane.server,
+    ...     obj_key="pane_id",
+    ...     obj_id=pane.pane_id,
+    ...     list_cmd="list-panes",
+    ...     list_extra_args=("-t", pane.pane_id),
+    ... )["pane_id"] == pane.pane_id
+    True
+
+    A pane that does not exist on a live server is a
+    :exc:`~libtmux.exc.TmuxObjectDoesNotExist`, not a bare tmux error:
+
+    >>> from libtmux import exc
+    >>> try:
+    ...     fetch_obj(
+    ...         server=pane.server,
+    ...         obj_key="pane_id",
+    ...         obj_id="%99999",
+    ...         list_cmd="list-panes",
+    ...         list_extra_args=("-t", "%99999"),
+    ...     )
+    ... except exc.TmuxObjectDoesNotExist as e:
+    ...     print(e)
+    Could not find pane_id=%99999 for list-panes ('-t', '%99999')
+    """
+    try:
+        obj_formatters_filtered = fetch_objs(
+            server=server,
+            list_cmd=list_cmd,
+            list_extra_args=list_extra_args,
+        )
+    except exc.LibTmuxException as e:
+        # A ``-t``-scoped listing pushes the "does it exist?" question down
+        # into tmux, which answers on stderr rather than with an empty listing.
+        # Re-raise those as the same TmuxObjectDoesNotExist an unscoped listing
+        # would have produced; anything else (a dead server) keeps propagating.
+        if not _is_target_not_found_error(str(e)):
+            raise
+        raise exc.TmuxObjectDoesNotExist(
+            obj_key=obj_key,
+            obj_id=obj_id,
+            list_cmd=list_cmd,
+            list_extra_args=list_extra_args,
+        ) from e
 
     obj = None
     for _obj in obj_formatters_filtered:
@@ -802,7 +920,5 @@ def fetch_obj(
             list_cmd=list_cmd,
             list_extra_args=list_extra_args,
         )
-
-    assert obj is not None
 
     return obj

--- a/src/libtmux/pane.py
+++ b/src/libtmux/pane.py
@@ -133,11 +133,25 @@ class Pane(
     def refresh(self) -> None:
         """Refresh pane attributes from tmux.
 
+        Scoped to this pane's own window (``list-panes -t %ID``), so tmux --
+        not libtmux -- decides which session the pane belongs to. See
+        :meth:`Pane.from_pane_id`.
+
         Raises
         ------
         ValueError
             When ``pane_id`` is unset. Surfaces a clear error under
             ``python -O``, where an ``assert`` would be stripped.
+        :exc:`~libtmux.exc.TmuxObjectDoesNotExist`
+            When the pane no longer exists.
+        :exc:`~libtmux.exc.LibTmuxException`
+            When tmux itself is unreachable.
+
+        Examples
+        --------
+        >>> pane.refresh()
+        >>> pane.pane_id
+        '%1'
         """
         if self.pane_id is None:
             msg = "Pane must have a pane_id to refresh"
@@ -145,18 +159,50 @@ class Pane(
         return super()._refresh(
             obj_key="pane_id",
             obj_id=self.pane_id,
-            list_extra_args=("-a",),
+            list_extra_args=("-t", self.pane_id),
         )
 
     @classmethod
     def from_pane_id(cls, server: Server, pane_id: str) -> Pane:
-        """Create Pane from existing pane_id."""
+        """Create Pane from existing pane_id.
+
+        tmux's ``cmd_find`` routes a ``-t`` target by *sigil*, so a ``%``-id
+        handed to ``list-panes`` resolves to that pane's window and lists it.
+        Every row comes back stamped with the session tmux considers canonical
+        for that window -- the most recently active one -- which is the same
+        session ``display-message -t %ID '#{session_id}'`` reports. A window
+        linked into several sessions therefore gets one authoritative answer
+        instead of "whichever session sorted last".
+
+        Parameters
+        ----------
+        server : :class:`~libtmux.server.Server`
+            The tmux server holding the pane.
+        pane_id : str
+            Pane id, e.g. ``"%3"``.
+
+        Returns
+        -------
+        :class:`Pane`
+
+        Raises
+        ------
+        :exc:`~libtmux.exc.TmuxObjectDoesNotExist`
+            When no such pane exists on a reachable server.
+        :exc:`~libtmux.exc.LibTmuxException`
+            When tmux itself is unreachable.
+
+        Examples
+        --------
+        >>> Pane.from_pane_id(server=pane.server, pane_id=pane.pane_id)
+        Pane(%1 Window(@1 1:..., Session($1 ...)))
+        """
         pane = fetch_obj(
             obj_key="pane_id",
             obj_id=pane_id,
             server=server,
             list_cmd="list-panes",
-            list_extra_args=("-a",),
+            list_extra_args=("-t", pane_id),
         )
         return cls(server=server, **pane)
 

--- a/src/libtmux/window.py
+++ b/src/libtmux/window.py
@@ -150,11 +150,25 @@ class Window(
     def refresh(self) -> None:
         """Refresh window attributes from tmux.
 
+        Scoped to this window's own session (``list-windows -t @ID``), so tmux
+        -- not libtmux -- decides which session the window belongs to. See
+        :meth:`Window.from_window_id`.
+
         Raises
         ------
         ValueError
             When ``window_id`` is unset. Surfaces a clear error under
             ``python -O``, where an ``assert`` would be stripped.
+        :exc:`~libtmux.exc.TmuxObjectDoesNotExist`
+            When the window no longer exists.
+        :exc:`~libtmux.exc.LibTmuxException`
+            When tmux itself is unreachable.
+
+        Examples
+        --------
+        >>> window.refresh()
+        >>> window.window_id
+        '@1'
         """
         if self.window_id is None:
             msg = "Window must have a window_id to refresh"
@@ -163,18 +177,48 @@ class Window(
             obj_key="window_id",
             obj_id=self.window_id,
             list_cmd="list-windows",
-            list_extra_args=("-a",),
+            list_extra_args=("-t", self.window_id),
         )
 
     @classmethod
     def from_window_id(cls, server: Server, window_id: str) -> Window:
-        """Create Window from existing window_id."""
+        """Create Window from existing window_id.
+
+        tmux's ``cmd_find`` routes a ``-t`` target by *sigil*, so an ``@``-id
+        handed to ``list-windows`` resolves to that window's session and lists
+        it. The rows come back stamped with the session tmux considers
+        canonical for the window -- the most recently active one -- so a window
+        linked into several sessions reports the same parent tmux itself would.
+
+        Parameters
+        ----------
+        server : :class:`~libtmux.server.Server`
+            The tmux server holding the window.
+        window_id : str
+            Window id, e.g. ``"@3"``.
+
+        Returns
+        -------
+        :class:`Window`
+
+        Raises
+        ------
+        :exc:`~libtmux.exc.TmuxObjectDoesNotExist`
+            When no such window exists on a reachable server.
+        :exc:`~libtmux.exc.LibTmuxException`
+            When tmux itself is unreachable.
+
+        Examples
+        --------
+        >>> Window.from_window_id(server=window.server, window_id=window.window_id)
+        Window(@1 1:..., Session($1 ...))
+        """
         window = fetch_obj(
             obj_key="window_id",
             obj_id=window_id,
             server=server,
             list_cmd="list-windows",
-            list_extra_args=("-a",),
+            list_extra_args=("-t", window_id),
         )
         return cls(server=server, **window)
 

--- a/tests/test_neo.py
+++ b/tests/test_neo.py
@@ -9,6 +9,8 @@ verified against tmux's ``format.c`` (see commit messages on
 
 from __future__ import annotations
 
+import typing as t
+
 import pytest
 
 from libtmux.neo import (
@@ -16,9 +18,73 @@ from libtmux.neo import (
     FIELD_VERSION,
     SCOPES_BY_LIST_CMD,
     Obj,
+    _is_target_not_found_error,
     _token_scope,
     get_output_format,
 )
+
+
+class TargetNotFoundFixture(t.NamedTuple):
+    """One line of tmux stderr, and whether it means "that object is gone"."""
+
+    test_id: str
+    stderr_text: str
+    expected: bool
+
+
+TARGET_NOT_FOUND_FIXTURES: list[TargetNotFoundFixture] = [
+    TargetNotFoundFixture(
+        test_id="missing-pane",
+        stderr_text="can't find pane: %99",
+        expected=True,
+    ),
+    TargetNotFoundFixture(
+        test_id="missing-window",
+        stderr_text="can't find window: @99",
+        expected=True,
+    ),
+    TargetNotFoundFixture(
+        test_id="missing-session",
+        stderr_text="can't find session: $99",
+        expected=True,
+    ),
+    TargetNotFoundFixture(
+        test_id="daemon-not-running",
+        stderr_text="no server running on /tmp/tmux-1000/default",
+        expected=False,
+    ),
+    TargetNotFoundFixture(
+        test_id="socket-missing",
+        stderr_text=(
+            "error connecting to /tmp/tmux-1000/nope (No such file or directory)"
+        ),
+        expected=False,
+    ),
+    TargetNotFoundFixture(
+        test_id="permission-denied",
+        stderr_text="error connecting to /tmp/tmux-1000/other (Permission denied)",
+        expected=False,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    list(TargetNotFoundFixture._fields),
+    TARGET_NOT_FOUND_FIXTURES,
+    ids=[test.test_id for test in TARGET_NOT_FOUND_FIXTURES],
+)
+def test_is_target_not_found_error(
+    test_id: str,
+    stderr_text: str,
+    expected: bool,
+) -> None:
+    """Only an unknown ``-t`` target means the object is gone.
+
+    Every other tmux failure -- a stopped daemon, a missing socket, a
+    permission error -- leaves the object's existence unknown, and must keep
+    surfacing as a :exc:`~libtmux.exc.LibTmuxException`.
+    """
+    assert _is_target_not_found_error(stderr_text) is expected
 
 
 def test_pane_dead_signal_gated_to_3_3() -> None:

--- a/tests/test_resolution.py
+++ b/tests/test_resolution.py
@@ -1,0 +1,179 @@
+"""Point lookups resolve through tmux, not through a server-wide scan.
+
+:meth:`~libtmux.Pane.from_pane_id`, :meth:`~libtmux.Window.from_window_id` and
+both ``refresh()`` methods name the object with ``-t`` and let tmux's
+``cmd_find`` resolve it.
+
+The difference only shows on a *linked* window -- one window that lives in more
+than one session at once. ``list-panes -a`` emits such a pane once per holding
+session, ordered by session name, and picking a row out of that listing answers
+with whichever session happens to sort last. Targeting the id instead hands the
+question to tmux, which answers with the session it would itself act on.
+"""
+
+from __future__ import annotations
+
+import typing as t
+
+import pytest
+
+from libtmux import exc
+from libtmux._internal.query_list import ObjectDoesNotExist
+from libtmux.pane import Pane
+from libtmux.window import Window
+
+if t.TYPE_CHECKING:
+    from libtmux.server import Server
+    from libtmux.session import Session
+
+
+def tmux_resolves_to(server: Server, target: str) -> str:
+    """Ask tmux which session it would act on for *target*."""
+    return server.cmd("display-message", "-p", "-t", target, "#{session_id}").stdout[0]
+
+
+def link_window_into_second_session(server: Server) -> tuple[Window, Session, Session]:
+    """Link one window into two sessions, name-order fighting activity-order.
+
+    ``zzz-old`` is created first, so it sorts *last* by name but is the *least*
+    recently active. ``aaa-recent`` sorts first and is the most recently active.
+    A resolver that reads the last row of a ``list-* -a`` listing answers
+    ``zzz-old``; tmux answers ``aaa-recent``.
+    """
+    old = server.new_session(session_name="zzz-old")
+    recent = server.new_session(session_name="aaa-recent")
+
+    window = old.active_window
+    assert window.window_id is not None
+    assert recent.session_name is not None
+
+    server.cmd("link-window", "-s", window.window_id, "-t", recent.session_name)
+
+    return window, old, recent
+
+
+def test_linked_window_resolves_like_tmux(server: Server) -> None:
+    """:meth:`Window.from_window_id` answers with tmux's own session."""
+    window, old, recent = link_window_into_second_session(server)
+    assert window.window_id is not None
+
+    canonical = tmux_resolves_to(server, window.window_id)
+    resolved = Window.from_window_id(server=server, window_id=window.window_id)
+
+    assert resolved.session_id == canonical
+    assert resolved.session_id == recent.session_id
+    assert resolved.session_id != old.session_id, (
+        "'zzz-old' sorts last by name -- resolving from a `list-windows -a` "
+        "listing would answer with it"
+    )
+
+
+def test_linked_pane_resolves_like_tmux(server: Server) -> None:
+    """:meth:`Pane.from_pane_id` answers with tmux's own session."""
+    window, old, recent = link_window_into_second_session(server)
+    pane = window.active_pane
+    assert pane is not None
+    assert pane.pane_id is not None
+
+    canonical = tmux_resolves_to(server, pane.pane_id)
+    resolved = Pane.from_pane_id(server=server, pane_id=pane.pane_id)
+
+    assert resolved.session_id == canonical
+    assert resolved.session_id == recent.session_id
+    assert resolved.session_id != old.session_id
+
+
+def test_pane_session_follows_move_window(server: Server) -> None:
+    """A :class:`Pane` held across a ``move-window`` still finds its session.
+
+    :attr:`Pane.session` resolves through :attr:`Pane.window`, which re-queries
+    tmux. Answering from the pane's own cached ``session_id`` would be one
+    subprocess cheaper and would break here: tmux destroys a session when its
+    last window leaves, so the cached id names a session that no longer exists.
+    """
+    origin = server.new_session(session_name="origin")
+    destination = server.new_session(session_name="destination")
+
+    window = origin.active_window
+    pane = window.active_pane  # captured *before* the move
+    assert pane is not None
+
+    window.move_window(destination="99", session=destination.session_id)
+
+    assert pane.session.session_id == destination.session_id
+    assert pane.window.session_id == destination.session_id
+
+
+class RefreshAfterKillFixture(t.NamedTuple):
+    """A live object, killed out from under a ``refresh()``."""
+
+    test_id: str
+    kind: str
+
+
+REFRESH_AFTER_KILL_FIXTURES: list[RefreshAfterKillFixture] = [
+    RefreshAfterKillFixture(test_id="window", kind="window"),
+    RefreshAfterKillFixture(test_id="pane", kind="pane"),
+]
+
+
+@pytest.mark.parametrize(
+    list(RefreshAfterKillFixture._fields),
+    REFRESH_AFTER_KILL_FIXTURES,
+    ids=[test.test_id for test in REFRESH_AFTER_KILL_FIXTURES],
+)
+def test_refresh_after_kill_raises_object_does_not_exist(
+    session: Session,
+    test_id: str,
+    kind: str,
+) -> None:
+    """A gone object still raises :exc:`~libtmux.exc.TmuxObjectDoesNotExist`.
+
+    tmux reports an unknown ``-t`` target on stderr rather than by returning an
+    empty listing, so the raised error has to be translated back.
+    """
+    window = session.new_window(window_name="doomed")
+    target: Window | Pane
+    if kind == "window":
+        target = window
+    else:
+        pane = window.split()
+        target = pane
+        pane.kill()
+
+    if kind == "window":
+        window.kill()
+
+    with pytest.raises(ObjectDoesNotExist):
+        target.refresh()
+
+
+def test_missing_pane_on_live_server_raises_object_does_not_exist(
+    server: Server,
+    session: Session,
+) -> None:
+    """A pane id that never existed is a missing object, not a broken server."""
+    with pytest.raises(exc.TmuxObjectDoesNotExist):
+        Pane.from_pane_id(server=server, pane_id="%99999")
+
+
+def test_dead_server_raises_libtmux_exception(
+    server: Server,
+    session: Session,
+) -> None:
+    """A dead server is a different failure from a missing object.
+
+    :exc:`~libtmux.exc.TmuxObjectDoesNotExist` would tell the caller the pane is
+    gone, when in fact nothing can be known -- the daemon is not answering.
+    """
+    pane = session.active_pane
+    assert pane is not None
+    assert pane.pane_id is not None
+    pane_id = pane.pane_id
+
+    server.kill()
+
+    with pytest.raises(exc.LibTmuxException) as excinfo:
+        Pane.from_pane_id(server=server, pane_id=pane_id)
+
+    assert not isinstance(excinfo.value, ObjectDoesNotExist)


### PR DESCRIPTION
Fixes #710.

## The bug

A window can be linked into several sessions at once. Ask libtmux which session such a window (or a pane inside it) is in, and the answer depends on **what the sessions are called**:

```python
>>> window = home.active_window                       # 'aaa-home'
>>> server.cmd("link-window", "-s", window.window_id, "-t", "zzz-guest")
>>> Window.from_window_id(server, window.window_id).session_name
'zzz-guest'
```

Rename `zzz-guest` to `aaa-guest` and the same call answers `aaa-home` instead. Nothing about the window changed.

The four point lookups — `Pane.refresh`, `Pane.from_pane_id`, `Window.refresh`, `Window.from_window_id` — passed `-a` to `list-panes` / `list-windows`, listing **every** object on the server. tmux emits a linked window once per holding session, ordered by session *name* (its session tree is keyed by `strcmp` — [`session.c:41-44`](https://github.com/tmux/tmux/blob/3.7b/session.c#L41-L44)), and `neo.fetch_obj` scans that listing keeping the **last** row that matches the id. So "which session?" resolved to *whichever session sorted last alphabetically*.

It also disagreed with tmux. `tmux display-message -t @0 '#{session_id}'` resolves the same window through `cmd_find`, which picks the **most recently active** session holding it ([`cmd-find.c:176-202`](https://github.com/tmux/tmux/blob/3.7b/cmd-find.c#L176-L202)). libtmux and tmux gave different answers for the same id.

## The fix

Name the object with `-t` and let tmux resolve it.

tmux's `cmd_find_target` routes a target to a slot **by sigil, not by the command's declared target type** ([`cmd-find.c:1078-1083`](https://github.com/tmux/tmux/blob/3.7b/cmd-find.c#L1078-L1083)): `$`→session, `@`→window, `%`→pane. So `list-panes -t %ID` routes `%ID` to the pane slot even though `list-panes` declares a *window* target, and resolves upward through `cmd_find_best_session_with_window()` — the same function tmux uses for every `-t` you type. One row comes back, stamped with the session tmux itself would act on.

This is byte-identical in every tmux CI covers (`3.2a` → `3.7b`), and libtmux already ships `-t` on these commands for same-type targets (`Window.panes`, `Session.windows`).

Point lookups also get cheaper: `-t` scans one window's panes or one session's windows instead of the whole server.

`Server.panes` / `Server.windows` / `Server.sessions` keep `-a` — a server-wide listing is what they're for.

## The catch, and what it cost

A live server rejects an unknown `-t` target on **stderr** (`can't find pane: %99`) rather than by returning an empty listing. `raise_if_stderr` turns that into a `LibTmuxException`, so `fetch_obj` would have stopped raising `TmuxObjectDoesNotExist` altogether — and `TmuxObjectDoesNotExist` extends `ObjectDoesNotExist`, not `LibTmuxException`, so nothing downstream would have caught it.

`neo._is_target_not_found_error` classifies that stderr, mirroring the existing `server._is_daemon_not_up_error`. It buys nothing new: it **keeps** a distinction that already works, which `-t` would otherwise have destroyed. A missing object stays `TmuxObjectDoesNotExist`; a dead daemon, a missing socket or a permission error stay `LibTmuxException` — exactly as in `0.61.0`. Only the mechanism behind that contract moved.

## Behaviour change

For a window in exactly one session — the overwhelmingly common case — nothing changes.

For a **linked or grouped** window, `refresh()` / `from_pane_id()` / `from_window_id()` now report tmux's canonical session instead of the alphabetically-last one. That is the fix. Note the consequence: because tmux picks by *activity*, the answer can now change over time as focus moves between the sessions holding the window, where before it was stable but arbitrary. That is tmux's own semantics, and it is what every `-t` command already does. Grouped sessions (`tmux new-session -t`) are ordinary usage — tmuxp creates them — so this is worth knowing before you upgrade.

## Not in this PR

**Duplicate rows still crash the server-wide accessors — #716.** `Server.panes` / `Server.windows` keep `-a`, so `server.panes.get(pane_id=…)` still raises `MultipleObjectsReturned` for a window shared between sessions: `tmux list-panes -a` emits one row per holding session, and `QueryList.get()` rejects >1 match before consulting `default`. Untouched here, and it pre-dates this branch. It is also why the fix has to be `-t`: you cannot dedupe an `-a` listing without inventing the very tie-break tmux already owns. `from_pane_id` / `from_window_id` are the correct migration target for callers hitting it.

**`window_index` is still wrong for a window linked twice into one session — #717.** `list-windows -t @N` returns one row per *winlink*, so a window linked into the same session at two indexes still produces two rows inside the `-t` scope, and the survivor loop still keeps the last. This PR fixes the `Pane` side (`list-panes` emits each pane once) and does not reach the `Window` side. The session this PR is about is right either way — both rows carry the same `session_id` — but `window_index` is not, and fixing it means resolving through `display-message -p -t`, which is a refactor rather than a patch.

## Tests

`tests/test_resolution.py` builds a window linked into two sessions whose **name order and activity order disagree** (`zzz-old` sorts last but `aaa-recent` is active), so a resolver that reads the last row of an `-a` listing cannot pass by luck. Both linked-window tests fail on `master` and pass here.

The others are guards for what the `-t` switch could have broken, and pass on `master` too:

- a `Pane` held **across** a `move-window` still finds its session (`Pane.session` resolves through `Pane.window`, which re-queries — answering from the pane's cached `session_id` would be one subprocess cheaper and would break here, because tmux destroys a session when its last window leaves)
- `refresh()` on a killed window/pane still raises `TmuxObjectDoesNotExist`
- a missing pane on a live server is `TmuxObjectDoesNotExist`; a dead server is not

`tests/test_neo.py` covers the classifier against real tmux stderr for both kinds of failure.

## Verification

`ruff` · `ruff format` · `mypy` · `pytest --reruns 0` · `just build-docs` — all green locally, and CI is green across the full matrix (`3.2a` → `master`).
