### PR TITLE
Bound a tmux command that may never return

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -45,6 +45,31 @@ $ uvx --from 'libtmux' --prerelease allow python
 _Notes on the upcoming release will go here._
 <!-- END PLACEHOLDER - ADD NEW CHANGELOG ENTRIES BELOW THIS LINE -->
 
+### What's new
+
+#### Bounded tmux commands (#735)
+
+{meth}`Server.wait_for() <libtmux.Server.wait_for>` takes a `timeout` in seconds.
+A tmux channel is a rendezvous with no clock on it: when the pane that was going
+to signal is killed, exits early, or has its window closed, the waiter blocks for
+the life of the process. `server.wait_for(channel, timeout=60)` turns that into
+a {exc}`~libtmux.exc.TmuxCommandTimeout` you can catch. It subclasses
+{exc}`~libtmux.exc.WaitTimeout`, so existing handlers keep working, and it
+carries the command that was killed and the bound it exceeded.
+
+The bound is available to any tmux command, not just `wait-for`.
+{meth}`Server.cmd() <libtmux.Server.cmd>`,
+{meth}`Session.cmd() <libtmux.Session.cmd>`,
+{meth}`Window.cmd() <libtmux.Window.cmd>`,
+{meth}`Pane.cmd() <libtmux.Pane.cmd>`, and
+{class}`~libtmux.common.tmux_cmd` beneath them all accept `timeout`, and all
+kill and reap the tmux client libtmux spawned before raising, so the call
+leaves no child of its own behind. Work the command started — a pane's
+foreground process, the tmux server — keeps running. The default, `None`,
+waits as long as tmux takes.
+
+See {ref}`automation-patterns` for waiting on a channel instead of polling.
+
 ### Documentation
 
 #### Automation patterns waits for tmux instead of guessing (#734)

--- a/docs/topics/automation_patterns.md
+++ b/docs/topics/automation_patterns.md
@@ -126,8 +126,9 @@ block on that channel with {meth}`~libtmux.Server.wait_for`. tmux remembers a si
 sent before the waiter starts, so this has no lost-wakeup race. It also avoids
 confusing the shell's echoed command with the command's output.
 
-{meth}`~libtmux.Server.wait_for` has no timeout. Make sure every expected exit path
-reaches `tmux wait-for -S` so a failed command cannot leave your script blocked.
+{meth}`~libtmux.Server.wait_for` waits indefinitely unless you give it a `timeout`.
+Either make sure every expected exit path reaches `tmux wait-for -S`, or bound the
+wait, so a failed command cannot leave your script blocked.
 Channels are server-wide, so give each in-flight command a distinct channel name.
 
 ```python
@@ -452,6 +453,65 @@ True
 >>> # Clean up
 >>> timeout_window.kill()
 ```
+
+### Waiting for a signal instead of polling
+
+Polling costs you a tmux round-trip per read and a `sleep` you pay whether the
+command finished or not. tmux offers the other half of the trade: a *channel*,
+where one process waits and another signals, and nobody polls in between. The
+pane signals with `tmux wait-for -S`, and your script waits with
+{meth}`~libtmux.Server.wait_for`.
+
+What you give up is the guarantee that the signal arrives at all — kill the pane,
+close its window, or have the command exit before it reaches the `wait-for`, and
+the waiter waits forever. Pass a `timeout` to cap it, and a missing signal becomes
+a {exc}`~libtmux.exc.TmuxCommandTimeout` you can catch. It is a
+{exc}`~libtmux.exc.WaitTimeout`, so an existing handler still catches it, and it
+carries the command that was killed and the bound it blew.
+
+```python
+>>> signal_window = session.new_window(window_name='signal-demo', attach=False)
+>>> signal_pane = signal_window.active_pane
+
+>>> channel = 'demo-work-done'
+>>> signal_pane.send_keys(f'echo "working"; tmux wait-for -S {channel}')
+>>> session.server.wait_for(channel, timeout=60)
+
+>>> signal_window.kill()
+```
+
+Nothing signals `never-arrives`, so the wait ends on the clock rather than on the
+work:
+
+```python
+>>> from libtmux import exc
+
+>>> try:
+...     session.server.wait_for('never-arrives', timeout=0.25)
+... except exc.TmuxCommandTimeout as e:
+...     print(f'gave up after {e.timeout}s')
+gave up after 0.25s
+```
+
+The bound belongs to the call, not to the server object, so the same server can
+carry a patient wait for a build and an impatient one for a health check.
+
+Two properties of tmux's rendezvous are worth knowing before you rely on it.
+
+A wait that times out is abandoned rather than withdrawn, and tmux only
+*remembers* a signal when nothing is waiting for the channel. The abandoned wait
+still counts, so the next signal on that channel is spent waking it instead of
+being remembered — one signal, after which the channel behaves normally again.
+Waits already in flight are woken as usual and other channels are untouched.
+Naming a fresh channel per rendezvous, from a build id or a UUID, sidesteps it
+entirely.
+
+A returning `wait_for` also means less than it appears to. tmux releases every
+waiter when the server shuts down, and it does so exactly as if the channel had
+been signalled, so a pane that died and a command that finished are
+indistinguishable from the wait alone. When it matters whether the work actually
+succeeded, have the command report its own result — write the exit status to a
+pane option and read it back — rather than treating the wake-up as proof.
 
 ### Retry pattern
 

--- a/src/libtmux/common.py
+++ b/src/libtmux/common.py
@@ -280,8 +280,69 @@ def raise_if_stderr(proc: tmux_cmd, subcommand: str) -> None:
         )
 
 
+def _kill_and_reap(process: subprocess.Popen[str]) -> None:
+    """Kill a subprocess that outstayed its timeout, then reap it.
+
+    :meth:`subprocess.Popen.communicate` leaves the child running when its
+    *timeout* expires -- the caller has to kill and reap it, the same dance
+    :func:`subprocess.run` does on its own timeout path. Skipping it leaks one
+    tmux process per expiry.
+
+    The child is waited for rather than drained: after ``SIGKILL`` it exits
+    promptly, while reading its pipes to EOF could block on a grandchild that
+    inherited them -- past the bound the caller just asked to enforce. The
+    pipes are closed by hand instead, since nothing will read them.
+
+    Parameters
+    ----------
+    process : :class:`subprocess.Popen`
+        The timed-out child.
+
+    Examples
+    --------
+    >>> from libtmux.common import _kill_and_reap
+    >>> process = subprocess.Popen(
+    ...     [sys.executable, '-c', 'import time; time.sleep(300)'],
+    ...     stdout=subprocess.PIPE,
+    ...     stderr=subprocess.PIPE,
+    ...     text=True,
+    ... )
+    >>> process.poll() is None  # still running
+    True
+
+    >>> _kill_and_reap(process)
+    >>> process.returncode is not None  # dead, and its exit status collected
+    True
+    """
+    process.kill()
+    process.wait()
+    for stream in (process.stdout, process.stderr):
+        if stream is not None:
+            stream.close()
+
+
 class tmux_cmd:
     """Run any :term:`tmux(1)` command through :py:mod:`subprocess`.
+
+    Parameters
+    ----------
+    *args : object
+        tmux arguments, stringified and appended after the binary.
+    tmux_bin : str, optional
+        Path to the tmux binary. Resolved from ``$PATH`` when *None*.
+    timeout : float, optional
+        Seconds to allow tmux to run. *None* (the default) waits as long as
+        tmux takes, which is what a rendezvous like ``wait-for`` needs when
+        nobody is watching the clock. Give it a number when the command can
+        block on something that may never happen.
+
+    Raises
+    ------
+    :exc:`~libtmux.exc.TmuxCommandTimeout`
+        When *timeout* elapses. The tmux client this spawned is killed and
+        reaped before the exception leaves, so the call leaves no child of its
+        own behind. Work the command started -- a pane's foreground process,
+        the tmux server -- is unaffected and keeps running.
 
     Examples
     --------
@@ -303,13 +364,46 @@ class tmux_cmd:
 
         $ tmux new-session -s my session
 
+    ``tmux wait-for`` blocks until another process signals the channel. Bound
+    it, and a channel nobody signals costs a known amount of time:
+
+    >>> from libtmux import exc
+    >>> try:
+    ...     tmux_cmd(
+    ...         f'-L{server.socket_name}', 'wait-for', 'nobody-signals-me',
+    ...         timeout=0.25,
+    ...     )
+    ... except exc.TmuxCommandTimeout as e:
+    ...     print(e)
+    tmux command timed out after 0.25s: ...wait-for nobody-signals-me
+
+    The exception carries what was killed and the bound it blew, so a caller
+    does not have to parse the message back apart:
+
+    >>> try:
+    ...     tmux_cmd(
+    ...         f'-L{server.socket_name}', 'wait-for', 'nobody-signals-me',
+    ...         timeout=0.25,
+    ...     )
+    ... except exc.TmuxCommandTimeout as e:
+    ...     (e.timeout, e.cmd[-2:])
+    (0.25, ['wait-for', 'nobody-signals-me'])
+
     Notes
     -----
+    .. versionchanged:: 0.63
+        Added *timeout*.
+
     .. versionchanged:: 0.8
         Renamed from ``tmux`` to ``tmux_cmd``.
     """
 
-    def __init__(self, *args: t.Any, tmux_bin: str | None = None) -> None:
+    def __init__(
+        self,
+        *args: t.Any,
+        tmux_bin: str | None = None,
+        timeout: float | None = None,
+    ) -> None:
         resolved = tmux_bin or shutil.which("tmux")
         if not resolved:
             raise exc.TmuxCommandNotFound
@@ -336,10 +430,20 @@ class tmux_cmd:
                 encoding="utf-8",
                 errors="backslashreplace",
             )
-            stdout, stderr = self.process.communicate()
+            stdout, stderr = self.process.communicate(timeout=timeout)
             returncode = self.process.returncode
         except FileNotFoundError:
             raise exc.TmuxCommandNotFound from None
+        except subprocess.TimeoutExpired as e:
+            _kill_and_reap(self.process)
+            logger.error(  # noqa: TRY400
+                "tmux command timed out",
+                extra={
+                    "tmux_cmd": shlex.join(cmd),
+                    "tmux_timeout": e.timeout,
+                },
+            )
+            raise exc.TmuxCommandTimeout(cmd=cmd, timeout=e.timeout) from None
         except Exception:
             logger.error(  # noqa: TRY400
                 "tmux subprocess failed",

--- a/src/libtmux/exc.py
+++ b/src/libtmux/exc.py
@@ -7,6 +7,7 @@ libtmux.exc
 
 from __future__ import annotations
 
+import shlex
 import typing as t
 
 if t.TYPE_CHECKING:
@@ -348,6 +349,78 @@ class AmbiguousOption(OptionError):
 
 class WaitTimeout(LibTmuxException):
     """Function timed out without meeting condition."""
+
+
+class TmuxCommandTimeout(WaitTimeout):
+    """A tmux command outlived its timeout and the tmux client was killed.
+
+    Raised from :class:`~libtmux.common.tmux_cmd`, and therefore from every
+    :meth:`Server.cmd() <libtmux.Server.cmd>`,
+    :meth:`Session.cmd() <libtmux.Session.cmd>`,
+    :meth:`Window.cmd() <libtmux.Window.cmd>`, and
+    :meth:`Pane.cmd() <libtmux.Pane.cmd>` call layered on it, whenever a
+    timeout is in force and the command exceeds it. The tmux client libtmux
+    spawned is sent ``SIGKILL`` and reaped before this is raised, so the call
+    leaves no child of its own behind.
+
+    That is the client, not the work. Anything the command set in motion --
+    a pane's foreground process, the tmux server itself -- keeps running, and
+    a caller that needs it stopped has to say so.
+
+    Subclasses :exc:`WaitTimeout` rather than replacing it: code that already
+    catches libtmux's timeout keeps working, while callers who want the
+    command line and the bound that was exceeded can reach for them.
+
+    Parameters
+    ----------
+    cmd : list[str]
+        Full tmux command line that was killed, argv-style.
+    timeout : float
+        Bound, in seconds, that the command exceeded.
+    *args : object
+        Forwarded to :exc:`LibTmuxException`.
+
+    Attributes
+    ----------
+    cmd : list[str]
+        Full tmux command line that was killed, argv-style.
+    timeout : float
+        Bound, in seconds, that the command exceeded.
+
+    Examples
+    --------
+    >>> from libtmux import exc
+    >>> err = exc.TmuxCommandTimeout(
+    ...     cmd=["tmux", "wait-for", "build-done"],
+    ...     timeout=1.5,
+    ... )
+    >>> str(err)
+    'tmux command timed out after 1.5s: tmux wait-for build-done'
+
+    Existing handlers keep working, because it is still a
+    :exc:`WaitTimeout`:
+
+    >>> isinstance(err, exc.WaitTimeout)
+    True
+
+    >>> err.timeout
+    1.5
+
+    .. versionadded:: 0.63
+    """
+
+    def __init__(
+        self,
+        cmd: list[str],
+        timeout: float,
+        *args: object,
+    ) -> None:
+        self.cmd = cmd
+        self.timeout = timeout
+        super().__init__(
+            f"tmux command timed out after {timeout}s: {shlex.join(cmd)}",
+            *args,
+        )
 
 
 class VariableUnpackingError(LibTmuxException):

--- a/src/libtmux/pane.py
+++ b/src/libtmux/pane.py
@@ -311,6 +311,7 @@ class Pane(
         cmd: str,
         *args: t.Any,
         target: str | int | None = None,
+        timeout: float | None = None,
     ) -> tmux_cmd:
         """Execute tmux subcommand within pane context.
 
@@ -332,15 +333,31 @@ class Pane(
         ----------
         target : str, optional
             Optional custom target override. By default, the target is the pane ID.
+        timeout : float, optional
+            Seconds to allow this command to run before killing the tmux
+            client libtmux spawned and raising
+            :exc:`~libtmux.exc.TmuxCommandTimeout`. *None* (the default)
+            waits indefinitely.
 
         Returns
         -------
         :meth:`server.cmd`
+
+        Raises
+        ------
+        :exc:`~libtmux.exc.TmuxCommandTimeout`
+            When *timeout* elapses.
+
+        Notes
+        -----
+        .. versionchanged:: 0.63
+
+           Added ``timeout``.
         """
         if target is None:
             target = self.pane_id
 
-        return self.server.cmd(cmd, *args, target=target)
+        return self.server.cmd(cmd, *args, target=target, timeout=timeout)
 
     """
     Commands (tmux-like)

--- a/src/libtmux/server.py
+++ b/src/libtmux/server.py
@@ -342,6 +342,7 @@ class Server(
         cmd: str,
         *args: t.Any,
         target: str | int | None = None,
+        timeout: float | None = None,
     ) -> tmux_cmd:
         """Execute tmux command respective of socket name and file, return output.
 
@@ -375,17 +376,42 @@ class Server(
         ... 'split-window', '-P', '-F#{pane_id}').stdout[0], server=window.server)
         Pane(%... Window(@... ...:..., Session($1 libtmux_...)))
 
+        Most tmux commands return at once. The few that block -- ``wait-for``,
+        a foreground ``run-shell`` -- can be bounded, and give up as a libtmux
+        error rather than hanging:
+
+        >>> from libtmux import exc
+        >>> try:
+        ...     server.cmd('wait-for', 'nobody-signals-me', timeout=0.25)
+        ... except exc.TmuxCommandTimeout:
+        ...     print('gave up')
+        gave up
+
         Parameters
         ----------
         target : str, optional
             Optional custom target.
+        timeout : float, optional
+            Seconds to allow this command to run before killing the tmux
+            client libtmux spawned and raising
+            :exc:`~libtmux.exc.TmuxCommandTimeout`. *None* (the default)
+            waits indefinitely.
 
         Returns
         -------
         :class:`common.tmux_cmd`
 
+        Raises
+        ------
+        :exc:`~libtmux.exc.TmuxCommandTimeout`
+            When *timeout* elapses.
+
         Notes
         -----
+        .. versionchanged:: 0.63
+
+            Added ``timeout``.
+
         .. versionchanged:: 0.8
 
             Renamed from ``.tmux`` to ``.cmd``.
@@ -408,7 +434,12 @@ class Server(
 
         cmd_args = ["-t", str(target), *args] if target is not None else [*args]
 
-        return tmux_cmd(*svr_args, *cmd_args, tmux_bin=self.tmux_bin)
+        return tmux_cmd(
+            *svr_args,
+            *cmd_args,
+            tmux_bin=self.tmux_bin,
+            timeout=timeout,
+        )
 
     @property
     def attached_sessions(self) -> list[Session]:
@@ -624,8 +655,15 @@ class Server(
         lock: bool | None = None,
         unlock: bool | None = None,
         set_flag: bool | None = None,
+        timeout: float | None = None,
     ) -> None:
         """Wait for, signal, or lock a channel via ``$ tmux wait-for``.
+
+        A channel is a rendezvous: one process waits, another signals, and
+        tmux wakes the waiter with no polling in between. The catch is that
+        nothing guarantees the signal ever arrives -- the pane that was going
+        to send it can be killed, exit early, or have its window closed. Pass
+        *timeout* to put a ceiling on the wait.
 
         Parameters
         ----------
@@ -637,12 +675,44 @@ class Server(
             Unlock the channel (``-U`` flag).
         set_flag : bool, optional
             Set the channel flag and wake waiters (``-S`` flag).
+        timeout : float, optional
+            Seconds to wait before giving up and raising
+            :exc:`~libtmux.exc.TmuxCommandTimeout`. *None* (the default) waits
+            forever, which is what you want when the signal is certain.
+
+        Raises
+        ------
+        :exc:`~libtmux.exc.TmuxCommandTimeout`
+            When *timeout* elapses before the channel is signalled.
 
         Examples
         --------
         >>> server.new_session(session_name='wait_test')
         Session(...)
         >>> server.wait_for('test_channel', set_flag=True)
+
+        Wait on a pane that signals when its work is done, bounded in case
+        the work never gets that far:
+
+        >>> channel = 'build-done'
+        >>> pane.send_keys(f'make; tmux wait-for -S {channel}')
+        >>> server.wait_for(channel, timeout=60)
+
+        A channel nobody signals costs *timeout* seconds instead of the rest
+        of the process's life:
+
+        >>> from libtmux import exc
+        >>> try:
+        ...     server.wait_for('nobody-signals-me', timeout=0.25)
+        ... except exc.TmuxCommandTimeout:
+        ...     print('gave up waiting')
+        gave up waiting
+
+        Notes
+        -----
+        .. versionchanged:: 0.63
+
+           Added ``timeout``.
         """
         tmux_args: tuple[str, ...] = ()
 
@@ -657,7 +727,7 @@ class Server(
 
         tmux_args += (channel,)
 
-        proc = self.cmd("wait-for", *tmux_args)
+        proc = self.cmd("wait-for", *tmux_args, timeout=timeout)
 
         raise_if_stderr(proc, "wait-for")
 

--- a/src/libtmux/session.py
+++ b/src/libtmux/session.py
@@ -418,6 +418,7 @@ class Session(
         cmd: str,
         *args: t.Any,
         target: str | int | None = None,
+        timeout: float | None = None,
     ) -> tmux_cmd:
         """Execute tmux subcommand within session context.
 
@@ -439,13 +440,27 @@ class Session(
         ----------
         target : str, optional
             Optional custom target override. By default, the target is the session ID.
+        timeout : float, optional
+            Seconds to allow this command to run before killing the tmux
+            client libtmux spawned and raising
+            :exc:`~libtmux.exc.TmuxCommandTimeout`. *None* (the default)
+            waits indefinitely.
 
         Returns
         -------
         :meth:`server.cmd`
 
+        Raises
+        ------
+        :exc:`~libtmux.exc.TmuxCommandTimeout`
+            When *timeout* elapses.
+
         Notes
         -----
+        .. versionchanged:: 0.63
+
+           Added ``timeout``.
+
         .. versionchanged:: 0.34
 
            Passing target by ``-t`` is ignored. Use ``target`` keyword argument instead.
@@ -456,7 +471,7 @@ class Session(
         """
         if target is None:
             target = self.session_id
-        return self.server.cmd(cmd, *args, target=target)
+        return self.server.cmd(cmd, *args, target=target, timeout=timeout)
 
     """
     Commands (tmux-like)

--- a/src/libtmux/window.py
+++ b/src/libtmux/window.py
@@ -463,6 +463,7 @@ class Window(
         cmd: str,
         *args: t.Any,
         target: str | int | None = None,
+        timeout: float | None = None,
     ) -> tmux_cmd:
         """Execute tmux subcommand within window context.
 
@@ -486,15 +487,31 @@ class Window(
         ----------
         target : str, optional
             Optional custom target override. By default, the target is the window ID.
+        timeout : float, optional
+            Seconds to allow this command to run before killing the tmux
+            client libtmux spawned and raising
+            :exc:`~libtmux.exc.TmuxCommandTimeout`. *None* (the default)
+            waits indefinitely.
 
         Returns
         -------
         :meth:`server.cmd`
+
+        Raises
+        ------
+        :exc:`~libtmux.exc.TmuxCommandTimeout`
+            When *timeout* elapses.
+
+        Notes
+        -----
+        .. versionchanged:: 0.63
+
+           Added ``timeout``.
         """
         if target is None:
             target = self.window_id
 
-        return self.server.cmd(cmd, *args, target=target)
+        return self.server.cmd(cmd, *args, target=target, timeout=timeout)
 
     """
     Commands (tmux-like)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+import inspect
 import locale
 import logging
+import os
 import re
+import signal
+import subprocess
 import sys
 import typing as t
 
@@ -762,3 +766,82 @@ def test_tmux_cmd_format_separator_survives_non_utf8_locale(
     result = parse_output(line, "list-sessions", tmux_version)
     assert isinstance(result, dict)
     assert "session_id" in result
+
+
+def test_tmux_cmd_timeout_kills_and_reaps_the_child(
+    session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A timed-out tmux process is killed, reaped, and its pipes closed.
+
+    :meth:`subprocess.Popen.communicate` leaves the child running when its
+    timeout expires, so an unhandled expiry leaks one tmux process per call.
+    The recorder wraps :class:`subprocess.Popen` because the exception path
+    never hands the caller the ``tmux_cmd`` holding the process.
+    """
+    spawned: list[subprocess.Popen[t.Any]] = []
+    real_popen = subprocess.Popen
+
+    def record_popen(*args: t.Any, **kwargs: t.Any) -> subprocess.Popen[t.Any]:
+        process = real_popen(*args, **kwargs)
+        spawned.append(process)
+        return process
+
+    monkeypatch.setattr(subprocess, "Popen", record_popen)
+
+    with pytest.raises(exc.TmuxCommandTimeout):
+        session.server.cmd("wait-for", "libtmux_reap_channel", timeout=0.5)
+
+    assert spawned, "no tmux subprocess was spawned"
+    process = spawned[-1]
+
+    assert process.returncode is not None, "child was left running"
+    assert process.returncode == -signal.SIGKILL, "child was not killed"
+
+    with pytest.raises(ChildProcessError):
+        os.waitpid(process.pid, os.WNOHANG)
+
+    assert process.stdout is not None
+    assert process.stdout.closed, "stdout pipe leaked"
+    assert process.stderr is not None
+    assert process.stderr.closed, "stderr pipe leaked"
+
+
+def test_tmux_cmd_timeout_that_is_not_reached_returns_normally(
+    session: Session,
+) -> None:
+    """A command that finishes inside its bound parses its output as usual."""
+    proc = tmux_cmd(
+        f"-L{session.server.socket_name}",
+        "display-message",
+        "-p",
+        "ok",
+        timeout=60,
+    )
+
+    assert proc.stdout == ["ok"]
+    assert proc.returncode == 0
+    assert proc.stderr == []
+
+
+def test_timeout_defaults_to_none_at_every_entry_point() -> None:
+    """Existing callers must not start timing out.
+
+    ``None`` is the only default that keeps today's unbounded behavior, and
+    keyword-only is what lets the parameter be added without disturbing the
+    positional ``*args`` every one of these entry points forwards to tmux.
+    """
+    entry_points = (
+        tmux_cmd.__init__,
+        libtmux.Server.cmd,
+        libtmux.Session.cmd,
+        libtmux.Window.cmd,
+        libtmux.Pane.cmd,
+        libtmux.Server.wait_for,
+    )
+
+    for func in entry_points:
+        parameter = inspect.signature(func).parameters["timeout"]
+
+        assert parameter.default is None, f"{func.__qualname__} defaults to a bound"
+        assert parameter.kind is inspect.Parameter.KEYWORD_ONLY

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1765,3 +1765,100 @@ def test_server_display_message_warns_on_tmux_error(
     """
     with pytest.warns(UserWarning, match="only one of -F or argument"):
         server.display_message("x", get_text=True, format_string="#{version}")
+
+
+def test_wait_for_bounds_a_channel_that_is_never_signalled(
+    session: Session,
+) -> None:
+    """A signal that never arrives costs ``timeout`` seconds, not forever.
+
+    Regression test for #732. ``enter=False`` types the command into the pane
+    without running it, so the ``wait-for -S`` half of the rendezvous never
+    happens -- the same shape as a pane that is killed, exits early, or has
+    its window closed before it can signal.
+    """
+    window = session.new_window(window_name="wait_for_timeout")
+    pane = window.active_pane
+    assert pane is not None
+
+    channel = "libtmux_never_signalled"
+    pane.send_keys(f"echo READY; tmux wait-for -S {channel}", enter=False)
+
+    start = time.monotonic()
+    with pytest.raises(exc.WaitTimeout):
+        session.server.wait_for(channel, timeout=1)
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 30, "wait_for(timeout=) did not bound the wait"
+
+
+def test_wait_for_returns_when_the_channel_is_signalled(session: Session) -> None:
+    """A bounded wait still resolves normally when the signal does arrive."""
+    window = session.new_window(window_name="wait_for_signalled")
+    pane = window.active_pane
+    assert pane is not None
+
+    channel = "libtmux_signalled"
+    pane.send_keys(f"tmux wait-for -S {channel}")
+
+    session.server.wait_for(channel, timeout=60)
+
+
+def test_wait_for_timeout_raises_a_libtmux_error(session: Session) -> None:
+    """The timeout surfaces as a libtmux error, never as a stdlib one.
+
+    Callers write ``except LibTmuxException``; a :exc:`subprocess.TimeoutExpired`
+    escaping here would leak the implementation through the library boundary,
+    including through exception chaining.
+    """
+    with pytest.raises(exc.TmuxCommandTimeout) as excinfo:
+        session.server.wait_for("libtmux_boundary_channel", timeout=0.5)
+
+    assert isinstance(excinfo.value, exc.LibTmuxException)
+    assert not isinstance(excinfo.value, subprocess.TimeoutExpired)
+    assert not isinstance(excinfo.value.__cause__, subprocess.TimeoutExpired)
+    assert "timed out after 0.5s" in str(excinfo.value)
+
+
+def test_wait_for_timeout_reports_what_it_killed(session: Session) -> None:
+    """The timeout carries the killed command and the bound it exceeded.
+
+    Callers that catch it should not have to parse the message back apart to
+    learn which command was killed, and an existing ``except WaitTimeout``
+    handler keeps working because the error is still one.
+    """
+    with pytest.raises(exc.TmuxCommandTimeout) as excinfo:
+        session.server.wait_for("libtmux_reported_channel", timeout=0.5)
+
+    assert isinstance(excinfo.value, exc.WaitTimeout)
+    assert excinfo.value.timeout == 0.5
+    assert excinfo.value.cmd[-2:] == ["wait-for", "libtmux_reported_channel"]
+
+
+def test_cmd_timeout_threads_through_the_object_hierarchy(session: Session) -> None:
+    """Every ``cmd()`` in the hierarchy honors ``timeout``.
+
+    A foreground ``run-shell`` blocks the tmux client until the shell command
+    finishes, and unlike ``wait-for`` it accepts the ``-t`` target that
+    :meth:`Session.cmd`, :meth:`Window.cmd`, and :meth:`Pane.cmd` bind
+    automatically.
+    """
+    window = session.new_window(window_name="cmd_timeout")
+    pane = window.active_pane
+    assert pane is not None
+
+    for obj in (session.server, session, window, pane):
+        start = time.monotonic()
+        with pytest.raises(exc.WaitTimeout):
+            obj.cmd("run-shell", "sleep 10", timeout=0.5)
+        elapsed = time.monotonic() - start
+
+        assert elapsed < 30, f"{type(obj).__name__}.cmd(timeout=) did not bound"
+
+
+def test_cmd_without_timeout_still_returns(session: Session) -> None:
+    """Commands that finish on their own are untouched by the new parameter."""
+    proc = session.server.cmd("display-message", "-p", "ok")
+
+    assert proc.stdout == ["ok"]
+    assert proc.returncode == 0


### PR DESCRIPTION
Closes #732. Stacked on #734, which owns `docs/topics/automation_patterns.md`.

## What this does

`Server.wait_for()` wraps `tmux wait-for`, a rendezvous with no clock on it. When whatever was going to signal the channel dies first — the command is killed, the shell exits, the window closes — the wait never ends, and there was no ceiling anywhere beneath it either: [`communicate()`](https://github.com/tmux-python/libtmux/blob/v0.62.0/src/libtmux/common.py#L339) was called without one.

```python
pane.send_keys(f"make; tmux wait-for -S {channel}")
server.wait_for(channel, timeout=60)
```

`timeout` is keyword-only and available on `wait_for()` and on `cmd()` for `Server`, `Session`, `Window` and `Pane`, forwarding to `tmux_cmd`. Every entry point defaults to `None`, which is unbounded, so no existing call changes behaviour.

## Why the bound rides on the call

An instance-level default (`Server(timeout=30)`) was built and measured before this was chosen. It works, and it breaks blocking-by-design commands: on `Server(timeout=1.0)`, `server.cmd("attach-session", ...)` is killed at ~1.06s. Mitigating it needs a hand-maintained deny-list that by construction cannot cover a command a user dispatches themselves.

The reason is that the analogy to HTTP clients does not hold. `httpx` gets away with a client-level timeout because requests are homogeneous; tmux's command set is not. `display-message` should take milliseconds and `attach-session` should take hours, so no single per-server number is correct, and it is wrong precisely where being wrong hurts most.

Per-call also stays well-defined under batching, which matters for the engine work: a timeout carried by the request has an unambiguous meaning in a batch, where an engine-level default or an ambient scope has to choose between bounding the batch and bounding each command in it.

## Killing is not enough

`communicate()` does not kill the child when its timeout expires, and `kill()` alone leaves a zombie. Both are covered, because the difference is invisible to the obvious assertion — `os.kill(pid, 0)` succeeds against a zombie. The test pins `returncode == -SIGKILL` and that `os.waitpid` raises `ChildProcessError`.

`TmuxCommandTimeout` carries the killed command line and the bound it exceeded. It subclasses `WaitTimeout`, so handlers that already catch libtmux's timeout keep working, and it deliberately does not subclass `subprocess.TimeoutExpired` — the stdlib type never crosses the library boundary, including by chaining.

## Two tmux behaviours documented

Both were measured against tmux 3.7b while building this, and both are properties of the rendezvous rather than of this change.

A wait that times out is abandoned rather than withdrawn. tmux only remembers a signal when nothing is waiting for the channel ([`cmd-wait-for.c#L148`](https://github.com/tmux/tmux/blob/3.7b/cmd-wait-for.c#L148)), so the next signal is spent waking the abandoned wait — one signal, after which the channel behaves normally. A fresh channel name per rendezvous avoids it.

A returning wait is also weaker evidence than it looks. tmux releases every waiter when the server shuts down ([`cmd-wait-for.c#L244`](https://github.com/tmux/tmux/blob/3.7b/cmd-wait-for.c#L244)), and does so exactly as if the channel had been signalled, so a pane that died and a command that finished are indistinguishable from the wait alone. When the outcome matters, have the command report its own exit status.

## Verification

`ruff check`, `ruff format`, `mypy` (69 files), `py.test --reruns 0` (1468 passed, 1 skipped) and `just build-docs` all clean.