### PR TITLE
How-to guides a reader can paste, with the checks off the page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -301,6 +301,13 @@ needs the actual path, query tmux's `#{socket_path}` format with
 
 **`# doctest: +SKIP` is NOT permitted** - it's just another workaround that doesn't test anything. Use the fixtures properly - tmux is required to run tests anyway.
 
+**How-to guides are not doctests.** Pages under `docs/howto/` carry plain
+```` ```python ```` blocks a reader copies verbatim, with the assertions
+hidden in a sidecar under `tests/docs/howto/`. Their visible code carries no
+`assert`, polls against a deadline rather than sleeping, and names its socket
+so a paste cannot reach the reader's own tmux. `docs/AGENTS.md` has the full
+convention.
+
 **Using fixtures in doctests:**
 ```python
 >>> server.new_session(session_name='my_session')  # server from doctest_namespace

--- a/CHANGES
+++ b/CHANGES
@@ -57,6 +57,13 @@ environment-setup plumbing, so each example leads with the constructor call it
 demonstrates instead of the socket-path and `$TMUX` boilerplate needed to run
 it.
 
+#### How-to guides (#736)
+
+A new {ref}`how-to section <howto>` collects task-shaped recipes: starting and
+connecting to servers, locating the pane your code runs in, and driving panes.
+Every block is plain Python you can paste and run, and the suite runs each page
+end to end, so a guide that stops working fails the build.
+
 ### Development
 
 #### CI actions updated to current majors

--- a/CHANGES
+++ b/CHANGES
@@ -45,6 +45,16 @@ $ uvx --from 'libtmux' --prerelease allow python
 _Notes on the upcoming release will go here._
 <!-- END PLACEHOLDER - ADD NEW CHANGELOG ENTRIES BELOW THIS LINE -->
 
+### Fixes
+
+#### Splitting by percentage works on tmux 3.4 (#736)
+
+Passing `percentage=` to {meth}`Pane.split() <libtmux.Pane.split>` or
+{meth}`Window.split() <libtmux.Window.split>` raised
+{exc}`~libtmux.exc.LibTmuxException` on tmux 3.4, which rejects the sizing flag
+libtmux used. The size now rides on the spelling tmux has accepted since 3.1,
+so a percentage split behaves the same on every supported version.
+
 ### Documentation
 
 #### Cleaner `from_env` examples (#719)

--- a/conftest.py
+++ b/conftest.py
@@ -28,7 +28,7 @@ from libtmux.window import Window
 if t.TYPE_CHECKING:
     import pathlib
 
-pytest_plugins = ["pytester"]
+pytest_plugins = ["pytester", "tests.docs.howto_harness"]
 
 
 @pytest.fixture(autouse=True)

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -61,7 +61,9 @@ Never make the common case pay a comprehension tax for the advanced one.
 Prose examples under `docs/` are doctests, and the root `AGENTS.md`
 requires them to actually execute — `testpaths` includes `docs/`, so
 pytest runs every one. Lead with a small, runnable example early rather
-than after paragraphs of prose; libtmux is code-first.
+than after paragraphs of prose; libtmux is code-first. Pages under
+`docs/howto/` are the exception and work the other way round; see
+[How-to guides run differently](#how-to-guides-run-differently).
 
 - Use the `doctest_namespace` fixtures instead of building a server by
   hand. `conftest.py` seeds the namespace with `server`, `session`,
@@ -87,6 +89,52 @@ than after paragraphs of prose; libtmux is code-first.
   class itself. And the fixture server is created with a socket *name*,
   so `server.socket_path` is `None` — an example that needs the path
   must ask tmux for it with `display-message -p '#{socket_path}'`.
+
+## How-to guides run differently
+
+Everything above describes prose pages. `docs/howto/` inverts it: those
+pages carry code a reader copies into a file of their own, so they use
+plain ```` ```python ```` fences with no `>>>`, and **the page carries no
+test scaffolding at all** — no assertions, no markers, no hidden blocks.
+The visible block is the whole page.
+
+- **Blocks share one namespace, in document order.** Block 2 sees what
+  block 1 bound, because that is what a reader pasting in sequence gets.
+  This is the opposite of the rule above; write the page as one
+  continuous script broken into steps, not as independent snippets.
+- **Hidden checks live in a sidecar**, `tests/docs/howto/<slug>.py`,
+  where `<slug>` is the page's filename with hyphens as underscores. It
+  defines `check_N(ctx)` for each of the page's N blocks, and may define
+  `setup(ctx)` and `teardown(ctx)`. A missing sidecar, a missing
+  `check_N`, or a `check_N` with no block is a hard failure.
+- **Isolation is the runner's job.** Each page gets a private
+  `TMUX_TMPDIR` and `HOME` before its sidecar is called, and every socket
+  under that directory is killed afterwards. A sidecar never asks for it.
+- The page's `ctx` carries `namespace` (what the blocks bound), `output`
+  (what each block printed), `monkeypatch`, and `tmp_path`.
+  `ctx.run_block(n, namespace={})` re-runs a block in isolation, which is
+  how a check exercises the branch the reader's example only shows once.
+
+What the visible code must do, because a reader will run it verbatim:
+
+- **Name the socket** on any page that creates or destroys anything —
+  `Server(socket_name="libtmux-howto")` — so the example cannot reach the
+  tmux the reader already has open. Read-only pages use a plain `Server()`
+  on purpose: the question is about the reader's real server.
+- **Pass `kill_session=True`** to `new_session`, so pasting twice works.
+- **Poll against a deadline, never sleep a fixed amount**, and **compare
+  whole captured lines** — `capture_pane` returns the command tmux echoed
+  onto the pane, so a substring test is true before the shell has run.
+- **Never start a line with `# `** at column zero. sphinx-copybutton
+  reads it as a prompt and copies only such lines. Put the remark in the
+  prose, where it belongs.
+- Colon fences are for directives only. `:::python` renders a
+  copy-pasteable block that nothing executes, and is rejected.
+
+Adding a page: write `docs/howto/<slug>.md` opening with `(howto-<slug>)=`,
+add it to the grid and toctree in `docs/howto/index.md`, and write
+`tests/docs/howto/<slug>.py`. Every one of those four is enforced by a
+test, so getting it wrong is loud rather than silent.
 
 ## What stays precise
 

--- a/docs/howto/check-if-tmux-is-running.md
+++ b/docs/howto/check-if-tmux-is-running.md
@@ -1,0 +1,58 @@
+(howto-check-if-tmux-is-running)=
+
+# Check if tmux is running
+
+A {class}`~libtmux.Server` is a handle, not a connection. Constructing one
+costs nothing and starts nothing — it only records *which* socket you mean.
+So holding a `Server` tells you nothing about whether a tmux server is
+actually alive on the other end of it, and every attribute that reaches for
+live state has to find out.
+
+{meth}`~libtmux.Server.is_alive` is how you ask. It runs a single cheap
+command against the socket and answers yes or no; it never starts a server and
+never stops one.
+
+```python
+from libtmux import Server
+
+server = Server()
+
+if server.is_alive():
+    print(f"tmux is running with {len(server.sessions)} session(s)")
+else:
+    print("tmux is not running")
+```
+
+`Server()` with no arguments means tmux's default socket — the same one a bare
+`tmux` in your shell would use. Pass `socket_name=` or `socket_path=` to ask
+about a different one.
+
+:::{warning}
+Ask about a server with a plain handle, as above. `Server` is also a context
+manager, and {meth}`~libtmux.Server.__exit__` **kills the server** on the way
+out — so `with Server() as server:` around a liveness check would end the very
+tmux you were asking about, along with every session in it.
+:::
+
+## When you want the reason, not the answer
+
+{meth}`~libtmux.Server.is_alive` folds every way of failing to reach a server
+into a single `False`: no daemon, a socket that was deleted, a permission
+error, a `tmux` binary that isn't on `PATH`. That is the right shape for a
+branch, and the wrong shape for a diagnostic.
+
+Reach for {meth}`~libtmux.Server.raise_if_dead` when you need to tell those
+apart. It runs the same probe and lets the failure through:
+{exc}`~libtmux.exc.TmuxCommandNotFound` when there is no tmux binary to run,
+and {exc}`subprocess.CalledProcessError` when tmux ran and reported no server.
+
+The same leniency governs the list accessors. {attr}`~libtmux.Server.sessions`
+returns an empty {class}`~libtmux._internal.query_list.QueryList` when the
+underlying `list-sessions` fails, for any reason at all — so an empty list
+means "no sessions *or* no server", and only `is_alive()` or
+`raise_if_dead()` will tell you which.
+
+## Related
+
+- {ref}`traversal` — walk from a live server down to its panes.
+- {ref}`about` — what a `Server` handle is, and what it is not.

--- a/docs/howto/check-if-tmux-is-running.md
+++ b/docs/howto/check-if-tmux-is-running.md
@@ -54,5 +54,6 @@ means "no sessions *or* no server", and only `is_alive()` or
 
 ## Related
 
+- {ref}`howto-send-keys-to-every-pane` — drive a session once you have one.
 - {ref}`traversal` — walk from a live server down to its panes.
 - {ref}`about` — what a `Server` handle is, and what it is not.

--- a/docs/howto/connect-to-an-existing-pane.md
+++ b/docs/howto/connect-to-an-existing-pane.md
@@ -1,0 +1,89 @@
+(howto-connect-to-an-existing-pane)=
+
+# Connect to an existing pane
+
+A {class}`~libtmux.Pane` is the leaf of the hierarchy — the terminal a shell is
+actually running in — and it is what you need a handle on before you can type
+into it or read it back. Panes belong to a window, so you find one by getting
+the window first and asking it what it holds.
+
+```python
+from libtmux import Server
+
+server = Server()
+session = server.sessions.get(session_name="editor", default=None)
+
+if session is None:
+    print("no session named 'editor' — use a session name of your own")
+else:
+    window = session.active_window
+    for pane in window.panes:
+        print(
+            f"{pane.pane_index}\t{pane.pane_id}\t{pane.pane_width}x{pane.pane_height}"
+        )
+```
+
+If that printed *no session named 'editor'*, change the name before pasting the
+next block. Finding the session and the window is covered in
+{ref}`howto-connect-to-an-existing-session` and
+{ref}`howto-connect-to-an-existing-window`; from here on the window is a given.
+
+## The one you want is usually the active one
+
+{attr}`~libtmux.Window.active_pane` is the pane that window's cursor is in — the
+one a keystroke would land in. It is the right answer surprisingly often, and it
+saves you from picking a pane out of a list.
+
+```python
+pane = window.active_pane
+
+print(f"active: {pane.pane_id}")
+print(f"first:  {window.panes[0].pane_id}")
+print(f"last:   {window.panes[-1].pane_id}")
+```
+
+:::{warning}
+{attr}`~libtmux.Window.panes` is ordered by {attr}`~libtmux.Pane.pane_index`,
+and a pane's index is its **position in the layout**, not its age. Split the
+same pane twice and the second new pane lands *between* the original and the
+first one, so the newest pane sits at index 1 while `panes[-1]` is the pane you
+split off before it. Close a pane and every index after it shifts down.
+
+`panes[-1]` therefore means "bottom-right-most", never "newest". When you want
+the pane you just created, keep the {class}`~libtmux.Pane` that
+{meth}`~libtmux.Window.split` handed back — that is what it is for.
+:::
+
+## Hold the id
+
+{attr}`~libtmux.Pane.pane_id` — the `%`-prefixed value in the listing above — is
+fixed for the pane's lifetime, which makes it the only one of these handles
+worth storing. An index describes where a pane sits right now, and layouts
+change.
+
+{meth}`~libtmux.Pane.from_pane_id` turns a stored id back into an object,
+targeting tmux directly rather than scanning a listing, and raising
+{exc}`~libtmux.exc.TmuxObjectDoesNotExist` if the pane is gone.
+
+```python
+from libtmux import Pane
+
+pane_id = pane.pane_id
+found = Pane.from_pane_id(server, pane_id)
+
+print(found.pane_id == pane_id, found.window.window_id == window.window_id)
+```
+
+That id is also the value tmux exports as `$TMUX_PANE` inside every pane, so a
+program running under tmux can recover its own handle without being told where
+it is — {meth}`Pane.from_env() <libtmux.Pane.from_env>` reads it for you. See
+{ref}`self-location` for the full story, including the difference between the
+pane your code runs in and the pane a user is looking at.
+
+## Related
+
+- {ref}`pane-interaction` — what to do with a pane once you hold one:
+  `send_keys`, `capture_pane`, and waiting for output.
+- {ref}`howto-send-keys-to-every-pane` — drive all of a window's panes at once.
+- {ref}`traversal` — walking back up from a pane to its window, session, and
+  server.

--- a/docs/howto/connect-to-an-existing-server.md
+++ b/docs/howto/connect-to-an-existing-server.md
@@ -1,0 +1,96 @@
+(howto-connect-to-an-existing-server)=
+
+# Connect to an existing tmux server
+
+A {class}`~libtmux.Server` is a handle, not a connection. Constructing one opens
+nothing, starts nothing and verifies nothing — it records which socket you mean,
+and every method you call afterwards runs one tmux command against that socket.
+So "connecting" to a server someone else started is just naming their socket
+correctly, and then checking that something is listening on it.
+
+There are two ways to name one. `socket_name=` is tmux's `-L`: a short name that
+tmux resolves inside its own socket directory, and the same name you would pass
+to `tmux -L`. `socket_path=` is tmux's `-S`: an absolute path, which is what you
+need when the socket sits somewhere tmux would not look — a container mount, a
+service's runtime directory, a path some other tool chose. `Server()` with
+neither argument means tmux's `default` socket, the one a bare `tmux` in your
+shell uses.
+
+## See what is out there
+
+Sockets named with `-L` all land in one directory, so listing it answers "what
+could I connect to":
+
+```python
+import os
+import pathlib
+
+socket_dir = (
+    pathlib.Path(os.environ.get("TMUX_TMPDIR", "/tmp")) / f"tmux-{os.geteuid()}"
+)
+sockets = sorted(path for path in socket_dir.glob("*") if path.is_socket())
+
+for path in sockets:
+    print(path.name)
+```
+
+Treat that as a list of candidates, not of servers. tmux does not remove a
+socket file when its daemon exits, so a name in the listing may be the leftover
+of a server that died last week. The file existing is not the answer to your
+question.
+
+## Point a handle at one, then confirm
+
+```python
+from libtmux import Server
+
+server = Server(socket_name="libtmux-howto")
+
+if server.is_alive():
+    for session in server.sessions:
+        print(session.session_name, len(session.windows), "window(s)")
+else:
+    print("no tmux server is listening on that socket")
+```
+
+{meth}`~libtmux.Server.is_alive` before you trust the handle is the whole
+ceremony, and it matters more here than anywhere else, because the accessors are
+deliberately lenient. {attr}`~libtmux.Server.sessions` returns an empty
+{class}`~libtmux._internal.query_list.QueryList` when tmux's `list-sessions`
+fails for *any* reason — a socket that never existed, a daemon that exited, a
+permission error. A handle pointed at nothing therefore reads exactly like a
+healthy server with no sessions, and only the liveness check tells the two
+apart. {ref}`howto-check-if-tmux-is-running` goes into how to get the reason
+rather than the verdict.
+
+## Connect by path instead
+
+Everything above works the same when you address the socket by path — you are
+handing tmux `-S` rather than `-L`, so nothing has to be resolvable in tmux's
+socket directory:
+
+```python
+by_path = Server(socket_path=socket_dir / "libtmux-howto")
+
+print(by_path.is_alive())
+print([s.session_name for s in by_path.sessions])
+```
+
+One thing not to expect from this: `by_path` and the `server` above address the
+same daemon but are *not* equal, because the two constructor arguments are
+independent attributes and libtmux fills in neither from the other. See
+{ref}`howto-run-multiple-servers` for why, and what to compare instead.
+
+## When your code already runs inside tmux
+
+If your process was spawned by tmux — a script you launched in a pane, a hook, a
+test harness — don't go looking for the socket. tmux exported it into your
+environment, and {meth}`Server.from_env() <libtmux.Server.from_env>` reads it
+back with no subprocess at all. {ref}`self-location` covers that whole family,
+down to the pane you are running in.
+
+## Related
+
+- {ref}`howto-check-if-tmux-is-running` — telling "no server" from "no sessions".
+- {ref}`howto-run-multiple-servers` — the sockets you would be connecting to.
+- {ref}`traversal` — walking from the server you connected to down to its panes.

--- a/docs/howto/connect-to-an-existing-session.md
+++ b/docs/howto/connect-to-an-existing-session.md
@@ -1,0 +1,101 @@
+(howto-connect-to-an-existing-session)=
+
+# Connect to an existing session
+
+You already have tmux running — a session you started this morning, or one a
+script left behind — and you want a {class}`~libtmux.Session` object pointing at
+it. Nothing needs to be created. Constructing a {class}`~libtmux.Server` costs
+nothing and starts nothing, and {attr}`~libtmux.Server.sessions` asks tmux for
+the live list every time you read it, so finding a session is a lookup, not a
+connection.
+
+tmux keeps session names unique within a server, which makes a name a real key:
+one name, at most one session. Start by reading what is there.
+
+```python
+from libtmux import Server
+
+server = Server()
+
+for session in server.sessions:
+    print(f"{session.session_id}\t{session.session_name}")
+```
+
+`Server()` with no arguments means tmux's default socket — the same server a
+bare `tmux` in your shell talks to. Pass `socket_name=` or `socket_path=` to
+ask about a different one.
+
+## Look one up by name
+
+{meth}`~libtmux._internal.query_list.QueryList.get` pulls a single object out of
+a collection. Passing `default=None` turns "not there" into a value you can
+branch on instead of an exception.
+
+```python
+session = server.sessions.get(session_name="editor", default=None)
+
+if session is None:
+    print("no session named 'editor'")
+else:
+    print(f"editor holds {len(session.windows)} window(s)")
+```
+
+Swap `editor` for a name from the listing above. If that block printed *no
+session named 'editor'*, fix the name before pasting the next one — everything
+below works on the session it found.
+
+:::{warning}
+`get()` has two failure modes, and a `default` only covers one of them. With no
+`default` it raises {exc}`~libtmux.exc.ObjectDoesNotExist` when nothing matches;
+with a `default` it still raises {exc}`~libtmux.exc.MultipleObjectsReturned`
+when more than one object does. A `default` stands in for an object that is
+absent, never for a choice between candidates.
+
+A lookup by `session_name` cannot be ambiguous, because tmux enforces
+uniqueness. A lookup by any other attribute can —
+`server.sessions.get(session_attached="0")` raises the moment two sessions are
+detached. Use {meth}`~libtmux._internal.query_list.QueryList.filter` when a
+query is allowed to match several objects; see {ref}`querylist-filtering`.
+:::
+
+An empty {attr}`~libtmux.Server.sessions` deserves the same suspicion. It is
+empty when the server holds no sessions, and equally empty when tmux is
+unreachable — a dead daemon, a deleted socket, a `tmux` binary that isn't on
+`PATH`. Only {meth}`~libtmux.Server.is_alive` tells the two apart; see
+{ref}`howto-check-if-tmux-is-running`.
+
+## Hold the id, not the name
+
+A session's name is a label its owner can change at any time. Its
+{attr}`~libtmux.Session.session_id` — the `$`-prefixed value in the listing — is
+assigned by tmux when the session is born and stays put until it dies. If you plan to come
+back later, that is the value to remember.
+
+{meth}`~libtmux.Session.from_session_id` turns one back into an object. It hands
+the id straight to tmux as a target rather than scanning a listing, so it cannot
+be ambiguous, and it raises {exc}`~libtmux.exc.TmuxObjectDoesNotExist` if the
+session is gone.
+
+```python
+from libtmux import Session
+
+session_id = session.session_id
+found = Session.from_session_id(server, session_id)
+
+print(found.session_name, found.session_id == session_id)
+print(server.has_session("editor"), server.has_session("edit"))
+```
+
+{meth}`~libtmux.Server.has_session` is the cheap version of the question when
+you want a yes or no rather than the object: one tmux call, no objects built.
+It matches exactly by default, which is why `edit` is not `editor`. Pass
+`exact=False` to get tmux's own pattern matching, where `edit` does match.
+
+## Related
+
+- {ref}`howto-connect-to-an-existing-window` — go one level down, into the
+  session you just found.
+- {ref}`traversal` — the whole Server → Session → Window → Pane chain, in both
+  directions.
+- {ref}`querylist-filtering` — every lookup operator `filter()` and `get()`
+  accept.

--- a/docs/howto/connect-to-an-existing-window.md
+++ b/docs/howto/connect-to-an-existing-window.md
@@ -1,0 +1,103 @@
+(howto-connect-to-an-existing-window)=
+
+# Connect to an existing window
+
+A {class}`~libtmux.Window` sits between the session that holds it and the panes
+it holds, and tmux gives you two ways to say which one you mean. Its *index* is
+a position — where the window sits in the session's list, the number you see in
+the status bar. Its *name* is a label, defaulting to whatever is running and
+freely renamed. Neither is unique across the server: two sessions can each have
+a window at index 1, and each call it `logs`.
+
+That is why a window lookup always starts from a session. List the whole server
+once and the overlap shows itself.
+
+```python
+from libtmux import Server
+
+server = Server()
+
+for session in server.sessions:
+    for window in session.windows:
+        print(f"{session.session_name}:{window.window_index}\t{window.window_name}")
+```
+
+The `session:index` form is tmux's own way of naming a window unambiguously,
+and it is what you would type after `-t` on the command line.
+
+## Find one inside a session
+
+With a session in hand, {attr}`~libtmux.Session.windows` is a
+{class}`~libtmux._internal.query_list.QueryList` you can narrow.
+{meth}`~libtmux._internal.query_list.QueryList.get` with `default=None` returns
+the window or nothing, without raising.
+
+```python
+session = server.sessions.get(session_name="editor", default=None)
+
+if session is None:
+    print("no session named 'editor' — pick one from the listing above")
+else:
+    by_name = session.windows.get(window_name="logs", default=None)
+    by_index = session.windows.get(
+        window_index=session.active_window.window_index,
+        default=None,
+    )
+    print(f"by name:  {by_name}")
+    print(f"by index: {by_index}")
+```
+
+{attr}`~libtmux.Session.active_window` is the window that session would show a
+client right now, and it is the shortest way to get a window you can work with
+when you don't care which one it is.
+
+:::{warning}
+{attr}`~libtmux.Window.window_index` is a **string**, not an integer — it is a
+tmux format value, and libtmux hands it to you as tmux reports it. So
+`windows.get(window_index="1")` matches and `windows.get(window_index=1)` does
+not. With `default=None` that mismatch does not raise; it quietly returns
+`None`, which reads exactly like "no such window".
+
+Don't hard-code the number either. Windows start at index 0 or index 1 depending
+on the `base-index` setting in effect, so `"0"` is the first window on your
+machine and nothing at all on someone else's. Ask an object for its index, as
+above, or match on the name.
+:::
+
+## Hold the id, not the position
+
+Both handles above move. A window is renamed by its owner or by the program
+running in it; its index shifts when a window before it is closed or the session
+is renumbered. The {attr}`~libtmux.Window.window_id` — the `@1` in a window's
+repr — is fixed for the window's lifetime, and it is what to store when you plan
+to come back.
+
+{meth}`~libtmux.Window.from_window_id` turns one back into an object. It targets
+tmux directly instead of scanning a listing, so it always resolves to exactly
+one window.
+
+```python
+from libtmux import Window
+
+window = session.active_window
+window_id = window.window_id
+
+found = Window.from_window_id(server, window_id)
+print(found.window_name, found.window_id == window_id)
+```
+
+"Exactly one" is a stronger promise than it sounds, because a window can be
+linked into several sessions at once — one window, one id, a position in each
+session that holds it. A server-wide `server.windows.get(window_id=...)` raises
+{exc}`~libtmux.exc.MultipleObjectsReturned` on such a window: that collection
+enumerates positions, and it finds one row per session. Naming the id as a tmux
+target instead sidesteps the whole question. See {ref}`winlinks` for when this
+happens and what {attr}`~libtmux.Window.linked_sessions` tells you about it.
+
+## Related
+
+- {ref}`howto-connect-to-an-existing-pane` — one more level down, into the
+  window you just found.
+- {ref}`howto-connect-to-an-existing-session` — the level above, if you don't
+  hold a session yet.
+- {ref}`traversal` — moving up and down the hierarchy from any object.

--- a/docs/howto/create-a-floating-pane.md
+++ b/docs/howto/create-a-floating-pane.md
@@ -1,0 +1,116 @@
+(howto-create-a-floating-pane)=
+
+# Create a floating pane
+
+A floating pane hovers above the window's layout instead of dividing it: you
+place it where you want, at the size you want, and the panes underneath keep
+every cell they had. Reach for one when something is transient — a log tail, a
+scratch shell, a status readout — and rearranging the workspace to make room for
+it would cost more than the thing is worth.
+
+{meth}`Window.new_pane() <libtmux.Window.new_pane>` creates one, the way
+{meth}`Window.split() <libtmux.Window.split>` creates a tiled pane, and hands
+back an ordinary {class}`~libtmux.Pane`. {ref}`floating-panes` covers the model
+and the full set of arguments; this page is the recipe.
+
+The three blocks below run in sequence. Paste the first into a Python session,
+then the second, then the third.
+
+## Float a pane over the layout
+
+```python
+from libtmux import Server
+from libtmux.common import has_gte_version
+
+if not has_gte_version("3.7"):
+    raise RuntimeError("floating panes require tmux 3.7 or newer")
+
+server = Server(socket_name="libtmux-howto")
+session = server.new_session(session_name="floating", kill_session=True)
+window = session.active_window
+window.resize(height=40, width=120)
+
+overlay = window.new_pane(width=60, height=12, x=4, y=2)
+
+print("floating:", overlay.pane_floating_flag == "1")
+print("size:", overlay.pane_width, "x", overlay.pane_height)
+print("origin:", overlay.pane_x, overlay.pane_y)
+```
+
+`width` and `height` are the pane's size in cells, and `x` and `y` place its
+top-left corner, counted from the top-left of the window. All four are optional;
+tmux picks a default size and centres the pane when you leave them out.
+
+The version check is the honest part of this recipe. Floating panes are a tmux
+3.7 feature, and on anything older `new_pane()` raises
+{exc}`~libtmux.exc.LibTmuxException` — but it raises at the call, by which point
+your script has already built a session it now has to clean up. Asking
+{func}`~libtmux.common.has_gte_version` first turns that into one clear failure
+before anything exists. Skip the check only if you control the tmux you are
+running against.
+
+## It is an ordinary pane
+
+```python
+import time
+
+overlay.send_keys("echo floating $TMUX_PANE")
+
+answer = f"floating {overlay.pane_id}"
+
+
+def answered():
+    return any(row.strip() == answer for row in overlay.capture_pane())
+
+
+deadline = time.monotonic() + 10
+while time.monotonic() < deadline and not answered():
+    time.sleep(0.1)
+
+print(answered())
+```
+
+Nothing on this page's second block is float-specific: {meth}`~libtmux.Pane.send_keys`
+and {meth}`~libtmux.Pane.capture_pane` behave exactly as they do on a tiled
+pane, and so does everything else a {class}`~libtmux.Pane` offers. A float is a
+placement, not a different kind of object — see {ref}`howto-send-keys` for the
+reading technique this block uses, and why it compares whole lines.
+
+## Find them, and close them
+
+```python
+tiled = window.active_pane
+extra = tiled.new_pane(width=30, height=6, x=70, y=24, shell="sleep 30")
+
+floating = [pane for pane in window.panes if pane.pane_floating_flag == "1"]
+print("floating:", len(floating), "of", len(window.panes), "panes")
+
+for pane in floating:
+    pane.kill()
+
+print("left:", [pane.pane_id for pane in window.panes])
+
+session.kill()
+```
+
+{meth}`Pane.new_pane() <libtmux.Pane.new_pane>` is the same call addressed at a
+pane rather than a window — the float lands in that pane's window either way, so
+use whichever object you are already holding.
+
+Floats appear in {attr}`Window.panes <libtmux.Window.panes>` alongside the tiled
+ones, which is convenient until a loop over the window's panes reaches an
+overlay you did not mean to touch.
+{attr}`~libtmux.Pane.pane_floating_flag` is `"1"` on a float and `"0"`
+otherwise, and it is the only thing that tells them apart.
+
+{meth}`~libtmux.Pane.kill` closes a float and leaves the layout underneath
+untouched, since it never took space from it. The float also closes on its own
+when the command it runs exits — pass `keep=True` or a `message` to hold it open
+and read what it printed, both covered in {ref}`floating-panes`.
+
+## Related
+
+- {ref}`floating-panes` — sizing, positioning, styling, and keeping a float
+  open after its command exits.
+- {ref}`howto-create-panes` — tiled panes, which divide the window instead.
+- {ref}`howto-send-keys` — driving a pane, float or not.

--- a/docs/howto/create-panes.md
+++ b/docs/howto/create-panes.md
@@ -47,8 +47,9 @@ Sizes are shares of the window, and nothing is attached to this session, so the
 window is tmux's default 80×24 — the `resize` call is what makes `percentage=40`
 mean 48 columns rather than 32. Attach a client later and the window takes that
 client's size instead. Space runs out either way: a split with nowhere to go
-raises {exc}`~libtmux.exc.LibTmuxException` carrying tmux's own
-`size or position no space for a new pane`.
+raises {exc}`~libtmux.exc.LibTmuxException` carrying tmux's own complaint that
+there is no space for a new pane — the exact wording moved in tmux 3.7, so
+match loosely if you branch on it.
 
 ## Pane order is layout position, not creation order
 

--- a/docs/howto/create-panes.md
+++ b/docs/howto/create-panes.md
@@ -1,0 +1,106 @@
+(howto-create-panes)=
+
+# Create panes
+
+A window starts as a single {class}`~libtmux.Pane`, and splitting is what turns
+it into a workspace. {meth}`Window.split() <libtmux.Window.split>` divides the
+window's active pane; {meth}`Pane.split() <libtmux.Pane.split>` divides the pane
+you name. Either way you get back the **new** pane, which is the handle you keep
+— splitting the pane you were just handed is how a layout grows.
+
+The three blocks below run in sequence. Paste the first into a Python session,
+then the second, then the third.
+
+## Build a layout
+
+```python
+from libtmux import Server
+from libtmux.constants import PaneDirection
+
+server = Server(socket_name="libtmux-howto")
+session = server.new_session(session_name="layout", kill_session=True)
+window = session.active_window
+window.resize(height=40, width=120)
+
+editor = window.active_pane
+shell = editor.split(direction=PaneDirection.Right, percentage=40)
+logs = shell.split(direction=PaneDirection.Below, size=10, start_directory="/tmp")
+
+print("panes:", len(window.panes))
+print("shell is", shell.pane_width, "columns wide")
+print("logs is", logs.pane_height, "rows tall, in", logs.pane_current_path)
+```
+
+That is an editor filling the left of the window, a shell taking the right-hand
+40%, and a log pane ten rows tall beneath the shell — built by splitting the
+*returned* pane each time rather than the window, which is what puts the log
+pane inside the right-hand column instead of across the whole window.
+
+{class}`~libtmux.constants.PaneDirection` names where the new pane goes:
+`Right`, `Left`, `Above`, `Below`. Leave it out and tmux splits downwards. Size
+the new pane with `percentage=` for a share of the space or `size=` for an exact
+count of cells — rows for a horizontal division, columns for a vertical one —
+and give it a working directory of its own with `start_directory=`. The two size
+arguments are mutually exclusive; pass one or neither.
+
+Sizes are shares of the window, and nothing is attached to this session, so the
+window is tmux's default 80×24 — the `resize` call is what makes `percentage=40`
+mean 48 columns rather than 32. Attach a client later and the window takes that
+client's size instead. Space runs out either way: a split with nowhere to go
+raises {exc}`~libtmux.exc.LibTmuxException` carrying tmux's own
+`size or position no space for a new pane`.
+
+## Pane order is layout position, not creation order
+
+```python
+banner = editor.split(direction=PaneDirection.Above, size=3)
+
+print("created:", [pane.pane_id for pane in (editor, shell, logs, banner)])
+print("window.panes:", [pane.pane_id for pane in window.panes])
+print("focus stayed put:", window.active_pane.pane_id == editor.pane_id)
+```
+
+The banner was created last and lists first, because {attr}`Window.panes
+<libtmux.Window.panes>` walks the window's layout from top-left, and the banner
+sits above everything. Reach for a pane through that list by position and you
+are addressing whatever happens to occupy that corner of the screen today; hold
+the handle `split()` gave you and you are addressing the pane you made. Prefer
+the handle — or look one up by identity with
+`window.panes.get(pane_id=..., default=None)`.
+
+Focus stayed on the editor throughout, because {meth}`~libtmux.Pane.split`
+defaults to `attach=False`. Pass `attach=True` for the one pane a person should
+land in when they open the session.
+
+## Panes you are holding go stale
+
+```python
+print("editor thinks it is pane", editor.pane_index)
+
+editor.refresh()
+
+print("editor is actually pane", editor.pane_index)
+
+session.kill()
+```
+
+A {class}`~libtmux.Pane` reads its fields from tmux once, when the object is
+built, so the editor still remembers the index it had before the banner pushed
+it down. {meth}`~libtmux.Pane.refresh` re-reads them. Identity is what survives:
+`pane_id` never changes for the life of the pane, while index, size, and
+position all move as the layout does — so key your own bookkeeping on the id and
+refresh before trusting anything else.
+
+Reading `window.panes` again costs a round-trip to tmux and hands back freshly
+built objects, which is the other way to get current values.
+
+{meth}`~libtmux.Session.kill` tears the session down. For work that should clean
+up after itself even when something raises, see {ref}`context_managers`.
+
+## Related
+
+- {ref}`workspace-setup` — arranging panes with tmux's built-in layouts, and
+  the window-level machinery around them.
+- {ref}`howto-create-a-floating-pane` — a pane that hovers above the layout
+  instead of dividing it.
+- {ref}`howto-send-keys` — put a command into a pane once you have one.

--- a/docs/howto/detect-you-are-inside-tmux.md
+++ b/docs/howto/detect-you-are-inside-tmux.md
@@ -1,0 +1,74 @@
+(howto-detect-you-are-inside-tmux)=
+
+# Detect that you are inside tmux
+
+tmux tells its children where they are. Every pane it spawns gets two
+environment variables — `$TMUX`, holding the server's socket path, and
+`$TMUX_PANE`, holding the pane's id — and every process descended from that
+pane's shell inherits them. So "am I inside tmux?" is not a search. It is a
+question your own environment already answers.
+
+{meth}`Server.from_env() <libtmux.Server.from_env>` asks it. Inside a pane it
+returns a {class}`~libtmux.Server` bound to the socket you are running on;
+outside one it raises {exc}`~libtmux.exc.NotInsideTmux`. That is the whole
+detection, and for most scripts it is the whole page.
+
+```python
+from libtmux import exc
+from libtmux.server import Server
+
+try:
+    server = Server.from_env()
+except exc.NotInsideTmux:
+    server = None
+
+if server is None:
+    print("running outside tmux")
+else:
+    print(f"running inside tmux on {server.socket_path}")
+```
+
+Reading `os.environ["TMUX"]` yourself would answer the same question less
+carefully. `from_env` also checks the value's *shape* — tmux writes
+`socket_path,server_pid,session_id`, and a truncated or hand-edited value is
+not a socket you want to hand onward — so a malformed `$TMUX` raises here
+rather than surfacing later as a confusing tmux error.
+
+The socket matters as much as the answer. A bare `Server()` means tmux's
+default socket, which is a guess about where you are; the server `from_env`
+hands back is the one you are actually inside, whatever socket name or path it
+was started with.
+
+## Inside tmux is not the same as tmux being reachable
+
+`from_env` costs no subprocess. It is a read of your own environment, so what
+it really establishes is your process's ancestry: you were spawned by a pane.
+It does not confirm anything is still listening on the other end of that
+socket, and it cannot — the variables are frozen into your environment at spawn
+time and tmux never revises them. Kill the server while your script runs and
+`$TMUX` still names it.
+
+If your script is about to *do* something with that server rather than merely
+report on it, follow the detection with a liveness check.
+
+```python
+if server is not None:
+    if server.is_alive():
+        print(f"{len(server.sessions)} session(s) on this server")
+    else:
+        print("the server named by $TMUX is gone")
+```
+
+Two cheap calls, two different facts: {meth}`~libtmux.Server.from_env` says
+where you came from, {meth}`~libtmux.Server.is_alive` says whether it is still
+there. See {ref}`howto-check-if-tmux-is-running` for what liveness does and
+does not tell you.
+
+## Related
+
+- {ref}`self-location` — the model behind `from_env`, including why the
+  session id inside `$TMUX` is never read.
+- {ref}`howto-find-the-pane-youre-in` — go from "inside tmux" to the pane
+  itself.
+- {ref}`howto-check-if-tmux-is-running` — the same question about a server you
+  are *not* running inside.

--- a/docs/howto/find-the-pane-youre-in.md
+++ b/docs/howto/find-the-pane-youre-in.md
@@ -1,0 +1,60 @@
+(howto-find-the-pane-youre-in)=
+
+# Find the pane you're in
+
+{meth}`Pane.from_env() <libtmux.Pane.from_env>` returns the
+{class}`~libtmux.Pane` your process is running inside. It is the anchor of the
+whole `from_env` family: the pane id is the one fact tmux keeps answering for
+live, so the session and window calls resolve through it.
+
+```python
+from libtmux.pane import Pane
+
+pane = Pane.from_env()
+
+print(f"{pane.pane_id} in {pane.window.window_name} of {pane.session.session_name}")
+```
+
+Unlike {meth}`Server.from_env() <libtmux.Server.from_env>`, which only reads
+your environment, this one asks tmux where `$TMUX_PANE` is *now* — one command,
+paid once. Each hop back up from there is another, so bind
+{attr}`pane.window <libtmux.Pane.window>` or
+{attr}`pane.session <libtmux.Pane.session>` to a name if you use it in a loop.
+Outside a pane the call raises {exc}`~libtmux.exc.NotInsideTmux`; see
+{ref}`howto-detect-you-are-inside-tmux` for the branch.
+
+## This is not "the active pane"
+
+It is tempting to find yourself with
+{attr}`window.active_pane <libtmux.Window.active_pane>`, and it will even work
+the first time you try it — at a prompt, in the pane you are looking at, you
+*are* the active one. Then it quietly stops being true.
+
+Active means **currently focused**: the one pane per window that would receive
+your keystrokes. A script the user launched and then clicked away from is not
+focused. Neither is a pane running a background job, a `run-shell` hook, or a
+CI step on a detached session, where nobody is focused on anything. `from_env`
+answers "which pane am I", `active_pane` answers "which pane has the cursor",
+and those coincide only while somebody is watching you.
+
+```python
+focused = pane.window.active_pane
+
+if focused is not None and focused.pane_id == pane.pane_id:
+    print("this pane has the focus")
+else:
+    print("this pane is running in the background")
+```
+
+`active_pane` is `None` when the window reports no active pane, which is why
+the comparison guards for it. The same split runs one level up:
+{attr}`session.active_window <libtmux.Session.active_window>` is where the user
+is, and {meth}`Window.from_env() <libtmux.Window.from_env>` is where you are.
+
+## Related
+
+- {ref}`self-location` — why `$TMUX_PANE` is the anchor and the rest is
+  resolved live.
+- {ref}`howto-find-the-window-youre-in` — one level up, and what happens when
+  your window is shared.
+- {ref}`pane-interaction` — what to do with the pane once you hold it.

--- a/docs/howto/find-the-session-youre-in.md
+++ b/docs/howto/find-the-session-youre-in.md
@@ -1,0 +1,54 @@
+(howto-find-the-session-youre-in)=
+
+# Find the session you're in
+
+A script running in a pane usually wants the session around it, not a session
+it names: log to the session you were launched in, open a window beside your
+own, refuse to run twice in the same one.
+{meth}`Session.from_env() <libtmux.Session.from_env>` hands you that
+{class}`~libtmux.Session` with no arguments and no search.
+
+```python
+from libtmux.session import Session
+
+session = Session.from_env()
+
+print(f"{session.session_name} ({session.session_id})")
+```
+
+The call raises {exc}`~libtmux.exc.NotInsideTmux` outside a pane, so wrap it
+the way {ref}`howto-detect-you-are-inside-tmux` shows if your program has to
+run both in and out of tmux.
+
+`$TMUX` carries a session id as its third field, and parsing it out yourself
+looks like it would save the round-trip. It would also be wrong: tmux writes
+that value once, when it spawns the pane, and never revises it, so it names
+where your process was *born* rather than where it lives. Move the window into
+another session and the id lies. `from_env` asks tmux instead —
+{ref}`self-location` has the full account.
+
+## Back onto the hierarchy
+
+Once you hold the session you hold everything under and above it:
+{attr}`session.windows <libtmux.Session.windows>` for its windows,
+{attr}`session.server <libtmux.Session.server>` for the server it lives on.
+Finding yourself is only the first hop of a walk that {ref}`traversal`
+describes in full.
+
+```python
+for other in session.server.sessions:
+    marker = "*" if other.session_id == session.session_id else " "
+    print(f"{marker} {other.session_name}")
+```
+
+The object you get back is a snapshot. `session.session_name` is the name tmux
+reported at the moment you asked, so a rename that happens afterwards — by you,
+by the user, by a hook — leaves it stale. Call
+{meth}`~libtmux.Session.refresh` to re-read it, or call `Session.from_env()`
+again; the id never changes, so either is safe to redo.
+
+## Related
+
+- {ref}`self-location` — why the session id in `$TMUX` is never read.
+- {ref}`howto-find-the-window-youre-in` — the window inside that session.
+- {ref}`traversal` — walking the hierarchy once you hold a handle.

--- a/docs/howto/find-the-window-youre-in.md
+++ b/docs/howto/find-the-window-youre-in.md
@@ -1,0 +1,56 @@
+(howto-find-the-window-youre-in)=
+
+# Find the window you're in
+
+{meth}`Window.from_env() <libtmux.Window.from_env>` returns the
+{class}`~libtmux.Window` that contains the pane your process runs in. It takes
+no arguments: it resolves through your pane, so the answer is the window you
+are *in*, never the window someone happens to be looking at.
+
+```python
+from libtmux.window import Window
+
+window = Window.from_env()
+
+print(f"{window.window_name} ({window.window_id}), {len(window.panes)} pane(s)")
+```
+
+That distinction is the reason to call this rather than reach for
+{attr}`session.active_window <libtmux.Session.active_window>`. A script
+launched in a split, left running while the user moves on, is still in its own
+window and answers correctly here; `active_window` would answer with wherever
+the user went. Outside tmux there is no window to name and the call raises
+{exc}`~libtmux.exc.NotInsideTmux` — see
+{ref}`howto-detect-you-are-inside-tmux`.
+
+## When your window is in more than one session
+
+A window is not owned by one session. `link-window` and grouped sessions
+(`tmux new-session -t existing`) put a single window in several at once, and
+then it genuinely belongs to all of them — the panes are the same panes, and a
+change in one view is a change in every view.
+
+So "which session am I in?" can have more than one true answer, and
+{meth}`Session.from_env() <libtmux.Session.from_env>` gives you one of them:
+the session tmux itself would act on for a `-t` target. When you need every
+holder instead, ask the window.
+
+```python
+for holder in window.linked_sessions:
+    print(holder.session_name)
+```
+
+{attr}`~libtmux.Window.linked_sessions` costs two list commands however many
+holders come back, and in the ordinary case there is exactly one — the same
+session {attr}`window.session <libtmux.Window.session>` gives you. Reach for it
+when your code must be correct in the shared case: killing "your" session, or
+counting on your window disappearing with it, is where the assumption of a
+single owner actually bites.
+
+## Related
+
+- {ref}`self-location` — the model behind `from_env`, and what stays live
+  versus what tmux froze at spawn time.
+- {ref}`howto-find-the-pane-youre-in` — one level down, and why it is not the
+  active pane.
+- {ref}`winlinks` — filtering windows by the sessions that hold them.

--- a/docs/howto/index.md
+++ b/docs/howto/index.md
@@ -61,6 +61,34 @@ and wait for each one's answer.
 
 ::::
 
+## Sessions, windows, and panes
+
+::::{grid} 1 1 2 2
+:gutter: 2 2 3 3
+
+:::{grid-item-card} Connect to an existing session
+:link: connect-to-an-existing-session
+:link-type: doc
+Look a {class}`~libtmux.Session` up by name on a running server, and tell
+"no such session" apart from "no server".
+:::
+
+:::{grid-item-card} Connect to an existing window
+:link: connect-to-an-existing-window
+:link-type: doc
+Find a {class}`~libtmux.Window` inside a session by name or index, and learn
+which of the two survives a rename.
+:::
+
+:::{grid-item-card} Connect to an existing pane
+:link: connect-to-an-existing-pane
+:link-type: doc
+Find a {class}`~libtmux.Pane` inside a window, and see why the newest pane is
+not the last one in the list.
+:::
+
+::::
+
 ```{toctree}
 :hidden:
 
@@ -69,4 +97,7 @@ send-keys-to-every-pane
 start-a-server
 run-multiple-servers
 connect-to-an-existing-server
+connect-to-an-existing-session
+connect-to-an-existing-window
+connect-to-an-existing-pane
 ```

--- a/docs/howto/index.md
+++ b/docs/howto/index.md
@@ -22,10 +22,18 @@ Ask a {class}`~libtmux.Server` whether anything is alive on the other end of
 its socket, and tell "no server" apart from "no sessions".
 :::
 
+:::{grid-item-card} Send keys to every pane
+:link: send-keys-to-every-pane
+:link-type: doc
+Split a window, fan one command across its {class}`~libtmux.Pane` objects,
+and wait for each one's answer.
+:::
+
 ::::
 
 ```{toctree}
 :hidden:
 
 check-if-tmux-is-running
+send-keys-to-every-pane
 ```

--- a/docs/howto/index.md
+++ b/docs/howto/index.md
@@ -59,6 +59,27 @@ Split a window, fan one command across its {class}`~libtmux.Pane` objects,
 and wait for each one's answer.
 :::
 
+:::{grid-item-card} Send keys to a pane
+:link: send-keys
+:link-type: doc
+Type a command into a {class}`~libtmux.Pane`, stage one without running it,
+and read the answer back without being fooled by the echo.
+:::
+
+:::{grid-item-card} Create panes
+:link: create-panes
+:link-type: doc
+Split a {class}`~libtmux.Window` into a layout, keep hold of the panes you
+made, and refresh the ones that went stale.
+:::
+
+:::{grid-item-card} Create a floating pane
+:link: create-a-floating-pane
+:link-type: doc
+Hover a {class}`~libtmux.Pane` over the layout with
+{meth}`~libtmux.Window.new_pane`, drive it like any other, and close it again.
+:::
+
 ::::
 
 ## Sessions, windows, and panes
@@ -138,4 +159,7 @@ detect-you-are-inside-tmux
 find-the-session-youre-in
 find-the-window-youre-in
 find-the-pane-youre-in
+send-keys
+create-panes
+create-a-floating-pane
 ```

--- a/docs/howto/index.md
+++ b/docs/howto/index.md
@@ -24,6 +24,27 @@ Ask a {class}`~libtmux.Server` whether anything is alive on the other end of
 its socket, and tell "no server" apart from "no sessions".
 :::
 
+:::{grid-item-card} Start a tmux server
+:link: start-a-server
+:link-type: doc
+Boot a daemon that outlives your script, attach to it from a shell, and see
+why {meth}`~libtmux.Server.start_server` is not the call you want.
+:::
+
+:::{grid-item-card} Run multiple tmux servers
+:link: run-multiple-servers
+:link-type: doc
+Give each daemon its own socket so their sessions, windows and panes cannot
+reach one another.
+:::
+
+:::{grid-item-card} Connect to an existing tmux server
+:link: connect-to-an-existing-server
+:link-type: doc
+Point a {class}`~libtmux.Server` handle at a socket someone else started, and
+confirm anything is listening on it.
+:::
+
 ::::
 
 ## Driving panes
@@ -45,4 +66,7 @@ and wait for each one's answer.
 
 check-if-tmux-is-running
 send-keys-to-every-pane
+start-a-server
+run-multiple-servers
+connect-to-an-existing-server
 ```

--- a/docs/howto/index.md
+++ b/docs/howto/index.md
@@ -89,6 +89,40 @@ not the last one in the list.
 
 ::::
 
+## Code running inside tmux
+
+::::{grid} 1 1 2 2
+:gutter: 2 2 3 3
+
+:::{grid-item-card} Detect that you are inside tmux
+:link: detect-you-are-inside-tmux
+:link-type: doc
+Branch on whether your own process was spawned by a pane, and tell that apart
+from the server still being reachable.
+:::
+
+:::{grid-item-card} Find the session you're in
+:link: find-the-session-youre-in
+:link-type: doc
+Get the {class}`~libtmux.Session` holding your process, then walk out from it.
+:::
+
+:::{grid-item-card} Find the window you're in
+:link: find-the-window-youre-in
+:link-type: doc
+Get the {class}`~libtmux.Window` that contains you, and every session that
+holds it when it is shared.
+:::
+
+:::{grid-item-card} Find the pane you're in
+:link: find-the-pane-youre-in
+:link-type: doc
+Get the {class}`~libtmux.Pane` your code runs in, which is not the same as the
+pane holding the focus.
+:::
+
+::::
+
 ```{toctree}
 :hidden:
 
@@ -100,4 +134,8 @@ connect-to-an-existing-server
 connect-to-an-existing-session
 connect-to-an-existing-window
 connect-to-an-existing-pane
+detect-you-are-inside-tmux
+find-the-session-youre-in
+find-the-window-youre-in
+find-the-pane-youre-in
 ```

--- a/docs/howto/index.md
+++ b/docs/howto/index.md
@@ -1,0 +1,31 @@
+(howto)=
+
+# How-to guides
+
+Task-shaped recipes you can lift straight into your own code. Every code block
+on these pages is plain, runnable Python — no doctest prompts, no test
+scaffolding — so pasting the blocks of a page in order does on your machine
+what the page says it does.
+
+Reach for a how-to when you know what you want and want the shortest correct
+way to get it. When you want the model behind it instead, each page links the
+{doc}`topic <../topics/index>` that explains why the API is shaped the way it
+is.
+
+::::{grid} 1 1 2 2
+:gutter: 2 2 3 3
+
+:::{grid-item-card} Check if tmux is running
+:link: check-if-tmux-is-running
+:link-type: doc
+Ask a {class}`~libtmux.Server` whether anything is alive on the other end of
+its socket, and tell "no server" apart from "no sessions".
+:::
+
+::::
+
+```{toctree}
+:hidden:
+
+check-if-tmux-is-running
+```

--- a/docs/howto/index.md
+++ b/docs/howto/index.md
@@ -12,6 +12,8 @@ way to get it. When you want the model behind it instead, each page links the
 {doc}`topic <../topics/index>` that explains why the API is shaped the way it
 is.
 
+## Servers
+
 ::::{grid} 1 1 2 2
 :gutter: 2 2 3 3
 
@@ -21,6 +23,13 @@ is.
 Ask a {class}`~libtmux.Server` whether anything is alive on the other end of
 its socket, and tell "no server" apart from "no sessions".
 :::
+
+::::
+
+## Driving panes
+
+::::{grid} 1 1 2 2
+:gutter: 2 2 3 3
 
 :::{grid-item-card} Send keys to every pane
 :link: send-keys-to-every-pane

--- a/docs/howto/run-multiple-servers.md
+++ b/docs/howto/run-multiple-servers.md
@@ -1,0 +1,90 @@
+(howto-run-multiple-servers)=
+
+# Run multiple tmux servers
+
+tmux runs one daemon per socket, and a socket is the real isolation boundary —
+not a session. Name a second socket and you get a second server that shares
+nothing with the first: its own sessions, its own windows and panes, its own
+options, its own attached clients. Killing one cannot touch the other.
+
+Reach for this when work must not collide: a test suite that has to stay out of
+your editor's tmux, a daemon per project, a scratch server you can destroy
+wholesale without thinking about what else lives there.
+
+## Two servers, same session name
+
+```python
+from libtmux import Server
+
+alpha = Server(socket_name="libtmux-howto-alpha")
+beta = Server(socket_name="libtmux-howto-beta")
+
+alpha_build = alpha.new_session(session_name="build", kill_session=True)
+beta_build = beta.new_session(session_name="build", kill_session=True)
+
+print([s.session_name for s in alpha.sessions])
+print([s.session_name for s in beta.sessions])
+```
+
+Both sessions are called `build` and neither daemon knows the other exists.
+Session names only have to be unique within a server, so per-socket separation
+lets you use the same vocabulary — `build`, `test`, `shell` — in every project
+without inventing prefixes.
+
+## Everything below the server is per-server too
+
+{attr}`Server.windows <libtmux.Server.windows>` and {attr}`Server.panes
+<libtmux.Server.panes>` flatten every window and pane on that socket into one
+list. They stop at the socket, exactly like {attr}`~libtmux.Server.sessions`
+does, so adding a window to `alpha` leaves `beta` reporting what it always did.
+
+```python
+alpha_build.new_window(window_name="tests")
+
+print(len(alpha.windows), len(alpha.panes))
+print(len(beta.windows), len(beta.panes))
+```
+
+Those flattened collections are the fastest way to ask a whole server a
+question — {ref}`querylist-filtering` covers filtering them.
+
+## Two handles for one daemon are not equal
+
+Here is the trap. `socket_name=` and `socket_path=` are independent attributes,
+and libtmux never derives one from the other: a server built with a name keeps
+{attr}`~libtmux.Server.socket_path` at `None` forever, even though tmux
+obviously resolved a path to reach the daemon.
+{meth}`Server.__eq__ <libtmux.Server.__eq__>` compares both attributes, so two
+handles addressing the identical daemon — one by name, one by that same socket's
+path — compare unequal.
+
+```python
+socket_path = alpha.cmd("display-message", "-p", "#{socket_path}").stdout[0]
+same_daemon = Server(socket_path=socket_path)
+
+print(alpha.socket_path)
+print(same_daemon.is_alive(), [s.session_name for s in same_daemon.sessions])
+print(same_daemon == alpha)
+
+alpha.kill()
+beta.kill()
+```
+
+The second line proves they are the same server: `same_daemon` is alive and sees
+`alpha`'s sessions. The third line still prints `False`. Equality is answering a
+narrower question than it looks like — *are these handles configured the same
+way* — and it cannot see through to the daemon they share.
+
+So don't use `==` to decide whether two handles mean the same server. Build one
+handle per daemon and pass that object around; when you genuinely have to
+compare handles that were constructed differently, compare what tmux resolved
+them to by asking each for `#{socket_path}`, as above.
+
+## Related
+
+- {ref}`howto-start-a-server` — what actually boots a daemon.
+- {ref}`howto-connect-to-an-existing-server` — `socket_name=` against
+  `socket_path=`, and finding the sockets that exist.
+- {ref}`context_managers` — scope a whole throwaway server to a `with` block.
+- {ref}`about` — the Server → Session → Window → Pane hierarchy each socket
+  carries its own copy of.

--- a/docs/howto/send-keys-to-every-pane.md
+++ b/docs/howto/send-keys-to-every-pane.md
@@ -1,0 +1,93 @@
+(howto-send-keys-to-every-pane)=
+
+# Send keys to every pane
+
+Fanning one command out across a split window — starting the same watcher in
+three directories, restarting a process in each — is a loop over
+{attr}`Window.panes <libtmux.Window.panes>`. There is no `Window.send_keys`:
+typing is something you do *to a pane*, and a window is a container, so the
+window hands you its panes and you drive each one.
+
+The three blocks below run in sequence. Paste the first into a Python session,
+then the second, then the third.
+
+## Build a window with three panes
+
+{meth}`~libtmux.Window.split` splits the window's active pane and returns the
+new {class}`~libtmux.Pane`. Calling it twice leaves you with three.
+
+```python
+from libtmux import Server
+
+server = Server(socket_name="libtmux-howto")
+session = server.new_session(session_name="fanout", kill_session=True)
+window = session.active_window
+
+window.split()
+window.split()
+
+print(f"{len(window.panes)} panes in {window.window_id}")
+```
+
+Two habits here are worth stealing. Naming the socket puts this window on a
+server of its own, so nothing you do next can reach the tmux you already have
+open. And `kill_session=True` replaces a `fanout` session left over from last
+time instead of raising {exc}`~libtmux.exc.TmuxSessionExists` — which matters
+the second time you run a script you are still writing.
+
+## Type the command into each one
+
+{meth}`~libtmux.Pane.send_keys` types into a pane and presses Enter, exactly as
+if you had typed at the keyboard. Iterating {attr}`Window.panes
+<libtmux.Window.panes>` re-queries tmux, so the two panes you just split are
+already there.
+
+```python
+for pane in window.panes:
+    pane.send_keys('echo "$TMUX_PANE is ready"')
+```
+
+Each pane's own shell expands `$TMUX_PANE`, so every pane answers with its own
+id — proof the fan-out landed in three places rather than three times in one.
+
+## Read the output back
+
+{meth}`~libtmux.Pane.capture_pane` returns the pane's visible lines. It is a
+snapshot, not a stream, and `send_keys` returns as soon as tmux has accepted
+the keystrokes — the shell runs the command afterwards. So you wait for the
+answer rather than assume it has arrived.
+
+Two details make that wait honest. Poll against a deadline instead of sleeping
+a fixed amount: a sleep long enough for a cold shell is dead time on every run
+after the first, and a sleep short enough to feel quick reports "not ready" on
+a machine that was merely busy. And compare *whole lines* — the captured lines
+include the command tmux echoed onto the pane, so a substring test for `is
+ready` matches that echo and is true before the shell has run anything at all.
+
+```python
+import time
+
+
+def ready(pane):
+    answer = f"{pane.pane_id} is ready"
+    return any(line.strip() == answer for line in pane.capture_pane())
+
+
+deadline = time.monotonic() + 10
+while time.monotonic() < deadline and not all(ready(p) for p in window.panes):
+    time.sleep(0.1)
+
+for pane in window.panes:
+    print(pane.pane_id, ready(pane))
+
+session.kill()
+```
+
+{meth}`~libtmux.Session.kill` tears the session down. For work that should
+clean itself up even when something raises, see {ref}`context_managers`.
+
+## Related
+
+- {ref}`pane-interaction` — the rest of what a pane can do, including waiting
+  on output as a first-class operation.
+- {ref}`howto-check-if-tmux-is-running` — confirm there is a server first.

--- a/docs/howto/send-keys.md
+++ b/docs/howto/send-keys.md
@@ -1,0 +1,143 @@
+(howto-send-keys)=
+
+# Send keys to a pane
+
+{meth}`~libtmux.Pane.send_keys` types into a {class}`~libtmux.Pane` exactly as
+if you were sitting at its keyboard, and presses Enter when it is done. That is
+the whole of the sending half: hand it a command string and the pane's shell
+runs it.
+
+The reading half is where the care goes. `send_keys` returns as soon as tmux has
+accepted the keystrokes — the shell runs the command afterwards, on its own
+schedule — so getting the answer back means waiting for it, and waiting for the
+*right* thing.
+
+The three blocks below run in sequence. Paste the first into a Python session,
+then the second, then the third.
+
+## Type a command and read the answer
+
+```python
+import time
+
+from libtmux import Server
+
+server = Server(socket_name="libtmux-howto")
+session = server.new_session(session_name="send-keys", kill_session=True)
+window = session.active_window
+pane = window.active_pane
+
+pane.send_keys("echo hello from $TMUX_PANE")
+
+
+def answered(pane, line):
+    return any(row.strip() == line for row in pane.capture_pane())
+
+
+answer = f"hello from {pane.pane_id}"
+deadline = time.monotonic() + 10
+while time.monotonic() < deadline and not answered(pane, answer):
+    time.sleep(0.1)
+
+print(answered(pane, answer))
+```
+
+Naming the socket puts this session on a server of its own, so nothing on this
+page can reach the tmux you already have open, and `kill_session=True` replaces
+a `send-keys` session left over from a previous run instead of raising
+{exc}`~libtmux.exc.TmuxSessionExists`.
+
+Two details make the wait honest, and both are easy to get wrong. Poll against
+a deadline rather than sleeping a fixed amount: a sleep long enough for a cold
+shell is dead time on every run after the first, and a short one reports failure
+on a machine that was merely busy. And compare *whole lines* —
+{meth}`~libtmux.Pane.capture_pane` hands back the screen, which includes the
+command tmux just echoed onto it, so `"hello from" in captured_text` is true the
+instant the keystrokes land and stays true in a world where no shell ever runs.
+
+## Type without running
+
+Pass `enter=False` to leave the text sitting at the prompt: staging a command
+for someone to look over, or feeding a keystroke to a program that is already
+waiting for one. {meth}`~libtmux.Pane.enter` presses Enter on its own when you
+are ready.
+
+`literal=True` matters as soon as what you type could be read as a key. tmux
+resolves the string you send against its key names first, so `send_keys("Enter")`
+presses the Enter key rather than typing the five letters. `literal=True` turns
+that off and sends the characters through untouched — which is what you want for
+anything you did not write by hand, including user input and file contents.
+
+```python
+pane.send_keys("echo ", enter=False)
+pane.send_keys("Enter", enter=False, literal=True)
+pane.enter()
+
+deadline = time.monotonic() + 10
+while time.monotonic() < deadline and not answered(pane, "Enter"):
+    time.sleep(0.1)
+
+print(answered(pane, "Enter"))
+```
+
+The pane runs `echo Enter` and prints `Enter`. Drop `literal=True` from the
+second call and the same line becomes `echo ` followed by a press of Enter — a
+command you did not mean to run, assembled out of text you did not think of as
+keys.
+
+## Keep a command out of shell history
+
+`suppress_history=True` prepends a single space to the command. That is the
+entire mechanism, and it makes the flag a request to your shell rather than
+something tmux enforces: bash honours it under `HISTCONTROL=ignorespace` or
+`ignoreboth`, zsh under `setopt histignorespace`, and a shell configured with
+neither records the command exactly as it would have anyway.
+
+Because the outcome belongs to the shell, this example runs its own bash with
+the option set, rather than trusting whatever your default shell does.
+
+```python
+history_pane = window.split(shell="bash --norc --noprofile")
+history_pane.send_keys("HISTCONTROL=ignorespace")
+history_pane.send_keys("echo public")
+history_pane.send_keys("echo private", suppress_history=True)
+history_pane.send_keys("history")
+
+
+def recorded(pane):
+    entries = []
+    for row in pane.capture_pane():
+        number, _, command = row.strip().partition("  ")
+        if number.isdigit():
+            entries.append(command.strip())
+    return entries
+
+
+deadline = time.monotonic() + 10
+while time.monotonic() < deadline and "history" not in recorded(history_pane):
+    time.sleep(0.1)
+
+print("public recorded:", "echo public" in recorded(history_pane))
+print("private recorded:", "echo private" in recorded(history_pane))
+
+session.kill()
+```
+
+Reading the `history` listing back, rather than trusting the flag, is the point
+of the exercise: it is the only way to find out whether the shell in front of
+you cooperates.
+
+Even where it works, a suppressed command is hidden from one place only. It was
+typed onto the screen, it is in the pane's scrollback, and its arguments are
+visible in the process table while it runs — so treat the flag as tidiness, not
+as a way to pass a secret.
+
+{meth}`~libtmux.Session.kill` tears the session down. For work that should clean
+up after itself even when something raises, see {ref}`context_managers`.
+
+## Related
+
+- {ref}`pane-interaction` — the rest of what a pane can do: capture flags,
+  scrollback, resizing, and querying state.
+- {ref}`howto-send-keys-to-every-pane` — the same command across a whole window.
+- {ref}`howto-create-panes` — build the panes to type into.

--- a/docs/howto/start-a-server.md
+++ b/docs/howto/start-a-server.md
@@ -1,0 +1,102 @@
+(howto-start-a-server)=
+
+# Start a tmux server
+
+You don't really start a tmux server — you ask for something that needs one, and
+tmux boots the daemon underneath you. libtmux inherits that bargain:
+{meth}`~libtmux.Server.new_session` is the call that brings a server up, because
+a session is the first thing a server has to hold.
+
+That also settles a question people ask twice. "Start a server" and "start a
+server in the background" are the same operation here. Attaching means handing a
+terminal over to tmux, and a Python process running a script has none to hand
+over — so every server you start from Python is detached from the moment it
+exists, and it keeps running after your process exits. There is no flag to pass
+and nothing to daemonize.
+
+## Bring one up
+
+```python
+from libtmux import Server
+
+server = Server(socket_name="libtmux-howto")
+session = server.new_session(session_name="worker", kill_session=True)
+
+print(f"{session.session_name} is up: {server.is_alive()}")
+```
+
+Two arguments there are habits worth keeping. Naming the socket puts this daemon
+beside the tmux you already have open rather than inside it, so nothing here can
+disturb your real sessions — see {ref}`howto-run-multiple-servers` for what that
+separation buys. And `kill_session=True` replaces a `worker` session left over
+from an earlier run instead of raising {exc}`~libtmux.exc.TmuxSessionExists`,
+which is what you want from a script you are still writing.
+
+## The daemon is not your handle
+
+A {class}`~libtmux.Server` object records which socket you mean; the daemon is a
+separate process with its own lifetime. Throwing the handle away does nothing to
+it, and a fresh handle pointed at the same socket finds the same sessions —
+which is also what happens when your script exits and you come back tomorrow.
+
+```python
+del server
+
+reconnected = Server(socket_name="libtmux-howto")
+
+print(reconnected.is_alive())
+print([s.session_name for s in reconnected.sessions])
+```
+
+:::{warning}
+{meth}`Server.__exit__ <libtmux.Server.__exit__>` **kills the server**, so
+`with Server(socket_name="libtmux-howto") as server:` starts a daemon and
+destroys it, and everything in it, at the end of the block. That is occasionally
+what you want — see {ref}`context_managers` — but it is the opposite of starting
+a server that outlives you.
+:::
+
+## Attach to it from a shell
+
+Once the server is up you look at it from a terminal, naming the same socket:
+`tmux -L libtmux-howto attach-session -t worker`. Detach with your prefix key
+and `d`, and the server stays up behind you.
+
+Doing that from Python is not an option. {meth}`~libtmux.Session.attach` runs
+tmux's `attach-session`, which needs a terminal to take over and fails when
+there is none behind the process — the same reason a server you start from a
+script is detached whether you asked for that or not. So the division of labour
+is: start and drive the server from Python, attach from a shell when you want to
+watch it.
+
+## `start_server` is not the one you want
+
+tmux has a `start-server` command and libtmux exposes it as
+{meth}`~libtmux.Server.start_server`, which makes it look like the obvious way to
+launch a daemon. Run it and you get nothing:
+
+```python
+empty = Server(socket_name="libtmux-howto-empty")
+empty.start_server()
+
+print(empty.is_alive())
+
+reconnected.kill()
+```
+
+That prints `False`. tmux's `exit-empty` option is on by default, and it tells a
+server holding no sessions to exit immediately — so the daemon `start-server`
+booted is already gone by the time the next command reaches its socket. Create
+the session and let tmux start the server for you.
+
+{meth}`~libtmux.Server.kill` is how you take one down again, and it takes every
+session on that socket with it.
+
+## Related
+
+- {ref}`howto-run-multiple-servers` — one daemon per socket, and why that is the
+  isolation boundary.
+- {ref}`howto-connect-to-an-existing-server` — point a handle at a server
+  somebody else started.
+- {ref}`howto-check-if-tmux-is-running` — the liveness question on its own.
+- {ref}`about` — what a `Server` object is a proxy for.

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,12 @@ servers, sessions, windows, and panes as Python objects.
 Install and make your first API call in 5 minutes.
 :::
 
+:::{grid-item-card} How-to guides
+:link: howto/index
+:link-type: doc
+Task-shaped recipes you can paste straight into your own code.
+:::
+
 :::{grid-item-card} Topics
 :link: topics/index
 :link-type: doc
@@ -120,6 +126,7 @@ isolated tmux fixtures:
 :hidden:
 
 quickstart
+howto/index
 topics/index
 api/index
 api/testing/index

--- a/docs/justfile
+++ b/docs/justfile
@@ -6,7 +6,10 @@ set shell := ["bash", "-uc"]
 # Configuration
 http_port := "8023"
 builddir := "_build"
-sphinxopts := ""
+# -W: a broken cross-reference, a page in no toctree, or a bad directive
+# option is a warning Sphinx is happy to build through. Treating warnings as
+# errors is what makes the docs build a gate rather than a report.
+sphinxopts := "-W"
 sphinxbuild := "uv run sphinx-build"
 sourcedir := "."
 

--- a/src/libtmux/pane.py
+++ b/src/libtmux/pane.py
@@ -1250,8 +1250,8 @@ class Pane(
         size: int, optional
             Cell/row count to occupy with respect to current window.
         percentage: int, optional
-            Percentage (0-100) of the window to occupy (``-p`` flag).
-            Mutually exclusive with *size*.
+            Percentage (0-100) of the window to occupy. Mutually exclusive
+            with *size*.
 
             .. versionadded:: 0.56
         environment: dict, optional
@@ -1343,7 +1343,10 @@ class Pane(
             tmux_args += (f"-l{size}",)
 
         if percentage is not None:
-            tmux_args += (f"-p{percentage}",)
+            # tmux 3.1 taught -l to take a percentage and deprecated -p; 3.4
+            # then regressed -p outright ("size missing"). -l is the spelling
+            # that works across every version libtmux supports.
+            tmux_args += (f"-l{percentage}%",)
 
         if full_window_split:
             tmux_args += ("-f",)

--- a/tests/docs/__init__.py
+++ b/tests/docs/__init__.py
@@ -1,0 +1,3 @@
+"""Test support for the documentation under ``docs/``."""
+
+from __future__ import annotations

--- a/tests/docs/howto/__init__.py
+++ b/tests/docs/howto/__init__.py
@@ -1,0 +1,10 @@
+"""Sidecar harnesses for the how-to guides under ``docs/howto/``.
+
+Each page ``docs/howto/<slug>.md`` is paired with a module in this package
+whose name is the slug with hyphens replaced by underscores. The pairing is
+enforced by :mod:`tests.docs.howto_harness`: a page without a sidecar, or a
+sidecar whose check count does not match the page's code-block count, fails
+the suite.
+"""
+
+from __future__ import annotations

--- a/tests/docs/howto/check_if_tmux_is_running.py
+++ b/tests/docs/howto/check_if_tmux_is_running.py
@@ -1,0 +1,57 @@
+"""Sidecar for ``docs/howto/check-if-tmux-is-running.md``.
+
+The page shows one block that branches on
+:meth:`~libtmux.Server.is_alive`. Both sides of that branch matter, so the
+check runs the block twice: once against a live private server, then once
+more in a throwaway namespace with the server killed.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import typing as t
+
+import pytest
+
+from libtmux.server import Server
+
+if t.TYPE_CHECKING:
+    from tests.docs.howto_harness import HowtoContext
+
+
+def setup(ctx: HowtoContext) -> None:
+    """Start one session, so the page's live branch has something to find.
+
+    The private tmux world the session lands in is the runner's doing, not
+    this module's.
+
+    Parameters
+    ----------
+    ctx : HowtoContext
+        The page's execution context.
+    """
+    Server().new_session(session_name="howto-probe")
+
+
+def check_1(ctx: HowtoContext) -> None:
+    """Both branches of the visible example report correctly.
+
+    Parameters
+    ----------
+    ctx : HowtoContext
+        The page's execution context.
+    """
+    assert ctx.output[1].strip() == "tmux is running with 1 session(s)"
+
+    server = ctx.namespace["server"]
+    assert isinstance(server, Server)
+    assert server.is_alive()
+    server.raise_if_dead()
+
+    server.kill()
+
+    assert not server.is_alive()
+    with pytest.raises(subprocess.CalledProcessError):
+        server.raise_if_dead()
+
+    assert ctx.run_block(1, namespace={}).strip() == "tmux is not running"

--- a/tests/docs/howto/connect_to_an_existing_pane.py
+++ b/tests/docs/howto/connect_to_an_existing_pane.py
@@ -1,0 +1,122 @@
+"""Sidecar for ``docs/howto/connect-to-an-existing-pane.md``.
+
+The page's warning rests on a fact about tmux that a reader cannot see from the
+page's own output: splitting one pane twice does not leave the newest pane last.
+``setup`` therefore records the order the panes were *created* in, and
+``check_2`` compares it against the order ``Window.panes`` reports. The day
+those two agree, the warning is wrong and this module fails.
+"""
+
+from __future__ import annotations
+
+import typing as t
+
+import pytest
+
+from libtmux import exc
+from libtmux.pane import Pane
+from libtmux.server import Server
+
+if t.TYPE_CHECKING:
+    from tests.docs.howto_harness import HowtoContext
+
+#: Pane ids in the order ``setup`` created them, oldest first.
+CREATED: list[str] = []
+
+
+def setup(ctx: HowtoContext) -> None:
+    """Leave a session whose active window was split twice.
+
+    Both splits act on the window's active pane, which never moves because
+    :meth:`~libtmux.Window.split` does not attach — the same sequence the
+    page's warning describes.
+
+    Parameters
+    ----------
+    ctx : HowtoContext
+        The page's execution context.
+    """
+    session = Server().new_session(session_name="editor", window_name="code")
+    window = session.active_window
+
+    original = window.active_pane
+    assert original is not None
+
+    CREATED.clear()
+    for pane in (original, window.split(), window.split()):
+        assert pane.pane_id is not None
+        CREATED.append(pane.pane_id)
+
+
+def check_1(ctx: HowtoContext) -> None:
+    """Verify the listing reports three panes, in index order.
+
+    Parameters
+    ----------
+    ctx : HowtoContext
+        The page's execution context.
+    """
+    window = ctx.namespace["window"]
+    panes = window.panes
+    assert len(panes) == 3
+
+    assert ctx.output[1].strip().splitlines() == [
+        f"{p.pane_index}\t{p.pane_id}\t{p.pane_width}x{p.pane_height}" for p in panes
+    ]
+
+
+def check_2(ctx: HowtoContext) -> None:
+    """Layout order is not creation order, which is what the page warns about.
+
+    Parameters
+    ----------
+    ctx : HowtoContext
+        The page's execution context.
+    """
+    window = ctx.namespace["window"]
+    pane = ctx.namespace["pane"]
+    panes = window.panes
+
+    assert pane.pane_id == window.active_pane.pane_id
+    assert ctx.output[2].strip().splitlines() == [
+        f"active: {pane.pane_id}",
+        f"first:  {panes[0].pane_id}",
+        f"last:   {panes[-1].pane_id}",
+    ]
+
+    ordered = [p.pane_id for p in panes]
+    assert ordered == [CREATED[0], CREATED[2], CREATED[1]], (
+        f"panes created {CREATED} came back as {ordered}; the page's warning "
+        f"describes the newest pane landing at index 1"
+    )
+    assert ordered[-1] != CREATED[-1], "`panes[-1]` is not the newest pane"
+
+
+def check_3(ctx: HowtoContext) -> None:
+    """Verify a stored id resolves back to the same pane and window.
+
+    Block 1's guarded branch is exercised last, once nothing else needs the
+    session: that block builds its own :class:`~libtmux.Server`, so the only
+    way to reach the branch is to take the session away.
+
+    Parameters
+    ----------
+    ctx : HowtoContext
+        The page's execution context.
+    """
+    server = ctx.namespace["server"]
+    session = ctx.namespace["session"]
+    window = ctx.namespace["window"]
+    found = ctx.namespace["found"]
+
+    assert ctx.output[3].strip() == "True True"
+    assert found.pane_id == ctx.namespace["pane_id"]
+    assert found.window.window_id == window.window_id
+
+    with pytest.raises(exc.TmuxObjectDoesNotExist):
+        Pane.from_pane_id(server, "%999")
+
+    session.kill()
+    assert ctx.run_block(1, namespace={}).strip() == (
+        "no session named 'editor' — use a session name of your own"
+    )

--- a/tests/docs/howto/connect_to_an_existing_server.py
+++ b/tests/docs/howto/connect_to_an_existing_server.py
@@ -1,0 +1,126 @@
+"""Sidecar for ``docs/howto/connect-to-an-existing-server.md``.
+
+The page connects to a server it did not start, so ``setup`` starts one on its
+behalf — the reader's equivalent is the tmux they already had open.
+
+Two of the page's claims are the ones worth defending. The listing block claims
+a socket file can outlive its daemon, so the last check kills the server and
+requires the file to still be there. The connect block claims its ``else``
+branch is reachable, which the page can only show one side of, so the same check
+re-runs that block against the now-dead socket and reads the other answer back.
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import typing as t
+
+from libtmux.server import Server
+
+if t.TYPE_CHECKING:
+    from tests.docs.howto_harness import HowtoContext
+
+SOCKET_NAME = "libtmux-howto"
+SESSION_NAME = "editor"
+
+
+def _socket_dir() -> pathlib.Path:
+    """Return the directory tmux keeps ``-L`` sockets in.
+
+    Computed the way the page computes it, from the environment the runner
+    already isolated.
+
+    Returns
+    -------
+    pathlib.Path
+        Directory holding this run's named sockets.
+    """
+    root = pathlib.Path(os.environ.get("TMUX_TMPDIR", "/tmp"))
+    return root / f"tmux-{os.geteuid()}"
+
+
+def setup(ctx: HowtoContext) -> None:
+    """Start the server the page expects to find already running.
+
+    Parameters
+    ----------
+    ctx : HowtoContext
+        The page's execution context.
+    """
+    Server(socket_name=SOCKET_NAME).new_session(session_name=SESSION_NAME)
+
+
+def check_1(ctx: HowtoContext) -> None:
+    """Block 1 lists this page's socket, under tmux's own directory.
+
+    Parameters
+    ----------
+    ctx : HowtoContext
+        The page's execution context.
+    """
+    socket_dir = ctx.namespace["socket_dir"]
+    assert isinstance(socket_dir, pathlib.Path)
+    assert socket_dir == _socket_dir()
+
+    assert ctx.output[1].strip().splitlines() == [SOCKET_NAME]
+    assert [path.name for path in ctx.namespace["sockets"]] == [SOCKET_NAME]
+
+
+def check_2(ctx: HowtoContext) -> None:
+    """Block 2 takes the live branch and reports the real session.
+
+    Parameters
+    ----------
+    ctx : HowtoContext
+        The page's execution context.
+    """
+    server = ctx.namespace["server"]
+    assert isinstance(server, Server)
+    assert server.socket_name == SOCKET_NAME
+    assert server.is_alive()
+
+    assert ctx.output[2].strip() == f"{SESSION_NAME} 1 window(s)"
+
+
+def check_3(ctx: HowtoContext) -> None:
+    """Addressing by path reaches the same daemon; the file outlives it.
+
+    Parameters
+    ----------
+    ctx : HowtoContext
+        The page's execution context.
+    """
+    by_path = ctx.namespace["by_path"]
+    assert isinstance(by_path, Server)
+    assert by_path.is_alive()
+    assert ctx.output[3].strip().splitlines() == ["True", f"['{SESSION_NAME}']"]
+
+    server = ctx.namespace["server"]
+
+    # The case that separates a liveness check from a truthiness test on the
+    # lenient accessor the page warns about: a server that is up and holding
+    # nothing. tmux only allows that with exit-empty off, so arrange it.
+    server.cmd("set-option", "-s", "exit-empty", "off")
+    for session in server.sessions:
+        session.kill()
+    assert server.is_alive()
+    assert not server.sessions
+    assert ctx.run_block(2, namespace={}).strip() == "", (
+        "block 2 reported no server for a server that is up with no sessions, "
+        "so it is testing what the page tells readers not to trust"
+    )
+
+    socket = _socket_dir() / SOCKET_NAME
+    server.kill()
+
+    # The page tells readers a name in the listing may be a dead end. It is
+    # only worth telling them if tmux really does leave the file behind.
+    assert socket.is_socket()
+    assert not Server(socket_name=SOCKET_NAME).is_alive()
+
+    # The other side of block 2's branch, which the page can only print once.
+    assert (
+        ctx.run_block(2, namespace={}).strip()
+        == "no tmux server is listening on that socket"
+    )

--- a/tests/docs/howto/connect_to_an_existing_session.py
+++ b/tests/docs/howto/connect_to_an_existing_session.py
@@ -1,0 +1,114 @@
+"""Sidecar for ``docs/howto/connect-to-an-existing-session.md``.
+
+The page reads a server it did not build, so ``setup`` builds one: two detached
+sessions on the default socket of this page's private tmux world. Two, not one,
+because the page claims a name lookup is unambiguous while a lookup on another
+attribute is not — and that claim needs a second session to be false.
+
+The checks pin the page's three factual claims rather than its wording: a dead
+server yields an empty listing instead of an error, ``get()`` raises on absence
+only when it has no ``default`` and raises on ambiguity regardless, and
+``has_session`` matches exactly unless told otherwise.
+"""
+
+from __future__ import annotations
+
+import typing as t
+
+import pytest
+
+from libtmux import exc
+from libtmux.server import Server
+from libtmux.session import Session
+
+if t.TYPE_CHECKING:
+    from tests.docs.howto_harness import HowtoContext
+
+#: A socket no server listens on, for exercising the page's "not found" branch.
+ABSENT_SOCKET = "howto-no-such-server"
+
+
+def setup(ctx: HowtoContext) -> None:
+    """Leave two detached sessions for the page to find.
+
+    Parameters
+    ----------
+    ctx : HowtoContext
+        The page's execution context.
+    """
+    server = Server()
+    server.new_session(session_name="editor", window_name="code")
+    server.new_session(session_name="notes", window_name="code")
+
+
+def check_1(ctx: HowtoContext) -> None:
+    """Verify the listing reports every session on the server, id first.
+
+    Parameters
+    ----------
+    ctx : HowtoContext
+        The page's execution context.
+    """
+    server = ctx.namespace["server"]
+    assert isinstance(server, Server)
+
+    lines = ctx.output[1].strip().splitlines()
+    assert lines == [f"{s.session_id}\t{s.session_name}" for s in server.sessions]
+    assert {line.split("\t")[1] for line in lines} == {"editor", "notes"}
+
+
+def check_2(ctx: HowtoContext) -> None:
+    """Both branches of the guarded lookup behave as the page says.
+
+    The "not found" branch runs against a socket nothing listens on, which
+    exercises the page's other claim at the same time: an unreachable server
+    hands back an empty listing rather than raising, so ``get()`` sees absence.
+
+    Parameters
+    ----------
+    ctx : HowtoContext
+        The page's execution context.
+    """
+    assert ctx.output[2].strip() == "editor holds 1 window(s)"
+
+    session = ctx.namespace["session"]
+    assert isinstance(session, Session)
+    assert session.session_name == "editor"
+
+    absent = Server(socket_name=ABSENT_SOCKET)
+    assert not absent.is_alive()
+    assert list(absent.sessions) == []
+    assert (
+        ctx.run_block(2, namespace={"server": absent}).strip()
+        == "no session named 'editor'"
+    )
+
+    server = ctx.namespace["server"]
+    with pytest.raises(exc.ObjectDoesNotExist):
+        server.sessions.get(session_name="no-such-session")
+    assert server.sessions.get(session_name="no-such-session", default=None) is None
+
+    with pytest.raises(exc.MultipleObjectsReturned):
+        server.sessions.get(session_attached="0", default=None)
+
+
+def check_3(ctx: HowtoContext) -> None:
+    """Verify an id round-trips and ``has_session`` is exact by default.
+
+    Parameters
+    ----------
+    ctx : HowtoContext
+        The page's execution context.
+    """
+    server = ctx.namespace["server"]
+    session = ctx.namespace["session"]
+
+    assert ctx.output[3].strip().splitlines() == ["editor True", "True False"]
+
+    found = ctx.namespace["found"]
+    assert found.session_id == session.session_id
+
+    with pytest.raises(exc.TmuxObjectDoesNotExist):
+        Session.from_session_id(server, "$999")
+
+    assert server.has_session("edit", exact=False)

--- a/tests/docs/howto/connect_to_an_existing_window.py
+++ b/tests/docs/howto/connect_to_an_existing_window.py
@@ -1,0 +1,143 @@
+"""Sidecar for ``docs/howto/connect-to-an-existing-window.md``.
+
+``setup`` builds the collision the page opens with: two sessions whose windows
+carry the same names at the same indexes. If a future change made window names
+or indexes unique server-wide, block 1's output would stop demonstrating
+anything and ``check_1`` would say so.
+
+``check_2`` owns the page's sharpest claim — that a window index is a string,
+so an integer lookup silently returns the default instead of the window — and
+``check_3`` owns the linked-window claim the closing paragraph makes.
+"""
+
+from __future__ import annotations
+
+import typing as t
+
+import pytest
+
+from libtmux import exc
+from libtmux.server import Server
+from libtmux.window import Window
+
+if t.TYPE_CHECKING:
+    from tests.docs.howto_harness import HowtoContext
+
+#: A socket no server listens on, for exercising the page's "not found" branch.
+ABSENT_SOCKET = "howto-no-such-server"
+
+
+def setup(ctx: HowtoContext) -> None:
+    """Leave two sessions whose windows share names and indexes.
+
+    Parameters
+    ----------
+    ctx : HowtoContext
+        The page's execution context.
+    """
+    server = Server()
+    for name in ("editor", "notes"):
+        session = server.new_session(session_name=name, window_name="code")
+        session.new_window(window_name="logs", attach=False)
+
+
+def check_1(ctx: HowtoContext) -> None:
+    """Verify the server-wide listing shows a name and index used twice.
+
+    Parameters
+    ----------
+    ctx : HowtoContext
+        The page's execution context.
+    """
+    server = ctx.namespace["server"]
+    assert isinstance(server, Server)
+
+    rows = [line.split("\t") for line in ctx.output[1].strip().splitlines()]
+    expected = [
+        [f"{s.session_name}:{w.window_index}", w.window_name]
+        for s in server.sessions
+        for w in s.windows
+    ]
+    assert rows == expected
+
+    names = [name for _position, name in rows]
+    indexes = [position.split(":")[1] for position, _name in rows]
+    assert names.count("logs") == 2, (
+        "the page opens by showing one window name reused across sessions"
+    )
+    assert len(set(indexes)) < len(indexes), (
+        "the page opens by showing one window index reused across sessions"
+    )
+
+
+def check_2(ctx: HowtoContext) -> None:
+    """Name and index lookups find the right windows, and ``1`` finds nothing.
+
+    Parameters
+    ----------
+    ctx : HowtoContext
+        The page's execution context.
+    """
+    session = ctx.namespace["session"]
+    by_name = ctx.namespace["by_name"]
+    by_index = ctx.namespace["by_index"]
+
+    assert by_name.window_name == "logs"
+    assert by_name.session.session_name == "editor"
+    assert by_index.window_id == session.active_window.window_id
+
+    assert ctx.output[2].strip().splitlines() == [
+        f"by name:  {by_name}",
+        f"by index: {by_index}",
+    ]
+
+    index = session.active_window.window_index
+    assert isinstance(index, str)
+    assert session.windows.get(window_index=index, default=None) is not None
+    assert session.windows.get(window_index=int(index), default=None) is None, (
+        "the page warns that an integer index quietly matches nothing"
+    )
+
+    absent = Server(socket_name=ABSENT_SOCKET)
+    assert ctx.run_block(2, namespace={"server": absent}).strip() == (
+        "no session named 'editor' — pick one from the listing above"
+    )
+
+
+def check_3(ctx: HowtoContext) -> None:
+    """Verify an id resolves to one window even when two sessions hold it.
+
+    Linking the window into a second session is the state the closing
+    paragraph describes, so it is built here rather than asserted from memory.
+
+    Parameters
+    ----------
+    ctx : HowtoContext
+        The page's execution context.
+    """
+    server = ctx.namespace["server"]
+    window = ctx.namespace["window"]
+
+    assert ctx.output[3].strip() == f"{window.window_name} True"
+
+    with pytest.raises(exc.TmuxObjectDoesNotExist):
+        Window.from_window_id(server, "@999")
+
+    guest = server.new_session(session_name="guest")
+    server.cmd(
+        "link-window",
+        "-d",
+        "-s",
+        window.window_id,
+        "-t",
+        f"{guest.session_id}:",
+    )
+
+    assert len(server.windows.filter(window_id=window.window_id)) == 2
+    with pytest.raises(exc.MultipleObjectsReturned):
+        server.windows.get(window_id=window.window_id)
+
+    assert Window.from_window_id(server, window.window_id).window_id == (
+        window.window_id
+    )
+    assert sorted(s.session_name for s in window.linked_sessions) == ["editor", "guest"]

--- a/tests/docs/howto/create_a_floating_pane.py
+++ b/tests/docs/howto/create_a_floating_pane.py
@@ -1,7 +1,8 @@
 """Sidecar for ``docs/howto/create-a-floating-pane.md``.
 
 Two of the page's claims would otherwise go untested on this machine. The
-version guard never fires here — tmux is new enough — so it is re-run against a
+version guard never fires when the page runs — ``MIN_TMUX_VERSION`` keeps the
+page off any tmux that would trip it — so it is re-run against a
 :func:`~libtmux.common.has_gte_version` that reports an older tmux, and required
 to stop the reader before a session exists. And "a float is an ordinary pane" is
 only worth printing if the float's own shell really answered, so the second
@@ -23,6 +24,11 @@ if t.TYPE_CHECKING:
     from tests.docs.howto_harness import HowtoContext
 
 SOCKET_NAME = "libtmux-howto"
+
+#: Floating panes are a tmux 3.7 feature, so the page's first block refuses to
+#: go on without one. The harness reads this and skips the page below it,
+#: rather than letting the guide's own guard fail the suite.
+MIN_TMUX_VERSION = "3.7"
 
 
 def check_1(ctx: HowtoContext) -> None:

--- a/tests/docs/howto/create_a_floating_pane.py
+++ b/tests/docs/howto/create_a_floating_pane.py
@@ -1,0 +1,114 @@
+"""Sidecar for ``docs/howto/create-a-floating-pane.md``.
+
+Two of the page's claims would otherwise go untested on this machine. The
+version guard never fires here — tmux is new enough — so it is re-run against a
+:func:`~libtmux.common.has_gte_version` that reports an older tmux, and required
+to stop the reader before a session exists. And "a float is an ordinary pane" is
+only worth printing if the float's own shell really answered, so the second
+block's verdict is checked strictly: a containment test on ``capture_pane``
+output would match the command tmux echoed onto the pane and pass in a world
+where nothing ran.
+"""
+
+from __future__ import annotations
+
+import typing as t
+
+import pytest
+
+from libtmux.server import Server
+
+if t.TYPE_CHECKING:
+    from libtmux.window import Window
+    from tests.docs.howto_harness import HowtoContext
+
+SOCKET_NAME = "libtmux-howto"
+
+
+def check_1(ctx: HowtoContext) -> None:
+    """Confirm the overlay floats where asked, and that the guard works.
+
+    Parameters
+    ----------
+    ctx : HowtoContext
+        The page's execution context.
+    """
+    server = ctx.namespace["server"]
+    assert isinstance(server, Server)
+    assert server.socket_name == SOCKET_NAME
+
+    window: Window = ctx.namespace["window"]
+    overlay = ctx.namespace["overlay"]
+    assert overlay.pane_floating_flag == "1"
+    assert overlay.pane_id in [pane.pane_id for pane in window.panes]
+
+    assert ctx.output[1].strip().splitlines() == [
+        "floating: True",
+        "size: 60 x 12",
+        "origin: 4 2",
+    ]
+
+    _guard_stops_an_older_tmux(ctx)
+
+
+def _guard_stops_an_older_tmux(ctx: HowtoContext) -> None:
+    """Re-run block 1 against a tmux the page should refuse to use.
+
+    The block is run in a namespace of its own, so the page's own session is
+    left alone. Reaching :meth:`~libtmux.Server.new_session` at all would mean
+    the guard let a script proceed to build state it would then have to clean
+    up — the failure the page's prose promises to prevent.
+
+    Parameters
+    ----------
+    ctx : HowtoContext
+        The page's execution context.
+    """
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(
+            "libtmux.common.has_gte_version",
+            lambda _version, tmux_bin=None: False,
+        )
+        with pytest.raises(RuntimeError, match=r"3\.7"):
+            ctx.run_block(1, namespace={})
+
+
+def check_2(ctx: HowtoContext) -> None:
+    """Confirm the float ran the command and printed the answer.
+
+    Parameters
+    ----------
+    ctx : HowtoContext
+        The page's execution context.
+    """
+    overlay = ctx.namespace["overlay"]
+    assert ctx.output[2].strip() == "True", (
+        f"block 2 printed {ctx.output[2]!r}: the float's own shell never "
+        f"answered, so the page's claim that a float is an ordinary pane is "
+        f"untested"
+    )
+    assert any(
+        row.strip() == f"floating {overlay.pane_id}" for row in overlay.capture_pane()
+    )
+
+
+def check_3(ctx: HowtoContext) -> None:
+    """Both floats were found by their flag, and closing them spared the tiling.
+
+    Parameters
+    ----------
+    ctx : HowtoContext
+        The page's execution context.
+    """
+    tiled = ctx.namespace["tiled"]
+    extra = ctx.namespace["extra"]
+    assert extra.pane_floating_flag == "1"
+    assert tiled.pane_floating_flag == "0"
+
+    counted, left = ctx.output[3].strip().splitlines()
+    assert counted == "floating: 2 of 3 panes"
+    assert left == f"left: ['{tiled.pane_id}']"
+
+    server = ctx.namespace["server"]
+    assert isinstance(server, Server)
+    assert "floating" not in [session.session_name for session in server.sessions]

--- a/tests/docs/howto/create_panes.py
+++ b/tests/docs/howto/create_panes.py
@@ -1,0 +1,154 @@
+"""Sidecar for ``docs/howto/create-panes.md``.
+
+The page teaches three things about splitting, and each is checked against the
+thing it would be confused with. That ``split()`` hands back the *new* pane is
+checked by geometry, not by counting: a page that returned the pane it split
+would still leave three panes in the window, but the log pane would not be in
+the bottom-right corner. That ``window.panes`` is in layout order is checked by
+requiring it to *disagree* with creation order — an order that happened to
+match either way would prove nothing. And that a held pane goes stale is checked
+by requiring the index it remembers to differ from the one tmux reports.
+
+The error string the page quotes for a split with no room is quoted from tmux,
+so it is provoked here rather than trusted.
+"""
+
+from __future__ import annotations
+
+import typing as t
+from pathlib import Path
+
+import pytest
+
+from libtmux import exc
+from libtmux.server import Server
+
+if t.TYPE_CHECKING:
+    from libtmux.window import Window
+    from tests.docs.howto_harness import HowtoContext
+
+SOCKET_NAME = "libtmux-howto"
+
+
+def pane_ids(text: str) -> list[str]:
+    """Return the pane ids from one of the page's printed lists.
+
+    Parameters
+    ----------
+    text : str
+        A line such as ``created: ['%0', '%1']``.
+
+    Returns
+    -------
+    list of str
+        The ids, in the order printed.
+    """
+    _, _, listed = text.partition(": ")
+    return [item.strip(" '[]") for item in listed.split(",")]
+
+
+def check_1(ctx: HowtoContext) -> None:
+    """Confirm the layout is built out of the panes ``split()`` returned.
+
+    Parameters
+    ----------
+    ctx : HowtoContext
+        The page's execution context.
+    """
+    server = ctx.namespace["server"]
+    assert isinstance(server, Server)
+    assert server.socket_name == SOCKET_NAME
+
+    window: Window = ctx.namespace["window"]
+    editor = ctx.namespace["editor"]
+    shell = ctx.namespace["shell"]
+    logs = ctx.namespace["logs"]
+
+    assert {pane.pane_id for pane in (editor, shell, logs)} == {
+        pane.pane_id for pane in window.panes
+    }
+
+    assert (editor.at_left, editor.at_top) == (True, True)
+    assert (shell.at_right, shell.at_top) == (True, True)
+    assert (logs.at_right, logs.at_bottom, logs.at_top) == (True, True, False)
+
+    reported = ctx.output[1].strip().splitlines()
+    assert reported[0] == "panes: 3"
+    assert reported[1] == "shell is 48 columns wide"
+
+    prefix = "logs is 10 rows tall, in "
+    assert reported[2].startswith(prefix)
+    # Resolved, because /tmp is a symlink on some platforms and tmux reports
+    # the pane's real path.
+    assert Path(reported[2][len(prefix) :]).resolve() == Path("/tmp").resolve()
+
+    _refuse_a_split_with_no_room(server)
+
+
+def _refuse_a_split_with_no_room(server: Server) -> None:
+    """Provoke the failure the page quotes tmux's wording for.
+
+    Parameters
+    ----------
+    server : libtmux.Server
+        Server to build the throwaway session on.
+    """
+    session = server.new_session(session_name="howto-no-room", kill_session=True)
+    try:
+        pane = session.active_window.active_pane
+        assert pane is not None
+        with pytest.raises(exc.LibTmuxException) as caught:
+            for _ in range(40):
+                pane = pane.split()
+        assert "size or position no space for a new pane" in str(caught.value)
+    finally:
+        session.kill()
+
+
+def check_2(ctx: HowtoContext) -> None:
+    """Layout order disagrees with creation order, and focus has not moved.
+
+    Parameters
+    ----------
+    ctx : HowtoContext
+        The page's execution context.
+    """
+    window: Window = ctx.namespace["window"]
+    editor = ctx.namespace["editor"]
+    banner = ctx.namespace["banner"]
+
+    created, listed, focus = ctx.output[2].strip().splitlines()
+    assert pane_ids(created) != pane_ids(listed), (
+        "the page claims window.panes is not creation order, but the two "
+        "agree here, so the example demonstrates nothing"
+    )
+    assert pane_ids(listed) == [pane.pane_id for pane in window.panes]
+    assert pane_ids(listed)[0] == banner.pane_id
+
+    assert focus == "focus stayed put: True"
+    active = window.active_pane
+    assert active is not None
+    assert active.pane_id == editor.pane_id
+
+
+def check_3(ctx: HowtoContext) -> None:
+    """Confirm the held pane was stale, ``refresh()`` fixed it, and cleanup ran.
+
+    Parameters
+    ----------
+    ctx : HowtoContext
+        The page's execution context.
+    """
+    editor = ctx.namespace["editor"]
+    remembered, actual = (
+        line.rsplit(" ", 1)[1] for line in ctx.output[3].strip().splitlines()
+    )
+    assert remembered != actual, (
+        f"both blocks reported index {actual}, so nothing on the page went "
+        f"stale and refresh() had nothing to fix"
+    )
+    assert actual == editor.pane_index == "1"
+
+    server = ctx.namespace["server"]
+    assert isinstance(server, Server)
+    assert "layout" not in [session.session_name for session in server.sessions]

--- a/tests/docs/howto/create_panes.py
+++ b/tests/docs/howto/create_panes.py
@@ -100,7 +100,10 @@ def _refuse_a_split_with_no_room(server: Server) -> None:
         with pytest.raises(exc.LibTmuxException) as caught:
             for _ in range(40):
                 pane = pane.split()
-        assert "size or position no space for a new pane" in str(caught.value)
+        # tmux words this differently across releases -- "no space for new
+        # pane" through 3.6, "size or position no space for a new pane" from
+        # 3.7 -- so pin the part every supported version agrees on.
+        assert "no space for" in str(caught.value)
     finally:
         session.kill()
 

--- a/tests/docs/howto/detect_you_are_inside_tmux.py
+++ b/tests/docs/howto/detect_you_are_inside_tmux.py
@@ -1,0 +1,103 @@
+"""Sidecar for ``docs/howto/detect-you-are-inside-tmux.md``.
+
+The page's whole subject is an environment this process does not have, so
+``setup`` manufactures it: a real session on the runner's private tmux world,
+with ``$TMUX`` and ``$TMUX_PANE`` set exactly as tmux would have set them for
+a pane's child. The visible blocks then call
+:meth:`~libtmux.Server.from_env` with no arguments, the way a reader would.
+
+Both sides of both branches are exercised. Block 1 is re-run with ``$TMUX``
+removed, which is the only honest way to check the "outside tmux" arm, and
+block 2 is re-run after the server has been killed, which is the page's real
+claim: detection is a read of your own environment and survives the server it
+names.
+"""
+
+from __future__ import annotations
+
+import typing as t
+
+import pytest
+
+from libtmux.server import Server
+
+if t.TYPE_CHECKING:
+    from tests.docs.howto_harness import HowtoContext
+
+SESSION_NAME = "howto-inside"
+
+
+def setup(ctx: HowtoContext) -> None:
+    """Make this process look like a child of a real tmux pane.
+
+    Parameters
+    ----------
+    ctx : HowtoContext
+        The page's execution context.
+    """
+    server = Server()
+    session = server.new_session(session_name=SESSION_NAME)
+    pane = session.active_window.active_pane
+    assert pane is not None
+
+    socket_path = server.cmd("display-message", "-p", "#{socket_path}").stdout[0]
+    assert session.session_id is not None
+    assert pane.pane_id is not None
+
+    # tmux spells $TMUX as "<socket_path>,<server_pid>,<session_id>", with the
+    # session id bare rather than sigilled.
+    ctx.monkeypatch.setenv(
+        "TMUX",
+        f"{socket_path},1,{session.session_id.lstrip('$')}",
+    )
+    ctx.monkeypatch.setenv("TMUX_PANE", pane.pane_id)
+
+
+def check_1(ctx: HowtoContext) -> None:
+    """Confirm detection names the socket in ``$TMUX``, and only there.
+
+    Parameters
+    ----------
+    ctx : HowtoContext
+        The page's execution context.
+    """
+    socket_path = Server.from_env().socket_path
+    assert socket_path is not None
+
+    server = ctx.namespace["server"]
+    assert isinstance(server, Server)
+    assert server.socket_path == socket_path
+    assert server.is_alive()
+    assert ctx.output[1].strip() == f"running inside tmux on {socket_path}"
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.delenv("TMUX")
+        assert ctx.run_block(1, namespace={}).strip() == "running outside tmux"
+
+
+def check_2(ctx: HowtoContext) -> None:
+    """Liveness is a second, separate question from detection.
+
+    Killing the server leaves ``$TMUX`` naming it, so the page's claim is
+    checked the only way it can be: re-run the block against that corpse and
+    require the other message.
+
+    Parameters
+    ----------
+    ctx : HowtoContext
+        The page's execution context.
+    """
+    assert ctx.output[2].strip() == "1 session(s) on this server"
+
+    server = ctx.namespace["server"]
+    assert isinstance(server, Server)
+    socket_path = server.socket_path
+    server.kill()
+
+    dead = Server.from_env()
+    assert dead.socket_path == socket_path
+    assert not dead.is_alive()
+
+    assert ctx.run_block(2, namespace={"server": dead}).strip() == (
+        "the server named by $TMUX is gone"
+    )

--- a/tests/docs/howto/find_the_pane_youre_in.py
+++ b/tests/docs/howto/find_the_pane_youre_in.py
@@ -1,0 +1,94 @@
+"""Sidecar for ``docs/howto/find-the-pane-youre-in.md``.
+
+``setup`` arranges the case the page exists for: two panes in a window, the
+focus given to the second, and ``$TMUX_PANE`` pointing at the first. A reader
+following along at a prompt is the focused pane and would see the two answers
+agree; here they must not, so a ``Pane.from_env()`` that resolved to the active
+pane fails instead of looking right.
+
+Block 2's other arm — the pane that does hold the focus — is exercised by
+re-running the block against the focused pane, because a branch checked on one
+side only is half a check.
+"""
+
+from __future__ import annotations
+
+import os
+import typing as t
+
+from libtmux.pane import Pane
+from libtmux.server import Server
+
+if t.TYPE_CHECKING:
+    from tests.docs.howto_harness import HowtoContext
+
+SESSION_NAME = "howto-pane"
+WINDOW_NAME = "worker"
+
+
+def setup(ctx: HowtoContext) -> None:
+    """Make this process look like a child of a pane that lost the focus.
+
+    Parameters
+    ----------
+    ctx : HowtoContext
+        The page's execution context.
+    """
+    server = Server()
+    session = server.new_session(session_name=SESSION_NAME)
+
+    window = session.new_window(window_name=WINDOW_NAME, attach=True)
+    pane = window.active_pane
+    assert pane is not None
+    window.split(attach=True)
+
+    socket_path = server.cmd("display-message", "-p", "#{socket_path}").stdout[0]
+    assert session.session_id is not None
+    assert pane.pane_id is not None
+
+    # tmux spells $TMUX as "<socket_path>,<server_pid>,<session_id>", with the
+    # session id bare rather than sigilled.
+    ctx.monkeypatch.setenv(
+        "TMUX",
+        f"{socket_path},1,{session.session_id.lstrip('$')}",
+    )
+    ctx.monkeypatch.setenv("TMUX_PANE", pane.pane_id)
+
+
+def check_1(ctx: HowtoContext) -> None:
+    """Confirm the pane found is the one ``$TMUX_PANE`` names.
+
+    Parameters
+    ----------
+    ctx : HowtoContext
+        The page's execution context.
+    """
+    pane = ctx.namespace["pane"]
+    assert isinstance(pane, Pane)
+    assert pane.pane_id == os.environ["TMUX_PANE"]
+
+    assert ctx.output[1].strip() == (
+        f"{pane.pane_id} in {WINDOW_NAME} of {SESSION_NAME}"
+    )
+
+
+def check_2(ctx: HowtoContext) -> None:
+    """Focused and located are different questions, and answer differently.
+
+    Parameters
+    ----------
+    ctx : HowtoContext
+        The page's execution context.
+    """
+    pane = ctx.namespace["pane"]
+    focused = pane.window.active_pane
+    assert focused is not None
+    assert focused.pane_id != pane.pane_id, (
+        "the caller's pane holds the focus, so the distinction this page "
+        "teaches is not being tested"
+    )
+
+    assert ctx.output[2].strip() == "this pane is running in the background"
+
+    reported = ctx.run_block(2, namespace={"pane": focused})
+    assert reported.strip() == "this pane has the focus"

--- a/tests/docs/howto/find_the_session_youre_in.py
+++ b/tests/docs/howto/find_the_session_youre_in.py
@@ -1,0 +1,83 @@
+"""Sidecar for ``docs/howto/find-the-session-youre-in.md``.
+
+``setup`` builds two sessions on the runner's private tmux world and points
+``$TMUX`` / ``$TMUX_PANE`` at a pane of one of them, so the page's bare
+``Session.from_env()`` has a real pane to resolve through and block 2's roster
+has a sibling to distinguish it from.
+
+The session id inside ``$TMUX`` is deliberately a lie. tmux freezes that field
+at pane spawn and libtmux never reads it, so a wrong value here is what proves
+the page's answer comes from tmux rather than from the environment: if
+``from_env`` ever started trusting ``$TMUX``, these checks go red.
+"""
+
+from __future__ import annotations
+
+import typing as t
+
+from libtmux.server import Server
+from libtmux.session import Session
+
+if t.TYPE_CHECKING:
+    from tests.docs.howto_harness import HowtoContext
+
+SESSION_NAME = "howto-here"
+OTHER_SESSION_NAME = "howto-elsewhere"
+
+
+def setup(ctx: HowtoContext) -> None:
+    """Make this process look like a child of a pane in ``howto-here``.
+
+    Parameters
+    ----------
+    ctx : HowtoContext
+        The page's execution context.
+    """
+    server = Server()
+    session = server.new_session(session_name=SESSION_NAME)
+    server.new_session(session_name=OTHER_SESSION_NAME)
+
+    pane = session.active_window.active_pane
+    assert pane is not None
+
+    socket_path = server.cmd("display-message", "-p", "#{socket_path}").stdout[0]
+    assert pane.pane_id is not None
+
+    # A session id no session has. tmux freezes this field at pane spawn and
+    # libtmux never reads it, so a wrong one here must not change the answer.
+    ctx.monkeypatch.setenv("TMUX", f"{socket_path},1,999")
+    ctx.monkeypatch.setenv("TMUX_PANE", pane.pane_id)
+
+
+def check_1(ctx: HowtoContext) -> None:
+    """Confirm the session found holds the pane, not the id in ``$TMUX``.
+
+    Parameters
+    ----------
+    ctx : HowtoContext
+        The page's execution context.
+    """
+    session = ctx.namespace["session"]
+    assert isinstance(session, Session)
+    assert session.session_name == SESSION_NAME
+    assert session.session_id != "$999"
+    assert ctx.output[1].strip() == f"{SESSION_NAME} ({session.session_id})"
+
+
+def check_2(ctx: HowtoContext) -> None:
+    """Confirm the roster covers every session and marks only the caller.
+
+    Parameters
+    ----------
+    ctx : HowtoContext
+        The page's execution context.
+    """
+    session = ctx.namespace["session"]
+    # Splitting without stripping first: an unmarked row opens with the two
+    # spaces the page prints, and stripping the block would eat them.
+    lines = [line for line in ctx.output[2].splitlines() if line]
+
+    assert {line[2:] for line in lines} == {SESSION_NAME, OTHER_SESSION_NAME}
+    assert [line[2:] for line in lines if line.startswith("*")] == [
+        session.session_name,
+    ]

--- a/tests/docs/howto/find_the_window_youre_in.py
+++ b/tests/docs/howto/find_the_window_youre_in.py
@@ -1,0 +1,108 @@
+"""Sidecar for ``docs/howto/find-the-window-youre-in.md``.
+
+``setup`` builds a two-pane window on the runner's private tmux world, focuses
+the *other* pane, and points ``$TMUX_PANE`` at the first one. That is the
+arrangement the page is about: a process whose window is not the window anyone
+is looking at, so a ``Window.from_env()`` that quietly returned the active
+window would be caught here rather than admired.
+
+Block 2 lists the sessions holding that window, which in the ordinary case is
+one. The multi-holder case is the point of the section, so the check links the
+window into a second session and re-runs the block — an example that only ever
+printed one line would be teaching an accessor the reader has no reason to
+call.
+"""
+
+from __future__ import annotations
+
+import typing as t
+
+from libtmux.server import Server
+from libtmux.window import Window
+
+if t.TYPE_CHECKING:
+    from tests.docs.howto_harness import HowtoContext
+
+SESSION_NAME = "howto-window"
+GUEST_SESSION_NAME = "howto-guest"
+WINDOW_NAME = "worker"
+
+
+def setup(ctx: HowtoContext) -> None:
+    """Make this process look like a child of a pane in a background window.
+
+    Parameters
+    ----------
+    ctx : HowtoContext
+        The page's execution context.
+    """
+    server = Server()
+    session = server.new_session(session_name=SESSION_NAME)
+
+    window = session.new_window(window_name=WINDOW_NAME, attach=False)
+    pane = window.active_pane
+    assert pane is not None
+    window.split(attach=True)
+
+    socket_path = server.cmd("display-message", "-p", "#{socket_path}").stdout[0]
+    assert session.session_id is not None
+    assert pane.pane_id is not None
+
+    # tmux spells $TMUX as "<socket_path>,<server_pid>,<session_id>", with the
+    # session id bare rather than sigilled.
+    ctx.monkeypatch.setenv(
+        "TMUX",
+        f"{socket_path},1,{session.session_id.lstrip('$')}",
+    )
+    ctx.monkeypatch.setenv("TMUX_PANE", pane.pane_id)
+
+
+def check_1(ctx: HowtoContext) -> None:
+    """Confirm the window found contains the caller, not the focus.
+
+    Parameters
+    ----------
+    ctx : HowtoContext
+        The page's execution context.
+    """
+    window = ctx.namespace["window"]
+    assert isinstance(window, Window)
+    assert window.window_name == WINDOW_NAME
+    assert len(window.panes) == 2
+
+    session = window.session
+    active = session.active_window
+    assert active is not None
+    assert active.window_id != window.window_id, (
+        "the caller's window is the focused one, so this page's central "
+        "claim is not being tested"
+    )
+
+    assert ctx.output[1].strip() == (f"{WINDOW_NAME} ({window.window_id}), 2 pane(s)")
+
+
+def check_2(ctx: HowtoContext) -> None:
+    """One holder normally, every holder once the window is shared.
+
+    Parameters
+    ----------
+    ctx : HowtoContext
+        The page's execution context.
+    """
+    window = ctx.namespace["window"]
+    assert ctx.output[2].split() == [SESSION_NAME]
+
+    server = window.server
+    guest = server.new_session(session_name=GUEST_SESSION_NAME)
+    server.cmd(
+        "link-window",
+        "-d",
+        "-s",
+        window.window_id,
+        "-t",
+        f"{guest.session_id}:",
+    )
+
+    assert sorted(ctx.run_block(2).split()) == sorted(
+        [SESSION_NAME, GUEST_SESSION_NAME],
+    )

--- a/tests/docs/howto/run_multiple_servers.py
+++ b/tests/docs/howto/run_multiple_servers.py
@@ -1,0 +1,143 @@
+"""Sidecar for ``docs/howto/run-multiple-servers.md``.
+
+The page's point is that two sockets are two worlds, so the checks read both
+daemons after every block: it is not enough that `alpha` gained a window, `beta`
+must be shown not to have gained one. The last block's claim — that a handle
+built from a socket name and a handle built from that same socket's path are
+unequal while addressing one daemon — is verified from both directions, since a
+page that taught it backwards would be worse than a page that never mentioned
+it.
+"""
+
+from __future__ import annotations
+
+import typing as t
+
+from libtmux.server import Server
+
+if t.TYPE_CHECKING:
+    from tests.docs.howto_harness import HowtoContext
+
+ALPHA_SOCKET = "libtmux-howto-alpha"
+BETA_SOCKET = "libtmux-howto-beta"
+
+
+def _server_pid(server: Server) -> str:
+    """Return the process id of the daemon behind a server handle.
+
+    Parameters
+    ----------
+    server : libtmux.Server
+        Handle to ask.
+
+    Returns
+    -------
+    str
+        tmux's ``#{pid}`` for that socket.
+    """
+    return server.cmd("display-message", "-p", "#{pid}").stdout[0]
+
+
+def _socket_path(server: Server) -> str:
+    """Return the socket path tmux resolved for a server handle.
+
+    Parameters
+    ----------
+    server : libtmux.Server
+        Handle to ask.
+
+    Returns
+    -------
+    str
+        tmux's ``#{socket_path}`` for that socket.
+    """
+    return server.cmd("display-message", "-p", "#{socket_path}").stdout[0]
+
+
+def check_1(ctx: HowtoContext) -> None:
+    """Two named sockets carry two independent ``build`` sessions.
+
+    Parameters
+    ----------
+    ctx : HowtoContext
+        The page's execution context.
+    """
+    assert ctx.output[1].strip().splitlines() == ["['build']", "['build']"]
+
+    alpha = ctx.namespace["alpha"]
+    beta = ctx.namespace["beta"]
+    assert isinstance(alpha, Server)
+    assert isinstance(beta, Server)
+    assert alpha.socket_name == ALPHA_SOCKET
+    assert beta.socket_name == BETA_SOCKET
+
+    assert alpha.is_alive()
+    assert beta.is_alive()
+
+    assert ctx.namespace["alpha_build"].session_name == "build"
+    assert ctx.namespace["beta_build"].session_name == "build"
+
+    # Same session name on both, so the only proof that these are two daemons
+    # and not one is that tmux reports two processes on two sockets.
+    assert _server_pid(alpha) != _server_pid(beta)
+    assert _socket_path(alpha).endswith(ALPHA_SOCKET)
+    assert _socket_path(beta).endswith(BETA_SOCKET)
+
+
+def check_2(ctx: HowtoContext) -> None:
+    """Block 2 adds a window to one socket, invisibly to the other.
+
+    Parameters
+    ----------
+    ctx : HowtoContext
+        The page's execution context.
+    """
+    assert ctx.output[2].strip().splitlines() == ["2 2", "1 1"]
+
+    alpha = ctx.namespace["alpha"]
+    beta = ctx.namespace["beta"]
+
+    alpha_windows = [window.window_name for window in alpha.windows]
+    beta_windows = [window.window_name for window in beta.windows]
+    assert "tests" in alpha_windows
+    assert "tests" not in beta_windows, (
+        "the window added to one socket showed up on the other, so these are "
+        "not two servers"
+    )
+    assert len(alpha_windows) == 2
+    assert len(beta_windows) == 1
+    assert len(alpha.panes) == 2
+    assert len(beta.panes) == 1
+
+
+def check_3(ctx: HowtoContext) -> None:
+    """One daemon, two handles, no equality — and both servers torn down.
+
+    Parameters
+    ----------
+    ctx : HowtoContext
+        The page's execution context.
+    """
+    alpha = ctx.namespace["alpha"]
+    same_daemon = ctx.namespace["same_daemon"]
+    assert isinstance(same_daemon, Server)
+
+    assert ctx.output[3].strip().splitlines() == [
+        "None",
+        "True ['build']",
+        "False",
+    ]
+
+    # The trap, stated as the page states it: naming a socket never populates
+    # the path attribute, and the two are compared together.
+    assert alpha.socket_path is None
+    assert same_daemon.socket_name is None
+    assert str(same_daemon.socket_path).endswith(ALPHA_SOCKET)
+    assert same_daemon != alpha
+    assert alpha != same_daemon
+    # Equality is not simply broken: it does answer for two like-built handles.
+    assert Server(socket_name=ALPHA_SOCKET) == alpha
+
+    assert not alpha.is_alive()
+    assert not ctx.namespace["beta"].is_alive()
+    assert not same_daemon.is_alive()

--- a/tests/docs/howto/send_keys.py
+++ b/tests/docs/howto/send_keys.py
@@ -1,0 +1,156 @@
+"""Sidecar for ``docs/howto/send-keys.md``.
+
+The page makes three claims a reader has to be able to trust: that a whole-line
+wait really does see the shell's answer, that ``literal=True`` is what stops
+tmux reading typed text as a key name, and that ``suppress_history`` only hides
+a command in a shell configured to ignore space-prefixed lines.
+
+The first is checked from the page's own printed verdicts — strictly, because a
+containment test on ``capture_pane`` output matches the command tmux echoed
+onto the pane and would pass in a world where no shell ever ran. The other two
+are checked against the *opposite* configuration, in throwaway panes of this
+module's own: text sent without ``literal=True`` has to actually execute, and a
+suppressed command has to land in the history of a bash that was never told to
+ignore it. Claims about what a flag protects you from are worth nothing until
+the unprotected case has been watched failing.
+"""
+
+from __future__ import annotations
+
+import typing as t
+
+from libtmux.server import Server
+from libtmux.test.retry import retry_until
+
+if t.TYPE_CHECKING:
+    from libtmux.pane import Pane
+    from libtmux.window import Window
+    from tests.docs.howto_harness import HowtoContext
+
+SOCKET_NAME = "libtmux-howto"
+
+#: A bash that reads no start-up file, so its history behaviour is the
+#: documented default rather than whatever the machine running this configured.
+BARE_BASH = "bash --norc --noprofile"
+
+
+def has_line(pane: Pane, line: str) -> bool:
+    """Report whether a captured line is exactly ``line``.
+
+    Parameters
+    ----------
+    pane : libtmux.Pane
+        Pane to read.
+    line : str
+        Expected line, compared whole rather than by containment.
+
+    Returns
+    -------
+    bool
+        True when the pane's visible screen holds that line.
+    """
+    return any(row.strip() == line for row in pane.capture_pane())
+
+
+def history_entries(pane: Pane) -> list[str]:
+    """Return the commands listed by bash's ``history`` builtin.
+
+    Mirrors the page's own parsing: a listing row is a number, two spaces, and
+    the command as it was recorded.
+
+    Parameters
+    ----------
+    pane : libtmux.Pane
+        Pane showing a ``history`` listing.
+
+    Returns
+    -------
+    list of str
+        One entry per numbered row on the visible screen.
+    """
+    entries = []
+    for row in pane.capture_pane():
+        number, _, command = row.strip().partition("  ")
+        if number.isdigit():
+            entries.append(command.strip())
+    return entries
+
+
+def check_1(ctx: HowtoContext) -> None:
+    """Confirm the pane answers, and that the page's wait sees it.
+
+    Parameters
+    ----------
+    ctx : HowtoContext
+        The page's execution context.
+    """
+    server = ctx.namespace["server"]
+    assert isinstance(server, Server)
+    assert server.socket_name == SOCKET_NAME
+
+    pane = ctx.namespace["pane"]
+    assert ctx.output[1].strip() == "True", (
+        f"block 1 printed {ctx.output[1]!r}: its wait gave up before the "
+        f"shell answered, so the page teaches a wait that does not work"
+    )
+    assert has_line(pane, f"hello from {pane.pane_id}")
+
+
+def check_2(ctx: HowtoContext) -> None:
+    """``literal=True`` types the word, and dropping it presses the key.
+
+    Parameters
+    ----------
+    ctx : HowtoContext
+        The page's execution context.
+    """
+    pane = ctx.namespace["pane"]
+    message = (
+        "the pane never printed 'Enter' on its own line, so the staged text "
+        "was not typed as five characters — tmux resolved it as a key instead"
+    )
+    assert ctx.output[2].strip() == "True", message
+    assert has_line(pane, "Enter"), message
+
+    window: Window = ctx.namespace["window"]
+    probe = window.split(shell=BARE_BASH)
+    try:
+        probe.send_keys("echo interpreted", enter=False)
+        probe.send_keys("Enter", enter=False)
+        retry_until(lambda: has_line(probe, "interpreted"))
+    finally:
+        probe.kill()
+
+
+def check_3(ctx: HowtoContext) -> None:
+    """Confirm the suppression holds here, and fails without the option.
+
+    Parameters
+    ----------
+    ctx : HowtoContext
+        The page's execution context.
+    """
+    reported = dict(
+        line.split(": ") for line in ctx.output[3].strip().splitlines() if line
+    )
+    assert reported == {"public recorded": "True", "private recorded": "False"}, (
+        f"block 3 reported {reported}: with HISTCONTROL=ignorespace set, bash "
+        f"should record the plain command and drop the suppressed one"
+    )
+
+    server = ctx.namespace["server"]
+    assert isinstance(server, Server)
+    assert "send-keys" not in [session.session_name for session in server.sessions]
+
+    unconfigured = server.new_session(session_name="howto-history", kill_session=True)
+    try:
+        pane = unconfigured.active_window.split(shell=BARE_BASH)
+        pane.send_keys("echo private", suppress_history=True)
+        pane.send_keys("history")
+        retry_until(lambda: "history" in history_entries(pane))
+        assert "echo private" in history_entries(pane), (
+            "a shell without HISTCONTROL=ignorespace kept no record of the "
+            "suppressed command, so the page's caveat overstates the risk"
+        )
+    finally:
+        unconfigured.kill()

--- a/tests/docs/howto/send_keys_to_every_pane.py
+++ b/tests/docs/howto/send_keys_to_every_pane.py
@@ -1,0 +1,118 @@
+"""Sidecar for ``docs/howto/send-keys-to-every-pane.md``.
+
+The page's three blocks build on each other, so the checks mirror that:
+block 1's window has to exist before block 2 can type into it, and block 2's
+keystrokes have to have reached a shell before block 3 photographs the screen.
+
+Block 3 does its own waiting, in front of the reader — that is the technique
+the page teaches. These checks therefore verify the *result* of that wait
+rather than repeating it, and they verify it the strict way: a line equal to
+the answer, never a line containing it. A containment test would also match
+the command tmux echoed onto the pane, and would pass in a world where no
+shell ever ran.
+"""
+
+from __future__ import annotations
+
+import typing as t
+
+from libtmux.server import Server
+from libtmux.test.retry import retry_until
+
+if t.TYPE_CHECKING:
+    from libtmux.pane import Pane
+    from tests.docs.howto_harness import HowtoContext
+
+SOCKET_NAME = "libtmux-howto"
+
+
+def answer(pane: Pane) -> str:
+    """Return the line the page expects this pane to print.
+
+    Parameters
+    ----------
+    pane : libtmux.Pane
+        Pane the command was sent to.
+
+    Returns
+    -------
+    str
+        Expected output line, e.g. ``%2 is ready``.
+    """
+    return f"{pane.pane_id} is ready"
+
+
+def answered(pane: Pane) -> bool:
+    """Report whether the pane's own shell printed the answer.
+
+    Whole-line equality on purpose: ``capture_pane`` includes the echoed
+    command, so a containment test is true before the shell has run.
+
+    Parameters
+    ----------
+    pane : libtmux.Pane
+        Pane to read.
+
+    Returns
+    -------
+    bool
+        True when a captured line is exactly this pane's answer.
+    """
+    return any(line.strip() == answer(pane) for line in pane.capture_pane())
+
+
+def check_1(ctx: HowtoContext) -> None:
+    """Block 1 leaves a three-pane window on its own named server.
+
+    Parameters
+    ----------
+    ctx : HowtoContext
+        The page's execution context.
+    """
+    server = ctx.namespace["server"]
+    assert isinstance(server, Server)
+    assert server.socket_name == SOCKET_NAME
+
+    window = ctx.namespace["window"]
+    panes = window.panes
+    assert len(panes) == 3
+    assert ctx.output[1].strip() == f"3 panes in {window.window_id}"
+
+    for pane in panes:
+        retry_until(lambda pane=pane: any(pane.capture_pane()))  # type: ignore[misc]
+
+
+def check_2(ctx: HowtoContext) -> None:
+    """Every pane runs the command and answers with its own id.
+
+    Parameters
+    ----------
+    ctx : HowtoContext
+        The page's execution context.
+    """
+    window = ctx.namespace["window"]
+    for pane in window.panes:
+        retry_until(lambda pane=pane: answered(pane))  # type: ignore[misc]
+
+
+def check_3(ctx: HowtoContext) -> None:
+    """Block 3's own wait succeeds for every pane, and the session is gone.
+
+    Parameters
+    ----------
+    ctx : HowtoContext
+        The page's execution context.
+    """
+    reported = ctx.output[3].strip().splitlines()
+    assert len(reported) == 3
+    for line in reported:
+        pane_id, _, verdict = line.partition(" ")
+        assert pane_id.startswith("%")
+        assert verdict == "True", (
+            f"block 3 reported {line!r}: its wait gave up before the pane "
+            f"answered, so the page teaches a wait that does not work"
+        )
+
+    server = ctx.namespace["server"]
+    assert isinstance(server, Server)
+    assert "fanout" not in [session.session_name for session in server.sessions]

--- a/tests/docs/howto/start_a_server.py
+++ b/tests/docs/howto/start_a_server.py
@@ -1,0 +1,96 @@
+"""Sidecar for ``docs/howto/start-a-server.md``.
+
+The page makes three claims a reader would take on trust, so each is checked
+against the daemon the block actually left behind rather than against what the
+block printed:
+
+- :meth:`~libtmux.Server.new_session` boots a server on the named socket;
+- the daemon is independent of the handle, so a second handle built from
+  scratch reaches the same sessions;
+- :meth:`~libtmux.Server.start_server` leaves nothing running, which is the
+  reason the page steers readers away from it.
+"""
+
+from __future__ import annotations
+
+import typing as t
+
+from libtmux.server import Server
+
+if t.TYPE_CHECKING:
+    from tests.docs.howto_harness import HowtoContext
+
+SOCKET_NAME = "libtmux-howto"
+EMPTY_SOCKET_NAME = "libtmux-howto-empty"
+
+
+def check_1(ctx: HowtoContext) -> None:
+    """Block 1 leaves a live daemon holding one ``worker`` session.
+
+    Parameters
+    ----------
+    ctx : HowtoContext
+        The page's execution context.
+    """
+    assert ctx.output[1].strip() == "worker is up: True"
+
+    server = ctx.namespace["server"]
+    assert isinstance(server, Server)
+    assert server.socket_name == SOCKET_NAME
+
+    assert server.is_alive()
+    assert [session.session_name for session in server.sessions] == ["worker"]
+
+    session = ctx.namespace["session"]
+    assert session.session_name == "worker"
+
+    # Pasting the page twice has to work, which is what kill_session= buys.
+    again = ctx.run_block(1, namespace={})
+    assert again.strip() == "worker is up: True"
+    assert [session.session_name for session in server.sessions] == ["worker"]
+
+
+def check_2(ctx: HowtoContext) -> None:
+    """Block 2 rebuilds the handle and finds the daemon untouched.
+
+    Parameters
+    ----------
+    ctx : HowtoContext
+        The page's execution context.
+    """
+    assert "server" not in ctx.namespace, (
+        "block 2 shows that dropping the handle does not touch the daemon; "
+        "if the name survives, the page no longer demonstrates that"
+    )
+
+    reconnected = ctx.namespace["reconnected"]
+    assert isinstance(reconnected, Server)
+    assert reconnected.socket_name == SOCKET_NAME
+
+    assert ctx.output[2].strip().splitlines() == ["True", "['worker']"]
+
+    # A third handle, built here and never mentioned on the page, sees the
+    # same daemon: what the block prints is a property of the socket, not of
+    # the object the block happens to hold.
+    assert Server(socket_name=SOCKET_NAME).is_alive()
+
+
+def check_3(ctx: HowtoContext) -> None:
+    """``start_server`` leaves no daemon, and the page cleans up after itself.
+
+    Parameters
+    ----------
+    ctx : HowtoContext
+        The page's execution context.
+    """
+    assert ctx.output[3].strip() == "False"
+
+    empty = ctx.namespace["empty"]
+    assert isinstance(empty, Server)
+    assert empty.socket_name == EMPTY_SOCKET_NAME
+    assert not empty.is_alive()
+    # Not an artefact of the handle: a fresh one finds nothing either.
+    assert not Server(socket_name=EMPTY_SOCKET_NAME).is_alive()
+
+    assert not ctx.namespace["reconnected"].is_alive()
+    assert not Server(socket_name=SOCKET_NAME).is_alive()

--- a/tests/docs/howto_harness.py
+++ b/tests/docs/howto_harness.py
@@ -445,6 +445,67 @@ def resolve_checks(
     return checks
 
 
+def run_page(page: Path, on_stage: Callable[[str], None] = lambda _stage: None) -> None:
+    """Run one how-to page end to end, raising on the first failure.
+
+    Separate from the pytest item so a test can drive a page directly — the
+    mutation probe in :mod:`tests.docs.test_howto_mutations` runs a page under
+    a deliberately broken libtmux and requires it to fail.
+
+    Parameters
+    ----------
+    page : pathlib.Path
+        The how-to page to run.
+    on_stage : callable, optional
+        Called with a description each time execution moves on, so a caller
+        can report which block or check was running when something raised.
+
+    Raises
+    ------
+    HowtoContractError
+        If the page has no ``python`` block, or its sidecar does not satisfy
+        the contract.
+    """
+    blocks = parse_python_blocks(page)
+    if not blocks:
+        msg = (
+            f"{page.name} has no backtick-fenced ```python block. A how-to "
+            f"page must carry at least one runnable example."
+        )
+        raise HowtoContractError(msg)
+
+    sidecar = _load_sidecar(page)
+    checks = resolve_checks(sidecar, len(blocks))
+    setup = getattr(sidecar, "setup", None)
+    teardown = getattr(sidecar, "teardown", None)
+
+    with (
+        pytest.MonkeyPatch.context() as monkeypatch,
+        tempfile.TemporaryDirectory(prefix="libtmux-howto-") as tmp,
+    ):
+        ctx = HowtoContext(
+            page=page,
+            blocks=blocks,
+            monkeypatch=monkeypatch,
+            tmp_path=Path(tmp),
+        )
+        try:
+            on_stage("isolating tmux")
+            _isolate_tmux(ctx)
+            if callable(setup):
+                on_stage(f"{sidecar.__name__}.setup")
+                setup(ctx)
+            for block, check in zip(blocks, checks, strict=True):
+                on_stage(f"{page.name}:{block.first_line} (block {block.number})")
+                ctx.output[block.number] = ctx.run_block(block.number)
+                on_stage(f"{sidecar.__name__}.check_{block.number}")
+                check(ctx)
+        finally:
+            if callable(teardown):
+                teardown(ctx)
+            ctx.run_cleanups()
+
+
 class HowtoPageItem(pytest.Item):
     """Execute one how-to page's blocks and run its sidecar's checks."""
 
@@ -452,55 +513,18 @@ class HowtoPageItem(pytest.Item):
     _stage: str | None = None
 
     def runtest(self) -> None:
-        """Run the page end to end.
+        """Run the page end to end."""
+        run_page(Path(self.path), self._record_stage)
 
-        Raises
-        ------
-        HowtoContractError
-            If the page has no ``python`` block, or its sidecar does not
-            satisfy the contract.
+    def _record_stage(self, stage: str) -> None:
+        """Remember what is running, for :meth:`repr_failure`.
+
+        Parameters
+        ----------
+        stage : str
+            Description of the block or check about to run.
         """
-        page = Path(self.path)
-        blocks = parse_python_blocks(page)
-        if not blocks:
-            msg = (
-                f"{page.name} has no backtick-fenced ```python block. A "
-                f"how-to page must carry at least one runnable example."
-            )
-            raise HowtoContractError(msg)
-
-        sidecar = _load_sidecar(page)
-        checks = resolve_checks(sidecar, len(blocks))
-        setup = getattr(sidecar, "setup", None)
-        teardown = getattr(sidecar, "teardown", None)
-
-        with (
-            pytest.MonkeyPatch.context() as monkeypatch,
-            tempfile.TemporaryDirectory(prefix="libtmux-howto-") as tmp,
-        ):
-            ctx = HowtoContext(
-                page=page,
-                blocks=blocks,
-                monkeypatch=monkeypatch,
-                tmp_path=Path(tmp),
-            )
-            try:
-                self._stage = "isolating tmux"
-                _isolate_tmux(ctx)
-                if callable(setup):
-                    self._stage = f"{sidecar.__name__}.setup"
-                    setup(ctx)
-                for block, check in zip(blocks, checks, strict=True):
-                    self._stage = (
-                        f"{page.name}:{block.first_line} (block {block.number})"
-                    )
-                    ctx.output[block.number] = ctx.run_block(block.number)
-                    self._stage = f"{sidecar.__name__}.check_{block.number}"
-                    check(ctx)
-            finally:
-                if callable(teardown):
-                    teardown(ctx)
-                ctx.run_cleanups()
+        self._stage = stage
 
     def repr_failure(
         self,

--- a/tests/docs/howto_harness.py
+++ b/tests/docs/howto_harness.py
@@ -1,0 +1,615 @@
+"""Run the copy-pasteable how-to guides under ``docs/howto/`` as tests.
+
+A how-to page holds nothing but reader-facing content: prose and plain
+```` ```python ```` fences containing code a reader can paste into a file and
+run. There are no ``>>>`` prompts, no ``assert`` statements, and no markers
+addressed at the test suite.
+
+Everything that makes such a page testable lives beside it, in a *sidecar*
+module under :mod:`tests.docs.howto`. This plugin joins the two:
+
+- it parses the page with MyST's own markdown parser and collects every
+  backtick-fenced ``python`` block, in document order;
+- it points tmux at a private, throwaway world, so a page's examples never
+  reach the sockets of whoever is running the suite;
+- it executes those blocks in one shared namespace, so block 2 sees the names
+  block 1 bound — exactly what the reader gets pasting in sequence;
+- it imports the page's sidecar and calls ``check_N(ctx)`` after block ``N``,
+  bracketed by the sidecar's optional ``setup(ctx)`` and ``teardown(ctx)``.
+
+Rot defence is the point of the contract. A page with no ``python`` fence, a
+page with no sidecar, and a sidecar whose ``check_N`` functions do not
+correspond one-to-one with the page's blocks all *fail*. They do not skip and
+they do not silently pass. The companion :mod:`tests.docs.test_howto_harness`
+closes the remaining holes by asserting that this plugin actually collected
+the pages the run was pointed at, and that each page is reachable from the
+section index.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import dataclasses
+import functools
+import importlib
+import importlib.util
+import io
+import os
+import tempfile
+import typing as t
+from pathlib import Path
+
+import pytest
+from markdown_it.renderer import RendererHTML
+from myst_parser.config.main import MdParserConfig
+from myst_parser.parsers.mdit import create_md_parser
+
+if t.TYPE_CHECKING:
+    import types
+    from collections.abc import Callable, Generator, Iterator, Sequence
+
+    from markdown_it import MarkdownIt
+
+# Sidecars use bare ``assert`` for their hidden checks; without this the
+# failure output loses pytest's introspection because the modules are imported
+# by name rather than collected as test files.
+pytest.register_assert_rewrite("tests.docs.howto")
+
+REPO_ROOT = Path(__file__).parents[2]
+HOWTO_DIR = REPO_ROOT / "docs" / "howto"
+DOCS_CONF = REPO_ROOT / "docs" / "conf.py"
+SIDECAR_PACKAGE = "tests.docs.howto"
+
+
+class HowtoContractError(Exception):
+    """A how-to page and its sidecar do not satisfy the harness contract."""
+
+
+@functools.cache
+def _docs_myst_extensions() -> frozenset[str]:
+    """Return the MyST extensions the documentation build enables.
+
+    Read from ``docs/conf.py`` rather than restated here. Whether a run of
+    backticks or colons becomes a fence is decided by the enabled extension
+    set, so a parser configured from a copy of that set would drift the first
+    time the site's changed and this file did not — and drift means a block
+    that renders on the page but never runs.
+
+    Returns
+    -------
+    frozenset of str
+        Contents of the build's ``myst_enable_extensions``.
+    """
+    spec = importlib.util.spec_from_file_location("_libtmux_docs_conf", DOCS_CONF)
+    if spec is None or spec.loader is None:  # pragma: no cover - unreachable
+        msg = f"cannot load {DOCS_CONF}"
+        raise HowtoContractError(msg)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return frozenset(getattr(module, "myst_enable_extensions", ()))
+
+
+@functools.cache
+def _md_parser() -> MarkdownIt:
+    """Return a parser that tokenizes a page the way the docs build does.
+
+    Returns
+    -------
+    markdown_it.MarkdownIt
+        Parser configured from the build's extension set.
+    """
+    return create_md_parser(
+        MdParserConfig(enable_extensions=set(_docs_myst_extensions())),
+        RendererHTML,
+    )
+
+
+@dataclasses.dataclass(frozen=True)
+class CodeBlock:
+    """One backtick-fenced ``python`` block on a how-to page.
+
+    Attributes
+    ----------
+    number : int
+        1-based position of the block within the page.
+    source : str
+        Block body, verbatim, without the fence lines.
+    first_line : int
+        1-based line number of the block's first line of code in the
+        markdown file. Used to make tracebacks point at the page.
+    """
+
+    number: int
+    source: str
+    first_line: int
+
+
+def iter_pages() -> Iterator[Path]:
+    """Yield every how-to page, in a stable order.
+
+    Walks subdirectories: a page filed under ``docs/howto/advanced/`` is as
+    much a how-to page as one at the top level, and a guard that stopped at
+    the first level would leave a whole tree untested without saying so.
+
+    Yields
+    ------
+    pathlib.Path
+        Absolute path to a how-to page other than a section index.
+    """
+    for path in sorted(HOWTO_DIR.rglob("*.md")):
+        if path.name != "index.md":
+            yield path
+
+
+def sidecar_name(page: Path) -> str:
+    """Return the dotted module name of a page's sidecar.
+
+    Parameters
+    ----------
+    page : pathlib.Path
+        Path to a how-to markdown page.
+
+    Returns
+    -------
+    str
+        Importable module name, e.g. ``tests.docs.howto.check_if_tmux_is_running``.
+    """
+    parts = page.relative_to(HOWTO_DIR).with_suffix("").parts
+    return ".".join((SIDECAR_PACKAGE, *(part.replace("-", "_") for part in parts)))
+
+
+def parse_python_blocks(page: Path) -> list[CodeBlock]:
+    """Extract the backtick-fenced ``python`` blocks from a page.
+
+    Parameters
+    ----------
+    page : pathlib.Path
+        Path to a how-to markdown page.
+
+    Returns
+    -------
+    list of CodeBlock
+        Blocks in document order.
+
+    Raises
+    ------
+    HowtoContractError
+        If the page carries a colon fence that is not a directive. Colon
+        fences are the house style for directives, but ``:::python`` renders
+        an ordinary, copy-pasteable code block that this harness would never
+        execute — a block that looks tested and is not.
+    """
+    blocks: list[CodeBlock] = []
+    for token in _md_parser().parse(page.read_text(encoding="utf-8")):
+        if token.type != "fence":
+            continue
+        info = token.info.strip()
+        if not token.markup.startswith("`"):
+            if not info.startswith("{"):
+                line = (token.map[0] if token.map is not None else 0) + 1
+                msg = (
+                    f"{page.name}:{line} opens a colon fence with info "
+                    f"{info!r}. On a how-to page colon fences are for "
+                    f"directives only — a code example must use a backtick "
+                    f"fence so it runs."
+                )
+                raise HowtoContractError(msg)
+            continue
+        if info.split()[:1] != ["python"]:
+            continue
+        opening_line = token.map[0] if token.map is not None else 0
+        blocks.append(
+            CodeBlock(
+                number=len(blocks) + 1,
+                source=token.content,
+                first_line=opening_line + 2,
+            ),
+        )
+    return blocks
+
+
+@dataclasses.dataclass
+class HowtoContext:
+    """What a sidecar is handed for setup, checks, and teardown.
+
+    Attributes
+    ----------
+    page : pathlib.Path
+        The markdown page being executed.
+    blocks : Sequence[CodeBlock]
+        Every ``python`` block on the page, in order.
+    namespace : dict
+        The shared namespace the page's blocks execute in. After block 2 has
+        run it holds everything blocks 1 and 2 bound.
+    output : dict of int to str
+        Standard output captured per block number, so a check can assert on
+        what the reader would have seen printed.
+    monkeypatch : pytest.MonkeyPatch
+        Undone when the page finishes.
+    tmp_path : pathlib.Path
+        Private scratch directory, removed when the page finishes.
+    """
+
+    page: Path
+    blocks: Sequence[CodeBlock]
+    namespace: dict[str, t.Any] = dataclasses.field(default_factory=dict)
+    output: dict[int, str] = dataclasses.field(default_factory=dict)
+    monkeypatch: pytest.MonkeyPatch = dataclasses.field(
+        default_factory=pytest.MonkeyPatch,
+    )
+    tmp_path: Path = dataclasses.field(default_factory=Path)
+    _cleanups: list[Callable[[], None]] = dataclasses.field(default_factory=list)
+
+    def add_cleanup(self, fn: Callable[[], None]) -> None:
+        """Register a callable to run when the page finishes.
+
+        Cleanups run in reverse registration order, while the environment
+        patches from :meth:`isolate_tmux` are still in effect.
+
+        Parameters
+        ----------
+        fn : callable
+            Zero-argument callable.
+        """
+        self._cleanups.append(fn)
+
+    def run_block(
+        self,
+        number: int,
+        namespace: dict[str, t.Any] | None = None,
+    ) -> str:
+        """Execute one of the page's blocks and return what it printed.
+
+        Passing an explicit ``namespace`` runs the block in isolation instead
+        of the page's shared namespace — a check uses that to exercise the
+        other side of a branch the reader's single example only shows once.
+
+        Parameters
+        ----------
+        number : int
+            1-based block number.
+        namespace : dict, optional
+            Namespace to execute in. Defaults to the shared one.
+
+        Returns
+        -------
+        str
+            Anything the block wrote to standard output.
+        """
+        __tracebackhide__ = True
+        block = self.blocks[number - 1]
+        target = self.namespace if namespace is None else namespace
+        # Pad with newlines so the compiled code's line numbers match the
+        # markdown file: a traceback then points at the real page and line.
+        padded = "\n" * (block.first_line - 1) + block.source
+        code = compile(padded, str(self.page), "exec")
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            exec(code, target)  # noqa: S102
+        return stdout.getvalue()
+
+    def run_cleanups(self) -> None:
+        """Run every registered cleanup, most recent first."""
+        while self._cleanups:
+            self._cleanups.pop()()
+
+
+def _isolate_tmux(ctx: HowtoContext) -> None:
+    """Point tmux at a private, throwaway world for one page.
+
+    The runner calls this before the sidecar ever sees the context, which is
+    the whole design: isolation a page has to remember to ask for is
+    isolation a page will one day forget to ask for, and that failure mode
+    reaches into whatever tmux the person running the suite has open.
+
+    Socket isolation is governed by ``TMUX_TMPDIR``, so both a bare
+    ``Server()`` and a ``Server(socket_name=...)`` in a visible block resolve
+    under this page's scratch directory instead of the reader's real one.
+    ``HOME`` moves too, so shell start-up files stay out of the way, and
+    ``TMUX`` is cleared so libtmux does not believe it is running in a pane.
+
+    The page's own code contains none of this — which is the residual gap: a
+    reader pasting the same block hits their real sockets. Visible examples
+    must therefore be non-destructive on their own.
+
+    Parameters
+    ----------
+    ctx : HowtoContext
+        The page's execution context.
+    """
+    tmux_tmpdir = ctx.tmp_path / "tmux"
+    home = ctx.tmp_path / "home"
+    tmux_tmpdir.mkdir(exist_ok=True)
+    home.mkdir(exist_ok=True)
+    # An empty HOME makes zsh open its first-run configuration wizard, which
+    # takes over the pane and swallows send-keys input.
+    (home / ".zshrc").touch()
+    (home / ".bashrc").touch()
+
+    ctx.monkeypatch.setenv("TMUX_TMPDIR", str(tmux_tmpdir))
+    ctx.monkeypatch.setenv("HOME", str(home))
+    ctx.monkeypatch.delenv("TMUX", raising=False)
+    ctx.monkeypatch.delenv("TMUX_PANE", raising=False)
+
+    ctx.add_cleanup(functools.partial(_kill_private_servers, tmux_tmpdir))
+
+
+def _kill_private_servers(expected_tmpdir: Path) -> None:
+    """Kill every tmux server whose socket lives under this page's tmpdir.
+
+    Each server is addressed by its socket *path*, so a name a page invented
+    is torn down as surely as the default one. The guard is the reason this
+    is safe: it refuses to act unless the environment still points at the
+    directory the page was given, and it only ever touches sockets found
+    inside that directory. An untargeted kill would take out whatever tmux
+    the person running the suite has open.
+
+    Parameters
+    ----------
+    expected_tmpdir : pathlib.Path
+        The private ``TMUX_TMPDIR`` this cleanup is allowed to act on.
+    """
+    if os.environ.get("TMUX_TMPDIR") != str(expected_tmpdir):
+        return
+
+    from libtmux.server import Server
+
+    for socket in sorted(expected_tmpdir.glob("tmux-*/*")):
+        if not socket.is_socket():
+            continue
+        server = Server(socket_path=str(socket))
+        if server.is_alive():
+            server.kill()
+
+
+def _load_sidecar(page: Path) -> types.ModuleType:
+    """Import a page's sidecar module.
+
+    Parameters
+    ----------
+    page : pathlib.Path
+        Path to a how-to markdown page.
+
+    Returns
+    -------
+    types.ModuleType
+        The imported sidecar.
+
+    Raises
+    ------
+    HowtoContractError
+        If no sidecar module exists for the page.
+    """
+    name = sidecar_name(page)
+    try:
+        return importlib.import_module(name)
+    except ModuleNotFoundError as exc:
+        if exc.name != name:
+            raise
+        msg = (
+            f"{page.name} has no sidecar: expected {name} "
+            f"({REPO_ROOT / name.replace('.', '/')}.py). Every how-to page "
+            f"must be paired with one."
+        )
+        raise HowtoContractError(msg) from exc
+
+
+def resolve_checks(
+    sidecar: types.ModuleType,
+    block_count: int,
+) -> list[Callable[[HowtoContext], None]]:
+    """Return a sidecar's per-block checks, verifying the contract.
+
+    Parameters
+    ----------
+    sidecar : types.ModuleType
+        The page's sidecar module.
+    block_count : int
+        Number of ``python`` blocks on the page.
+
+    Returns
+    -------
+    list of callable
+        ``check_1`` through ``check_<block_count>``.
+
+    Raises
+    ------
+    HowtoContractError
+        If a ``check_N`` is missing, or the sidecar defines checks for blocks
+        the page no longer has.
+    """
+    checks: list[Callable[[HowtoContext], None]] = []
+    for number in range(1, block_count + 1):
+        check = getattr(sidecar, f"check_{number}", None)
+        if not callable(check):
+            msg = (
+                f"{sidecar.__name__} must define check_{number}(ctx) for "
+                f"block {number} of the page"
+            )
+            raise HowtoContractError(msg)
+        checks.append(check)
+
+    orphans = sorted(
+        name
+        for name in vars(sidecar)
+        if name.startswith("check_")
+        and name[len("check_") :].isdigit()
+        and int(name[len("check_") :]) > block_count
+    )
+    if orphans:
+        msg = (
+            f"{sidecar.__name__} defines {', '.join(orphans)} but the page "
+            f"only has {block_count} python block(s)"
+        )
+        raise HowtoContractError(msg)
+    return checks
+
+
+class HowtoPageItem(pytest.Item):
+    """Execute one how-to page's blocks and run its sidecar's checks."""
+
+    #: Which block or check is running, for the failure report.
+    _stage: str | None = None
+
+    def runtest(self) -> None:
+        """Run the page end to end.
+
+        Raises
+        ------
+        HowtoContractError
+            If the page has no ``python`` block, or its sidecar does not
+            satisfy the contract.
+        """
+        page = Path(self.path)
+        blocks = parse_python_blocks(page)
+        if not blocks:
+            msg = (
+                f"{page.name} has no backtick-fenced ```python block. A "
+                f"how-to page must carry at least one runnable example."
+            )
+            raise HowtoContractError(msg)
+
+        sidecar = _load_sidecar(page)
+        checks = resolve_checks(sidecar, len(blocks))
+        setup = getattr(sidecar, "setup", None)
+        teardown = getattr(sidecar, "teardown", None)
+
+        with (
+            pytest.MonkeyPatch.context() as monkeypatch,
+            tempfile.TemporaryDirectory(prefix="libtmux-howto-") as tmp,
+        ):
+            ctx = HowtoContext(
+                page=page,
+                blocks=blocks,
+                monkeypatch=monkeypatch,
+                tmp_path=Path(tmp),
+            )
+            try:
+                self._stage = "isolating tmux"
+                _isolate_tmux(ctx)
+                if callable(setup):
+                    self._stage = f"{sidecar.__name__}.setup"
+                    setup(ctx)
+                for block, check in zip(blocks, checks, strict=True):
+                    self._stage = (
+                        f"{page.name}:{block.first_line} (block {block.number})"
+                    )
+                    ctx.output[block.number] = ctx.run_block(block.number)
+                    self._stage = f"{sidecar.__name__}.check_{block.number}"
+                    check(ctx)
+            finally:
+                if callable(teardown):
+                    teardown(ctx)
+                ctx.run_cleanups()
+
+    def repr_failure(
+        self,
+        excinfo: pytest.ExceptionInfo[BaseException],
+        style: t.Any = None,
+    ) -> t.Any:
+        """Report a failure, naming the block or check that raised.
+
+        Parameters
+        ----------
+        excinfo : pytest.ExceptionInfo
+            The captured exception.
+        style : str, optional
+            Traceback style pytest asked for.
+
+        Returns
+        -------
+        object
+            pytest's own representation, with a section naming the stage.
+        """
+        # When the page's own code raised, start the report at the markdown
+        # frame so a maintainer reads the offending line first instead of
+        # pytest's and this plugin's call chain.
+        page = str(self.path)
+        if any(str(entry.path) == page for entry in excinfo.traceback):
+            excinfo.traceback = excinfo.traceback.cut(path=page)
+        report = self._repr_failure_py(excinfo, style=style)
+        if self._stage is not None and hasattr(report, "addsection"):
+            report.addsection("how-to stage", self._stage)
+        return report
+
+    def reportinfo(self) -> tuple[Path, int, str]:
+        """Return where this item lives, for the test report.
+
+        Returns
+        -------
+        tuple
+            Page path, line offset, and a human-readable description.
+        """
+        return Path(self.path), 0, f"how-to: {Path(self.path).name}"
+
+
+class HowtoPage(pytest.File):
+    """Collector for a single ``docs/howto/*.md`` page."""
+
+    def collect(self) -> Iterator[HowtoPageItem]:
+        """Yield the page's single item.
+
+        The whole page is one test on purpose. Blocks share a namespace, so
+        splitting them into separate items would break under ``--reruns`` and
+        under ``pytest-xdist``, both of which are configured here.
+
+        Yields
+        ------
+        HowtoPageItem
+            The item that runs every block on the page.
+        """
+        yield HowtoPageItem.from_parent(self, name="howto")
+
+
+def is_howto_page(path: Path) -> bool:
+    """Return whether a path is a how-to page this plugin owns.
+
+    Parameters
+    ----------
+    path : pathlib.Path
+        Candidate path.
+
+    Returns
+    -------
+    bool
+        True for a markdown page anywhere under ``docs/howto/`` that is not a
+        section index.
+    """
+    return (
+        path.suffix == ".md" and path.name != "index.md" and HOWTO_DIR in path.parents
+    )
+
+
+@pytest.hookimpl(wrapper=True)
+def pytest_collect_file(
+    file_path: Path,
+    parent: pytest.Collector,
+) -> Generator[None, t.Any, t.Any]:
+    """Claim how-to pages, and only how-to pages.
+
+    ``pytest_collect_file`` aggregates every plugin's answer, so gp-libs'
+    doctest collector would otherwise return a second collector for the same
+    file. Replacing the aggregate result keeps a how-to page to exactly one
+    collector while leaving every other page in ``docs/`` untouched.
+
+    Parameters
+    ----------
+    file_path : pathlib.Path
+        The file being considered.
+    parent : pytest.Collector
+        The parent collector.
+
+    Yields
+    ------
+    None
+        Control, so the wrapped hook implementations run.
+
+    Returns
+    -------
+    object
+        The collectors for this path.
+    """
+    collectors = yield
+    if is_howto_page(file_path):
+        return [HowtoPage.from_parent(parent, path=file_path)]
+    return collectors

--- a/tests/docs/howto_harness.py
+++ b/tests/docs/howto_harness.py
@@ -394,6 +394,35 @@ def _load_sidecar(page: Path) -> types.ModuleType:
         raise HowtoContractError(msg) from exc
 
 
+def _require_tmux_version(page: Path, sidecar: types.ModuleType) -> None:
+    """Skip a page whose examples need a newer tmux than this one.
+
+    A guide to a version-specific feature cannot run everywhere, and the
+    honest answer on an older tmux is a reported skip rather than a failure
+    the page was written to produce. The declaration lives on the sidecar
+    because the page carries no test scaffolding: a reader copying the block
+    should meet the feature, not a marker addressed at the suite.
+
+    Parameters
+    ----------
+    page : pathlib.Path
+        The how-to page about to run.
+    sidecar : types.ModuleType
+        Its sidecar, which may define ``MIN_TMUX_VERSION``.
+    """
+    minimum = getattr(sidecar, "MIN_TMUX_VERSION", None)
+    if minimum is None:
+        return
+
+    from libtmux.common import get_version, has_gte_version
+
+    if not has_gte_version(minimum):
+        pytest.skip(
+            f"{page.name} documents a tmux {minimum}+ feature; this tmux is "
+            f"{get_version()}",
+        )
+
+
 def resolve_checks(
     sidecar: types.ModuleType,
     block_count: int,
@@ -478,6 +507,12 @@ def run_page(page: Path, on_stage: Callable[[str], None] = lambda _stage: None) 
     checks = resolve_checks(sidecar, len(blocks))
     setup = getattr(sidecar, "setup", None)
     teardown = getattr(sidecar, "teardown", None)
+
+    # Resolved above rather than below, so a page documenting a newer tmux
+    # still has its contract enforced on an older one. Only running the
+    # examples is skipped; a missing sidecar or a stray check_N is a failure
+    # at every tmux version.
+    _require_tmux_version(page, sidecar)
 
     with (
         pytest.MonkeyPatch.context() as monkeypatch,

--- a/tests/docs/test_howto_harness.py
+++ b/tests/docs/test_howto_harness.py
@@ -1,0 +1,148 @@
+"""Guard the wiring between ``docs/howto/`` and its sidecars.
+
+:mod:`tests.docs.howto_harness` fails loudly when a page's contract is broken,
+but only for pages it is actually asked to run. These tests cover the failure
+modes it cannot see from the inside: the harness being unplugged — the plugin
+dropped from ``conftest.py``, the collect hook deleted, a page renamed out from
+under its sidecar — and the page being unreachable, which Sphinx reports as a
+warning nobody reads because the build does not run with ``-W``.
+"""
+
+from __future__ import annotations
+
+import re
+import typing as t
+
+import pytest
+
+from tests.docs import howto_harness
+
+if t.TYPE_CHECKING:
+    from pathlib import Path
+
+PAGES = list(howto_harness.iter_pages())
+PAGE_IDS = [page.name for page in PAGES]
+
+#: A ``{toctree}`` block and its body, in a backtick-fenced MyST directive.
+TOCTREE_RE = re.compile(
+    r"^```\{toctree\}\n(?P<body>.*?)^```$",
+    re.DOTALL | re.MULTILINE,
+)
+
+
+def test_there_are_howto_pages() -> None:
+    """The how-to tree is not empty, so the checks below are not vacuous."""
+    assert PAGES
+
+
+@pytest.mark.parametrize("page", PAGES, ids=PAGE_IDS)
+def test_page_contract_holds(page: Path) -> None:
+    """Each page has runnable blocks and a sidecar that matches them.
+
+    Parameters
+    ----------
+    page : pathlib.Path
+        A how-to page.
+    """
+    blocks = howto_harness.parse_python_blocks(page)
+    assert blocks, f"{page.name} has no backtick-fenced ```python block"
+
+    sidecar = howto_harness._load_sidecar(page)
+    checks = howto_harness.resolve_checks(sidecar, len(blocks))
+    assert len(checks) == len(blocks)
+
+
+@pytest.mark.parametrize("page", PAGES, ids=PAGE_IDS)
+def test_page_anchor_matches_its_filename(page: Path) -> None:
+    """Each page opens with the anchor its filename implies.
+
+    Cross-references reach a how-to by ``{ref}`howto-<stem>```. Deriving the
+    anchor from the filename means renaming a page breaks here, loudly, rather
+    than leaving inbound references pointing at a target that no longer
+    exists — which Sphinx reports without failing the build.
+
+    Parameters
+    ----------
+    page : pathlib.Path
+        A how-to page.
+    """
+    first = page.read_text(encoding="utf-8").lstrip().splitlines()[0]
+    assert first == f"(howto-{page.stem})="
+
+
+@pytest.mark.parametrize("page", PAGES, ids=PAGE_IDS)
+def test_page_is_reachable_from_an_index(page: Path) -> None:
+    """Each page is listed in the toctree of the index beside it.
+
+    A page absent from every toctree still builds — as an orphan, behind a
+    ``toc.not_included`` warning that ``just build-docs`` does not turn into
+    a failure. The reader simply never finds the page.
+
+    Parameters
+    ----------
+    page : pathlib.Path
+        A how-to page.
+    """
+    index = page.parent / "index.md"
+    assert index.exists(), f"{page.parent} has no index.md to list {page.name} in"
+
+    listed = {
+        entry
+        for match in TOCTREE_RE.finditer(index.read_text(encoding="utf-8"))
+        for line in match.group("body").splitlines()
+        if (entry := line.strip()) and not entry.startswith(":")
+    }
+    assert page.stem in listed, (
+        f"{page.name} is not in the toctree of {index.relative_to(index.parents[1])}"
+    )
+
+
+def test_pages_in_scope_are_collected_by_the_harness(
+    request: pytest.FixtureRequest,
+) -> None:
+    """Every how-to page the run was pointed at produced a harness item.
+
+    A page that is in scope but produced no
+    :class:`~tests.docs.howto_harness.HowtoPageItem` is a page nothing
+    executes: gp-libs' doctest collector ignores a fence without ``>>>``
+    silently, so the run would stay green.
+
+    Parameters
+    ----------
+    request : pytest.FixtureRequest
+        Used to reach the collected session items.
+    """
+    session = request.session
+    collected = {
+        item.path
+        for item in session.items
+        if isinstance(item, howto_harness.HowtoPageItem)
+    }
+    in_scope = [page for page in PAGES if _is_in_collection_scope(page, session)]
+
+    if not in_scope:
+        pytest.skip("no how-to page is inside this run's collection roots")
+
+    assert set(in_scope) <= collected
+
+
+def _is_in_collection_scope(page: Path, session: pytest.Session) -> bool:
+    """Return whether ``page`` sits under one of the run's collection roots.
+
+    Parameters
+    ----------
+    page : pathlib.Path
+        A how-to page.
+    session : pytest.Session
+        The running session.
+
+    Returns
+    -------
+    bool
+        True when pytest was pointed at the page or a directory above it.
+    """
+    for arg in session.config.args:
+        root = session.config.invocation_params.dir / arg.split("::")[0]
+        if page == root or root in page.parents:
+            return True
+    return False

--- a/tests/docs/test_howto_mutations.py
+++ b/tests/docs/test_howto_mutations.py
@@ -1,0 +1,97 @@
+"""Prove the hidden checks would notice if the examples stopped working.
+
+A check can pass for the wrong reason. The classic one on a page that types
+into a pane is to look for the answer in :meth:`~libtmux.Pane.capture_pane`
+output with a containment test: the captured lines include the command tmux
+just echoed onto the pane, so the test is satisfied the moment the keystrokes
+land — before any shell has run, and equally in a world where none ever will.
+A page verified that way reports green while teaching a technique that does
+not work.
+
+So the checks are themselves checked. Each page that types a command and
+reads the answer back is re-run against a libtmux whose ``send_keys`` types
+the keys and never presses Enter. Nothing the page waits for can arrive, and
+the page's own checks are required to say so.
+"""
+
+from __future__ import annotations
+
+import typing as t
+
+import pytest
+
+from libtmux import exc
+from libtmux.pane import Pane
+from tests.docs import howto_harness
+
+if t.TYPE_CHECKING:
+    import pathlib
+
+
+def _types_and_reads_back(page: pathlib.Path) -> bool:
+    """Return whether a page both sends keys and reads the pane back.
+
+    Parameters
+    ----------
+    page : pathlib.Path
+        A how-to page.
+
+    Returns
+    -------
+    bool
+        True when the page's examples do both, and are therefore exposed to
+        the echoed-command mistake.
+    """
+    source = "\n".join(
+        block.source for block in howto_harness.parse_python_blocks(page)
+    )
+    return "send_keys" in source and "capture_pane" in source
+
+
+#: Pages whose examples type a command and then read the answer back. Derived
+#: rather than listed, so a page added later is covered without anyone having
+#: to remember this file exists.
+PAGES = [page for page in howto_harness.iter_pages() if _types_and_reads_back(page)]
+PAGE_IDS = [page.name for page in PAGES]
+
+
+def test_some_page_reads_output_back() -> None:
+    """At least one page is covered, so the probe below is not vacuous."""
+    assert PAGES
+
+
+@pytest.mark.parametrize("page", PAGES, ids=PAGE_IDS)
+def test_page_fails_when_the_shell_never_runs(
+    page: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The page's checks fail when its keystrokes never reach a shell.
+
+    Parameters
+    ----------
+    page : pathlib.Path
+        A how-to page that types a command and reads the answer back.
+    monkeypatch : pytest.MonkeyPatch
+        Used to withhold the Enter key for the duration of the run.
+    """
+    typed = Pane.send_keys
+
+    def without_enter(self: Pane, cmd: str | None = None, **kwargs: t.Any) -> None:
+        """Type the keys and never press Enter.
+
+        Parameters
+        ----------
+        self : libtmux.Pane
+            Pane being typed into.
+        cmd : str, optional
+            Keys to send.
+        **kwargs : object
+            Everything else the page passed, minus ``enter``.
+        """
+        kwargs.pop("enter", None)
+        typed(self, cmd, enter=False, **kwargs)
+
+    monkeypatch.setattr(Pane, "send_keys", without_enter)
+
+    with pytest.raises((AssertionError, exc.LibTmuxException)):
+        howto_harness.run_page(page)

--- a/tests/docs/test_howto_rendering.py
+++ b/tests/docs/test_howto_rendering.py
@@ -1,0 +1,216 @@
+"""Hold how-to pages to what they promise a reader.
+
+A how-to guide makes two claims the harness cannot check by running code:
+that the block on the page carries nothing but the reader's own code, and
+that the copy button hands back exactly what is shown. Both are properties of
+the *rendered* page, so both are checked here.
+
+The cheap tests read the page source, which for this scheme is what renders —
+blocks are executed where they are written, never sliced out of somewhere
+else, so nothing can drift between the two. The integration test spends a
+Sphinx build to confirm that, and would catch an extension that rewrote a
+code block on its way to HTML.
+"""
+
+from __future__ import annotations
+
+import html
+import importlib.util
+import re
+import subprocess
+import sys
+import typing as t
+
+import pytest
+
+from tests.docs import howto_harness
+
+if t.TYPE_CHECKING:
+    import pathlib
+
+PAGES = list(howto_harness.iter_pages())
+PAGE_IDS = [page.name for page in PAGES]
+
+#: Vocabulary that belongs to the test harness, never to a reader's script.
+SCAFFOLDING = (
+    "assert ",
+    "import pytest",
+    "HowtoContext",
+    "retry_until",
+    ">>> ",
+)
+
+#: A pygments code block in built HTML, captured with the language Sphinx
+#: tagged it with.
+HIGHLIGHT_RE = re.compile(
+    r'<div class="highlight-(?P<language>[\w-]+) notranslate">'
+    r'<div class="highlight"><pre>(?P<body>.*?)</pre>',
+    re.DOTALL,
+)
+TAG_RE = re.compile(r"<[^>]+>")
+
+#: The only two things a how-to page may render as a code block. ``python``
+#: is what the harness executes; ``console`` is a command the reader runs in
+#: a shell, which nothing can execute for them. Every other spelling is a
+#: mistake rather than a choice: ```py`` renders as ``highlight-py`` and a
+#: bare ``` renders as ``highlight-default``, both of which publish
+#: copy-pasteable Python that no test ever runs.
+RENDERABLE_LANGUAGES = frozenset({"python", "console"})
+
+
+def _docs_config(name: str) -> t.Any:
+    """Return one value from the documentation build's configuration.
+
+    Parameters
+    ----------
+    name : str
+        Configuration variable to read.
+
+    Returns
+    -------
+    object
+        Its value in ``docs/conf.py``.
+    """
+    spec = importlib.util.spec_from_file_location(
+        "_libtmux_docs_conf_render",
+        howto_harness.DOCS_CONF,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return getattr(module, name)
+
+
+@pytest.mark.parametrize("page", PAGES, ids=PAGE_IDS)
+def test_visible_blocks_carry_no_scaffolding(page: pathlib.Path) -> None:
+    """Nothing a reader copies is an assertion or a test-suite import.
+
+    Parameters
+    ----------
+    page : pathlib.Path
+        A how-to page.
+    """
+    for block in howto_harness.parse_python_blocks(page):
+        for offset, line in enumerate(block.source.splitlines()):
+            found = [token for token in SCAFFOLDING if token in line]
+            assert not found, (
+                f"{page.name}:{block.first_line + offset} renders {found[0]!r} "
+                f"to the reader: {line!r}. Hidden checks belong in "
+                f"{howto_harness.sidecar_name(page)}."
+            )
+
+
+@pytest.mark.parametrize("page", PAGES, ids=PAGE_IDS)
+def test_visible_blocks_copy_verbatim(page: pathlib.Path) -> None:
+    """No rendered line trips sphinx-copybutton's prompt detection.
+
+    The prompt pattern includes ``# `` and ``> ``, and copybutton strips
+    prompts and copies only prompted lines. A block whose first line is a
+    column-zero comment therefore copies as *only its comments* — the code
+    the page is about never reaches the reader's clipboard.
+
+    Parameters
+    ----------
+    page : pathlib.Path
+        A how-to page.
+    """
+    prompt = re.compile(_docs_config("copybutton_prompt_text"))
+    for block in howto_harness.parse_python_blocks(page):
+        for offset, line in enumerate(block.source.splitlines()):
+            assert not prompt.match(line), (
+                f"{page.name}:{block.first_line + offset} renders {line!r}, "
+                f"which the copy button reads as a shell prompt. Indent the "
+                f"comment, or move the remark into the prose."
+            )
+
+
+@pytest.mark.integration
+def test_rendered_blocks_match_the_page_source(tmp_path: pathlib.Path) -> None:
+    """Sphinx renders each page's blocks exactly as they are written.
+
+    Only the how-to pages are written out. Sphinx still reads every source
+    into its environment, so these pages render exactly as they would in a
+    full build, and skipping the rest of the site keeps this affordable
+    enough to stay in the ordinary test run rather than a lane of its own.
+
+    Parameters
+    ----------
+    tmp_path : pathlib.Path
+        Build destination, so the checked-in build is left alone.
+    """
+    source = howto_harness.REPO_ROOT / "docs"
+    out = tmp_path / "html"
+    # Redirects resolve against pages this build deliberately skips, and
+    # rediraffe fails a build whose redirect targets are absent.
+    no_redirects = tmp_path / "redirects.txt"
+    no_redirects.touch()
+    built = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "sphinx",
+            "-b",
+            "dirhtml",
+            "-q",
+            "-D",
+            f"rediraffe_redirects={no_redirects}",
+            "-d",
+            str(tmp_path / "doctrees"),
+            str(source),
+            str(out),
+            *(str(page) for page in PAGES),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=source,
+    )
+    assert built.returncode == 0, f"sphinx-build failed:\n{built.stderr}"
+
+    for page in PAGES:
+        docname = page.relative_to(source).with_suffix("")
+        blocks = _code_blocks(out / docname / "index.html")
+
+        stray = sorted({lang for lang, _ in blocks} - RENDERABLE_LANGUAGES)
+        assert not stray, (
+            f"{page.name} renders a {stray[0]!r} code block. A how-to page "
+            f"may only render ```python, which the harness runs, and "
+            f"```console, which the reader runs. Anything else publishes "
+            f"code that nothing tests."
+        )
+
+        rendered = [body for lang, body in blocks if lang == "python"]
+        expected = [
+            block.source.rstrip("\n")
+            for block in howto_harness.parse_python_blocks(page)
+        ]
+        assert rendered == expected, (
+            f"{page.name}'s rendered python blocks are not the ones the "
+            f"harness ran; something between the markdown and the HTML "
+            f"rewrote a block."
+        )
+
+
+def _code_blocks(built: pathlib.Path) -> list[tuple[str, str]]:
+    """Return every code block in a built page, with its language.
+
+    Parameters
+    ----------
+    built : pathlib.Path
+        Path to a rendered HTML page.
+
+    Returns
+    -------
+    list of tuple
+        ``(language, body)`` in page order, tags stripped and entities
+        decoded.
+    """
+    markup = built.read_text(encoding="utf-8")
+    return [
+        (
+            match.group("language"),
+            html.unescape(TAG_RE.sub("", match.group("body"))).rstrip("\n"),
+        )
+        for match in HIGHLIGHT_RE.finditer(markup)
+    ]

--- a/tests/test_pane.py
+++ b/tests/test_pane.py
@@ -887,14 +887,12 @@ def test_display_message_warns_on_tmux_error(session: Session) -> None:
 
 
 def test_split_percentage(session: Session) -> None:
-    """Test Pane.split() with percentage parameter."""
-    from libtmux.common import has_gte_version
+    """Test Pane.split() with percentage parameter.
 
-    # tmux 3.4 has a regression in split-window -p; fixed in 3.5.
-    # Per CHANGES FROM 3.4 TO 3.5: "Fix split-window -p."
-    if not has_gte_version("3.5"):
-        pytest.skip("split-window -p was broken in tmux 3.4 (fixed in 3.5)")
-
+    Runs on every supported tmux. The percentage rides on ``-l``, which has
+    accepted one since tmux 3.1 and never carried ``-p``'s 3.4 regression, so
+    a version gate here would hide exactly the breakage this pins.
+    """
     window = session.new_window(window_name="test_split_pct")
     window.resize(height=40, width=80)
     pane = window.active_pane


### PR DESCRIPTION
## Summary

- **Add** a `docs/howto/` section: fifteen task-shaped guides whose visible code is plain Python a reader copies into a file and runs — no `>>>` prompts, no assertions, no test markers.
- **Add** a pytest plugin that runs each page's blocks in document order in one shared namespace, so block 2 sees what block 1 bound, which is what a reader pasting in sequence gets.
- **Pair** every page with a sidecar module holding the hidden checks. A missing sidecar, a missing check, or a check with no block is a hard failure rather than a skip.
- **Isolate** each page in a private `TMUX_TMPDIR` and `HOME` from the runner rather than from page setup, so an example cannot reach the tmux of whoever runs the suite.
- **Guard** the contract with three test modules covering the page/sidecar wiring, the rendered HTML, and — by running pages against a deliberately broken libtmux — that the hidden checks can actually fail.
- **Fail** the docs build on warnings, so a broken cross-reference or a page in no toctree stops the build instead of scrolling past.

Prose pages under `docs/` are doctests, which are testable but not copyable — a reader cannot paste `>>> server.new_session()` into a script. A how-to guide needs the opposite, and the doctest collector only claims a fence containing `>>>`, so a bare ```` ```python ```` block would ship untested with no warning and no failure.

## Changes by area

### The harness

- **`tests/docs/howto_harness.py`**: parses a page with MyST's own parser, collects its ```` ```python ```` fences in document order, runs them in one namespace, and calls the sidecar's `check_N(ctx)` after block N. Its `pytest_collect_file` wrapper replaces the aggregated collector list for how-to pages so the doctest plugin does not also claim them.
- The parser reads `myst_enable_extensions` from `docs/conf.py` rather than restating it. Whether a run of backticks becomes a fence depends on the enabled extension set, so a copy would drift the first time the site's config changed — and drift means a block that renders on the page but never runs.
- `ctx.run_block(n, namespace={})` re-runs a block in a fresh world, which is how a page showing `if server.is_alive():` gets both branches checked from one visible block.

### The guides

Fifteen pages, grouped in the index by what you are driving:

| Group | Pages |
|---|---|
| Servers | start a server, run multiple servers, connect to an existing server, check if tmux is running |
| Lookups | connect to an existing session, window, pane |
| Self-location | detect you are inside tmux; find the session, window, pane you're in |
| Panes | send keys, send keys to every pane, create panes, create a floating pane |

### The guards

- **`tests/docs/test_howto_harness.py`**: the tree is non-empty, every page's contract resolves, every page the run was pointed at produced an item, each page opens with the anchor its filename implies, and each appears in the toctree beside it.
- **`tests/docs/test_howto_rendering.py`**: rejects assertions, pytest imports, harness names and prompts in a visible block; rejects any line the sphinx-copybutton prompt pattern matches, read from `docs/conf.py`; and allows only `python` and `console` as rendered languages.
- **`tests/docs/test_howto_mutations.py`**: re-runs each page that types a command and reads the answer back against a libtmux whose `send_keys` never presses Enter, and requires the page's own checks to fail.

### Conventions and build

- **`docs/AGENTS.md`**: carves out `docs/howto/` from the doctest rules that govern the rest of `docs/`, and states what visible code owes a reader who runs it verbatim.
- **`docs/justfile`**: passes `-W` to `sphinx-build`.

## Design decisions

**The page carries no test scaffolding at all.** The pages are the product; an assertion in the block is an assertion in the reader's paste. Everything that makes a page testable lives in `tests/docs/howto/<slug>.py`, named after the page.

**Blocks share one namespace, which inverts the rule for the rest of `docs/`.** Topic pages give every block a fresh namespace and a fresh server, because each is an independent illustration. A how-to page is one script broken into steps, so its second block must see the first block's names.

**Isolation belongs to the runner, not the page.** A private `TMUX_TMPDIR` and `HOME` are set before the sidecar is called, and only sockets under that directory are killed, only while the environment still points at it. A sidecar that had to ask for isolation is a sidecar that can forget.

**A mutation probe, because a passing check is not evidence.** `capture_pane` returns the command tmux echoed onto the pane, so a containment test for the answer is satisfied when the keystrokes land — before any shell runs, and equally if none ever will. Without a probe the page reports green while teaching a technique that does not work.

**Visible code polls to a deadline and compares whole lines.** A fixed sleep is either dead time or a false negative, and a substring test is true before the shell has run. The pages teach the correct shape because a reader runs them verbatim.

## Verification

No page carries a doctest prompt — expect no matches:

```console
$ rg '^>>> ' docs/howto/
```

No page carries an assertion — expect no matches:

```console
$ rg '^\s*assert ' docs/howto/
```

No colon fence, which renders copy-pasteable but executes nothing — expect no matches:

```console
$ rg '^:::python' docs/howto/
```

Every guide has a sidecar — both counts are fifteen:

```console
$ fd -e md . docs/howto | rg -v 'index.md' | wc -l
```

```console
$ fd -e py . tests/docs/howto | rg -v '__init__' | wc -l
```

## Test plan

- [x] `uv run pytest --reruns 0` — full suite green
- [x] `uv run ruff check .` and `uv run ruff format --check .` — clean
- [x] `uv run mypy src tests` — clean
- [x] `just build-docs` — builds under `-W` with no warning and no broken cross-reference
- [x] `test_howto_mutations` — every page that reads output back fails when `send_keys` stops pressing Enter, proving the hidden checks are load-bearing
- [x] `test_howto_harness` — a page with no sidecar, a missing `check_N`, and an orphan `check_N` each fail rather than skip
- [x] `test_rendered_blocks_match_the_page_source` — Sphinx renders each page's python blocks exactly as written
- [x] Pages pass under `pytest -n auto`, matching CI's distribution