### PR TITLE
Bound the control-mode wait off the descriptor

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -59,6 +59,13 @@ it.
 
 ### Development
 
+#### The control-mode test no longer flakes in CI (#733)
+
+`test_control_mode_stdout_preserves_non_ascii_output` intermittently timed out
+waiting for output that had already arrived, so it failed on loaded runners and
+passed on re-run. The test now bounds its wait with a reader thread and a
+deadline. The non-ASCII decoding regression it guards is still covered.
+
 #### CI actions updated to current majors
 
 Workflow actions moved to their current major releases: `actions/checkout` v7,

--- a/tests/test_control_mode.py
+++ b/tests/test_control_mode.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import locale
 import os
-import select
+import queue
 import sys
+import threading
+import time
 import typing as t
 
 import pytest
@@ -14,7 +16,63 @@ from libtmux._internal.control_mode import ControlMode
 from libtmux.formats import FORMAT_SEPARATOR
 
 if t.TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from libtmux.server import Server
+
+
+def _read_lines(
+    stream: t.IO[str],
+    *,
+    limit: int,
+    timeout: float,
+) -> Iterator[str]:
+    """Yield up to *limit* lines from *stream*, giving up after *timeout*.
+
+    A reader thread owns the stream and the caller polls a queue, so the wait
+    is bounded without anything having to ask the file descriptor whether a
+    line is available.
+
+    That question has no useful answer here. ``ControlMode`` builds its
+    subprocess with ``text=True``, so ``stream`` is a ``TextIOWrapper`` over a
+    ``BufferedReader``: ``select`` would report readiness on the raw
+    descriptor while ``readline`` serves from the userspace buffer above it.
+    tmux writes a whole ``%begin``/``%end`` block in one burst, so the first
+    ``readline`` routinely drains every remaining line off the descriptor --
+    leaving ``select`` with nothing to report and the answer already in hand.
+    """
+    lines: queue.Queue[str | BaseException | None] = queue.Queue()
+
+    def pump() -> None:
+        try:
+            for line in stream:
+                lines.put(line)
+        except BaseException as e:  # noqa: BLE001
+            # Carry it across the thread boundary. Collapsing it into the
+            # ``None`` sentinel would report the reader as having reached EOF,
+            # naming the wrong cause for a decode error this test exists to
+            # catch.
+            lines.put(e)
+        finally:
+            lines.put(None)
+
+    reader = threading.Thread(target=pump, daemon=True)
+    reader.start()
+
+    deadline = time.monotonic() + timeout
+    for _ in range(limit):
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            pytest.fail("timed out waiting for control-mode output")
+        try:
+            line = lines.get(timeout=remaining)
+        except queue.Empty:
+            pytest.fail("timed out waiting for control-mode output")
+        if isinstance(line, BaseException):
+            raise line
+        if line is None:
+            pytest.fail("control-mode stream closed before the expected output")
+        yield line
 
 
 def test_control_mode_creates_client(
@@ -86,11 +144,7 @@ def test_control_mode_stdout_preserves_non_ascii_output(
                 f"display-message -p '{FORMAT_SEPARATOR}'\n".encode(),
             )
 
-            for _ in range(20):
-                ready, _, _ = select.select([ctl.stdout], [], [], 1)
-                assert ready, "timed out waiting for control-mode output"
-
-                line = ctl.stdout.readline()
+            for line in _read_lines(ctl.stdout, limit=20, timeout=5):
                 if FORMAT_SEPARATOR in line:
                     break
             else:


### PR DESCRIPTION
Closes #731.

## Summary

- **Fix** `test_control_mode_stdout_preserves_non_ascii_output` timing out while the line it wants sits in the buffer. It bounded its wait with `select` on the descriptor and read with `readline`, which serves from the `TextIOWrapper` above it.
- **Replace** `select` with a reader thread and a queue polled against a monotonic deadline, so the wait is bounded without asking the descriptor a question it cannot answer.
- **Leave `ControlMode` untouched.** `text=True, encoding="utf-8"` is exactly the behaviour this test exists to guard.

## Why the descriptor cannot answer

tmux writes a whole `%begin`/`%end` block in one burst, so the reply arrives together. The first `readline` drains up to 8192 bytes off the descriptor into userspace and returns one line; the rest sits in the decoder, and the descriptor is now empty. `select` reports not-ready while the answer is microseconds away:

```
select NOT ready at iter=1 (last read = '%begin 1785458429 355 1')
  readline #0 returned in 7us  -> '␞'
  readline #1 returned in 3us  -> '%end 1785458429 355 1'
  readline #2 BLOCKED (fd empty)
```

What made the old test pass was unrelated `%output` from the pane's shell painting its prompt, arriving ~460 ms later and re-arming `select`. The test passed for a reason unconnected to the data it asserts on, which is why it failed on loaded CI runners: once the read loop starts after that burst, failure is certain rather than unlikely.

## Before / After

Injecting a 300 ms stall before the read loop, everything else verbatim:

```
before:  delay=0.0  0/4 failed   delay=0.15  1/4 failed   delay=0.3  3/4 failed
after:   delay=0.3  0/4 failed
```

## The coverage is preserved

The risk in rewriting this test is silently retiring what it guards. Verified by removing `encoding="utf-8"` from `ControlMode` and re-running:

```
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 107: ordinal not in range(128)
1 failed
```

Still caught. Restored, it passes.

## Design notes

**A thread rather than `select` on `stdout.buffer.raw`.** Both work. Selecting on the raw descriptor means the test owns partial-line assembly and decoding — real logic, in a test whose subject is decoding. The thread keeps `readline` doing the line splitting and adds only a bound.

**Monotonic deadline, not a per-iteration timeout.** A fixed timeout per line lets a slow-but-progressing stream run for `limit × timeout`. The deadline bounds the whole read.

**Fails, never hangs.** Stream exhaustion is reported distinctly from expiry, so a closed pipe does not present as a timeout.

## Test plan

- [x] `tests/test_control_mode.py` green, 3 consecutive runs at `--reruns 0`
- [x] Survives a 300 ms injected stall, 4/4, where the previous version failed 3/4
- [x] Still fails with `encoding="utf-8"` removed from `ControlMode`
- [x] `uv run ruff check .` / `uv run ruff format .` / `uv run mypy` clean
- [x] `uv run py.test --reruns 0` clean
- [x] `just build-docs` clean

## Note for the merger

`CHANGES` will conflict with the sibling PRs for #723, #724, #725 and #726, which all add to the same block — keep both sides.