### PR TITLE
from_env(docs): Hide doctest setup with # doctest: +HIDE

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -45,6 +45,18 @@ $ uvx --from 'libtmux' --prerelease allow python
 _Notes on the upcoming release will go here._
 <!-- END PLACEHOLDER - ADD NEW CHANGELOG ENTRIES BELOW THIS LINE -->
 
+### Documentation
+
+#### Cleaner `from_env` examples (#719)
+
+The rendered examples for {meth}`Pane.from_env() <libtmux.Pane.from_env>` and
+its {meth}`Server <libtmux.Server.from_env>`,
+{meth}`Session <libtmux.Session.from_env>`, and
+{meth}`Window <libtmux.Window.from_env>` siblings now hide the incidental
+environment-setup plumbing, so each example leads with the constructor call it
+demonstrates instead of the socket-path and `$TMUX` boilerplate needed to run
+it.
+
 ## libtmux 0.62.0 (2026-07-12)
 
 libtmux 0.62.0 teaches libtmux objects to locate themselves and to resolve

--- a/src/libtmux/pane.py
+++ b/src/libtmux/pane.py
@@ -238,10 +238,13 @@ class Pane(
 
         Examples
         --------
-        >>> socket_path = server.cmd(
+        >>> socket_path = server.cmd(  # doctest: +HIDE
         ...     "display-message", "-p", "-t", pane.pane_id, "#{socket_path}"
         ... ).stdout[0]
-        >>> env = {"TMUX": f"{socket_path},1,0", "TMUX_PANE": pane.pane_id}
+        >>> env = {  # doctest: +HIDE
+        ...     "TMUX": f"{socket_path},1,0",
+        ...     "TMUX_PANE": pane.pane_id,
+        ... }
 
         >>> Pane.from_env(env)
         Pane(%1 Window(@1 1:..., Session($1 ...)))

--- a/src/libtmux/server.py
+++ b/src/libtmux/server.py
@@ -230,11 +230,14 @@ class Server(
 
         Examples
         --------
-        >>> from libtmux.server import Server as TmuxServer
-        >>> socket_path = server.cmd(
+        >>> from libtmux.server import Server as TmuxServer  # doctest: +HIDE
+        >>> socket_path = server.cmd(  # doctest: +HIDE
         ...     "display-message", "-p", "-t", pane.pane_id, "#{socket_path}"
         ... ).stdout[0]
-        >>> env = {"TMUX": f"{socket_path},1,0", "TMUX_PANE": pane.pane_id}
+        >>> env = {  # doctest: +HIDE
+        ...     "TMUX": f"{socket_path},1,0",
+        ...     "TMUX_PANE": pane.pane_id,
+        ... }
 
         >>> TmuxServer.from_env(env)
         Server(socket_path=...)

--- a/src/libtmux/session.py
+++ b/src/libtmux/session.py
@@ -217,7 +217,7 @@ class Session(
 
         Examples
         --------
-        >>> socket_path = server.cmd(
+        >>> socket_path = server.cmd(  # doctest: +HIDE
         ...     "display-message", "-p", "-t", pane.pane_id, "#{socket_path}"
         ... ).stdout[0]
 

--- a/src/libtmux/window.py
+++ b/src/libtmux/window.py
@@ -253,10 +253,13 @@ class Window(
 
         Examples
         --------
-        >>> socket_path = server.cmd(
+        >>> socket_path = server.cmd(  # doctest: +HIDE
         ...     "display-message", "-p", "-t", pane.pane_id, "#{socket_path}"
         ... ).stdout[0]
-        >>> env = {"TMUX": f"{socket_path},1,0", "TMUX_PANE": pane.pane_id}
+        >>> env = {  # doctest: +HIDE
+        ...     "TMUX": f"{socket_path},1,0",
+        ...     "TMUX_PANE": pane.pane_id,
+        ... }
 
         >>> Window.from_env(env)
         Window(@1 1:..., Session($1 ...))


### PR DESCRIPTION
## What

The four `from_env` classmethods (`Server`/`Session`/`Window`/`Pane`)
open their `Examples` with plumbing — a socket path and an `env` mapping —
needed for the doctest to run but noise to the reader. Each such line is
now marked `# doctest: +HIDE`: it still executes as a doctest (the runner
reads `__doc__` from source), but is stripped from the rendered docs.

`Session.from_env` hides only its `socket_path`; its `env` carries the
"deliberately wrong session id" the surrounding prose explains, so it
stays visible — hide plumbing, not meaning.

## Requires (already on master)

- `gp-libs>=0.0.19` — the `HIDE` optionflag (so `# doctest: +HIDE` parses
  instead of raising at collection).
- `gp-sphinx>=0.0.1a34` — the `autodoc-process-docstring` render strip
  (plus the modifier-badge dedup that drops the duplicate left-hand
  `classmethod` prefix).

Both were bumped on `master`, so this branch carries only the four
docstring edits — no dependency or lockfile changes.

## Verification

All four `from_env` doctests pass; `ruff`/`mypy` clean; the docs build
renders each example without its setup block and each signature without
the duplicate `classmethod` prefix.