### PR TITLE
Fix `retry_until`'s clock, and let it forward args

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -45,6 +45,16 @@ $ uvx --from 'libtmux' --prerelease allow python
 _Notes on the upcoming release will go here._
 <!-- END PLACEHOLDER - ADD NEW CHANGELOG ENTRIES BELOW THIS LINE -->
 
+### Fixes
+
+- {func}`~libtmux.test.retry.retry_until` measures its budget with
+  {func}`time.monotonic` instead of the wall clock, so an NTP correction, a
+  container clock sync, or a VM resume can no longer cut a wait short or
+  stretch it (#726)
+- {func}`~libtmux.test.retry.retry_until` accepts an `args` tuple forwarded to
+  the predicate, so waiting on a loop variable no longer needs a closure that
+  ruff's `B023` rejects and mypy cannot infer (#726)
+
 ### Documentation
 
 #### Cleaner `from_env` examples (#719)

--- a/src/libtmux/test/retry.py
+++ b/src/libtmux/test/retry.py
@@ -70,6 +70,13 @@ def retry_until(
     raises : bool
         Whether or not to raise an exception on timeout. Defaults to ``True``.
 
+    Notes
+    -----
+    The budget is measured with :func:`time.monotonic`, which only ever moves
+    forward. A wall clock does not: an NTP correction, a container clock sync,
+    or a VM resume steps it, and a step landing inside the wait would end it
+    early or stretch it by the size of the step.
+
     Examples
     --------
     >>> def fn():
@@ -100,10 +107,10 @@ def retry_until(
     ...         args=(pane,),
     ...     )
     """
-    ini = time.time()
+    ini = time.monotonic()
 
     while not fun(*args):
-        end = time.time()
+        end = time.monotonic()
         if end - ini >= seconds:
             if raises:
                 raise WaitTimeout

--- a/src/libtmux/test/retry.py
+++ b/src/libtmux/test/retry.py
@@ -19,10 +19,32 @@ if t.TYPE_CHECKING:
         pass
 
 
+@t.overload
 def retry_until(
     fun: Callable[[], bool],
+    seconds: float = ...,
+    *,
+    interval: float = ...,
+    raises: bool | None = ...,
+) -> bool: ...
+
+
+@t.overload
+def retry_until(
+    fun: Callable[..., bool],
+    seconds: float = ...,
+    *,
+    args: tuple[t.Any, ...],
+    interval: float = ...,
+    raises: bool | None = ...,
+) -> bool: ...
+
+
+def retry_until(
+    fun: Callable[..., bool],
     seconds: float = RETRY_TIMEOUT_SECONDS,
     *,
+    args: tuple[t.Any, ...] = (),
     interval: float = RETRY_INTERVAL_SECONDS,
     raises: bool | None = True,
 ) -> bool:
@@ -33,10 +55,15 @@ def retry_until(
     ----------
     fun : callable
         A function that will be called repeatedly until it returns ``True``  or
-        the specified time passes.
+        the specified time passes. Called with ``args`` unpacked, so it accepts
+        no arguments unless ``args`` is given.
     seconds : float
         Seconds to retry. Defaults to ``8``, which is configurable via
         ``RETRY_TIMEOUT_SECONDS`` environment variables.
+    args : tuple
+        Positional arguments passed to ``fun`` on every call. Pass the subject
+        being waited on here instead of closing over it, which keeps predicates
+        written inside a loop free of a loop-variable binding.
     interval : float
         Time in seconds to wait between calls. Defaults to ``0.05`` and is
         configurable via ``RETRY_INTERVAL_SECONDS`` environment variable.
@@ -55,10 +82,27 @@ def retry_until(
     In pytest:
 
     >>> assert retry_until(fn, raises=False)
+
+    Waiting on something from a loop takes ``args`` rather than a closure:
+
+    >>> window = session.new_window(window_name='retry_until_args')
+    >>> panes = [window.active_pane, window.split()]
+    >>> for pane in panes:
+    ...     pane.send_keys('echo ready')
+
+    Compare whole lines. ``capture_pane`` returns the command tmux echoed onto
+    the pane, so ``'ready' in line`` matches that echo and is already true
+    before the shell has run anything:
+
+    >>> for pane in panes:
+    ...     assert retry_until(
+    ...         lambda p: any(line.strip() == 'ready' for line in p.capture_pane()),
+    ...         args=(pane,),
+    ...     )
     """
     ini = time.time()
 
-    while not fun():
+    while not fun(*args):
         end = time.time()
         if end - ini >= seconds:
             if raises:

--- a/tests/test/test_retry.py
+++ b/tests/test/test_retry.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import typing as t
-from time import sleep, time
+from time import monotonic, sleep
 
 import pytest
 
@@ -16,7 +16,7 @@ if t.TYPE_CHECKING:
 
 def test_retry_three_times() -> None:
     """Test retry_until()."""
-    ini = time()
+    ini = monotonic()
     value = 0
 
     def call_me_three_times() -> bool:
@@ -31,14 +31,14 @@ def test_retry_three_times() -> None:
 
     retry_until(call_me_three_times, 1)
 
-    end = time()
+    end = monotonic()
 
     assert 0.9 <= (end - ini) <= 1.1  # Allow for small timing variations
 
 
 def test_function_times_out() -> None:
     """Test time outs with retry_until()."""
-    ini = time()
+    ini = monotonic()
 
     def never_true() -> bool:
         sleep(
@@ -49,14 +49,14 @@ def test_function_times_out() -> None:
     with pytest.raises(exc.WaitTimeout):
         retry_until(never_true, 1)
 
-    end = time()
+    end = monotonic()
 
     assert 0.9 <= (end - ini) <= 1.1  # Allow for small timing variations
 
 
 def test_function_times_out_no_raise() -> None:
     """Tests retry_until() with exception raising disabled."""
-    ini = time()
+    ini = monotonic()
 
     def never_true() -> bool:
         sleep(
@@ -66,13 +66,13 @@ def test_function_times_out_no_raise() -> None:
 
     retry_until(never_true, 1, raises=False)
 
-    end = time()
+    end = monotonic()
     assert 0.9 <= (end - ini) <= 1.1  # Allow for small timing variations
 
 
 def test_function_times_out_no_raise_assert() -> None:
     """Tests retry_until() with exception raising disabled, returning False."""
-    ini = time()
+    ini = monotonic()
 
     def never_true() -> bool:
         sleep(
@@ -82,13 +82,13 @@ def test_function_times_out_no_raise_assert() -> None:
 
     assert not retry_until(never_true, 1, raises=False)
 
-    end = time()
+    end = monotonic()
     assert 0.9 <= (end - ini) <= 1.1  # Allow for small timing variations
 
 
 def test_retry_three_times_no_raise_assert() -> None:
     """Tests retry_until() with exception raising disabled, with closure variable."""
-    ini = time()
+    ini = monotonic()
     value = 0
 
     def call_me_three_times() -> bool:
@@ -105,7 +105,7 @@ def test_retry_three_times_no_raise_assert() -> None:
 
     assert retry_until(call_me_three_times, 1, raises=False)
 
-    end = time()
+    end = monotonic()
     assert 0.9 <= (end - ini) <= 1.1  # Allow for small timing variations
 
 
@@ -140,3 +140,33 @@ def test_retry_until_args_reach_predicate() -> None:
 
     assert retry_until(ready, 1, args=("pane", 3), interval=0)
     assert seen == [("pane", 3)] * 3
+
+
+def test_wall_clock_step_does_not_end_the_wait(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A wall-clock jump mid-wait neither shortens nor lengthens the budget.
+
+    Regression: the budget was measured with :func:`time.time`, so an NTP
+    correction, a container clock sync, or a VM resume landing inside the
+    wait ended it early. Stepping :func:`time.time` forward by an hour here
+    must not be observable, because nothing reads it.
+    """
+    stepped = 0.0
+
+    def stepping_time() -> float:
+        nonlocal stepped
+        stepped += 3600.0
+        return monotonic() + stepped
+
+    monkeypatch.setattr("time.time", stepping_time)
+
+    calls = 0
+
+    def true_on_third() -> bool:
+        nonlocal calls
+        calls += 1
+        return calls >= 3
+
+    assert retry_until(true_on_third, 5)
+    assert calls == 3

--- a/tests/test/test_retry.py
+++ b/tests/test/test_retry.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+import typing as t
 from time import sleep, time
 
 import pytest
 
 from libtmux import exc
 from libtmux.test.retry import retry_until
+
+if t.TYPE_CHECKING:
+    from libtmux.session import Session
 
 
 def test_retry_three_times() -> None:
@@ -103,3 +107,36 @@ def test_retry_three_times_no_raise_assert() -> None:
 
     end = time()
     assert 0.9 <= (end - ini) <= 1.1  # Allow for small timing variations
+
+
+def test_retry_until_forwards_args_from_loop(session: Session) -> None:
+    """Waiting on a loop variable needs no closure, so no B023 suppression."""
+    window = session.new_window(window_name="retry_until_args")
+    active_pane = window.active_pane
+    assert active_pane is not None
+    panes = [active_pane, window.split()]
+
+    for pane in panes:
+        pane.send_keys("echo ready")
+
+    for pane in panes:
+        # Whole lines, not a substring: capture_pane returns the command tmux
+        # echoed onto the pane, so ``"ready" in ...`` is true before the shell
+        # has run and the wait would prove nothing.
+        assert retry_until(
+            lambda p: any(line.strip() == "ready" for line in p.capture_pane()),
+            2,
+            args=(pane,),
+        )
+
+
+def test_retry_until_args_reach_predicate() -> None:
+    """Every retry passes the same ``args`` to the predicate."""
+    seen: list[tuple[str, int]] = []
+
+    def ready(name: str, threshold: int) -> bool:
+        seen.append((name, threshold))
+        return len(seen) >= threshold
+
+    assert retry_until(ready, 1, args=("pane", 3), interval=0)
+    assert seen == [("pane", 3)] * 3


### PR DESCRIPTION
## Summary

- **Add** a keyword-only `args` tuple to `retry_until()`, unpacked into every call of the predicate, so the object being waited on is passed rather than closed over.
- **Add** two typing overloads: the zero-argument predicate keeps strict checking when `args` is absent, and `args` is required on the forwarding overload so it cannot be selected by accident.
- **Document** the parameter, with a doctest that waits on each pane of a loop.

## The problem

A zero-argument predicate has nowhere to put the subject, so a wait written inside a loop has to close over the loop variable. This repo enables flake8-bugbear, which rejects that:

```
B023 Function definition does not bind loop variable `pane`
    retry_until(lambda: any(pane.capture_pane()))
                             ^^^^
```

B023's documented fix is a default-argument binding — which mypy then refuses to infer:

```
error: Cannot infer type of lambda  [misc]
```

So the lint-clean form does not type-check and the type-clean form does not lint, leaving `# type: ignore[misc]` as the only way out at every such call site.

**No existing call site on `master` suffers from this** — they all use named nested functions. This is a preventative ergonomic change, not a repair of live breakage.

## Before / After

```python
for pane in panes:
    retry_until(lambda pane=pane: any(pane.capture_pane()))  # type: ignore[misc]
```

```python
for pane in panes:
    retry_until(lambda p: any(p.capture_pane()), args=(pane,))
```

## Design decisions

**Overloads rather than one widened signature.** Widening `fun` to `Callable[..., bool]` outright would have stopped mypy catching a predicate that wrongly takes arguments in the common zero-argument case. Two overloads keep that: the first takes `Callable[[], bool]` and has no `args` parameter at all, the second takes `Callable[..., bool]` with `args` **required** — no default — so the strict overload is selected whenever `args` is absent.

**`args` is keyword-only.** `seconds` is already positional-second, so a positional `args` would have been ambiguous at the call site and a source of silent misreads.

**Not shipping ready-made waits.** The issue also proposes exposing the two common cases ("this pane produced anything", "this pane printed this whole line") as methods. That is a larger, separate change with its own API surface, and would deserve its own issue; this PR only removes the reason a caller has to write a closure.

## A trap the examples deliberately avoid

`capture_pane()` returns the command tmux echoed onto the pane, so a substring test for the expected output matches that echo and is already true before the shell has run anything. Both the new doctest and the new test therefore compare **whole lines**, and say why in a comment — otherwise they would pass in a world where no shell ever ran, which is exactly the failure mode being tracked in #715.

## Test plan

- [x] `test_retry_until_forwards_args_from_loop` — waits on each pane of a loop through the new path, with no `# type: ignore` and no `# noqa` in the file
- [x] `test_retry_until_args_reach_predicate` — the tuple arrives at the predicate on every attempt
- [x] `uv run ruff check .` clean, which is the assertion that B023 no longer fires
- [x] `uv run mypy` clean, which is the assertion that the overloads resolve
- [x] Doctests on `retry_until` collected and run
- [x] `uv run py.test --reruns 0` clean
- [x] `just build-docs` clean

## Note for the merger

The `CHANGES` entry cites the issue number; swap it for this PR's number on merge. It will conflict with the sibling PRs for #723, #724 and #725, which all add to the same block — keep both sides.