### PR TITLE
Test against tmux 3.7c

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.14']
-        tmux-version: ['3.2a', '3.3a', '3.4', '3.5', '3.6', '3.7a', '3.7b', 'master']
+        tmux-version: ['3.2a', '3.3a', '3.4', '3.5', '3.6', '3.7a', '3.7c', 'master']
     steps:
       - uses: actions/checkout@v7
 

--- a/CHANGES
+++ b/CHANGES
@@ -87,6 +87,18 @@ parsers, {meth}`Server.is_alive() <libtmux.Server.is_alive>`, and the Sphinx
 config carry scoped per-file ignores where catching everything is the intended
 contract.
 
+#### tmux 3.7c joins the tested versions (#746)
+
+CI exercises tmux 3.7c. The point release needs no library change:
+{func}`~libtmux.common.get_version` strips the point-release suffix, so the
+existing `3.7` feature gates already accept it, and the tmux 3.7
+{meth}`~libtmux.Pane.break_pane` workaround keys on the raw `"3.7"` string
+through {func}`~libtmux.common.get_version_str`.
+
+One tmux-side behavior change is worth knowing: on 3.7c, creating a floating
+pane with {meth}`~libtmux.Pane.new_pane` in a zoomed window unzooms the
+window, where tmux 3.7 through 3.7b left it zoomed.
+
 ## libtmux 0.62.0 (2026-07-12)
 
 libtmux 0.62.0 teaches libtmux objects to locate themselves and to resolve

--- a/tests/test_pane.py
+++ b/tests/test_pane.py
@@ -1350,7 +1350,7 @@ def test_break_pane_no_name_uses_natural_name(session: Session) -> None:
     """Pane.break_pane() without a name keeps tmux's default window name.
 
     The tmux 3.7 break-pane crash workaround injects a placeholder ``-n``
-    when no ``window_name`` is given. On tmux 3.7a/3.7b, where the crash is
+    when no ``window_name`` is given. On tmux 3.7a onward, where the crash is
     already fixed, that placeholder must not leak as the window name -- the
     broken window should keep tmux's own auto-name (here ``sleep``).
     """

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -289,8 +289,8 @@ def test_new_window_name_colon_period_accepted(
     3.7a reverted the restriction (tmux commit 166267c8, "overly
     pernickety"). libtmux's version helpers strip the letter suffix, so
     :func:`~libtmux.common.get_version` cannot tell 3.7 from 3.7a -- both
-    report ``3.7`` -- so CI exercises 3.7a/3.7b rather than the superseded
-    3.7 release.
+    report ``3.7`` -- so CI exercises 3.7a and later point releases rather
+    than the superseded 3.7 release.
     """
     window = session.new_window(window_name=window_name)
     assert window.window_name == window_name


### PR DESCRIPTION
[tmux 3.7c](https://github.com/tmux/tmux/blob/3.7c/CHANGES) is the current 3.7 point release. libtmux supports it with no library change, so this swaps the CI matrix lane and refreshes two test docstrings that named `3.7b`.

### Why no library change is needed

`libtmux.common.get_version()` normalizes point releases — it strips the letter suffix, so `"3.7c"` parses as `LooseVersion("3.7")`. Every `has_gte_version("3.7")` gate already accepts it. The single caller that reads the raw suffix, `libtmux.common.get_version_str()`, feeds the `Pane.break_pane()` crash workaround, and that gate compares against the literal `"3.7"` — so 3.7c takes the fixed path.

### Upstream changes assessed

Every entry in the [3.7c changelog](https://github.com/tmux/tmux/blob/3.7c/CHANGES), checked against libtmux's surface:

- **Build with jemalloc on macOS** — build only.
- **Scrollbar initial state** (`window.c`) — libtmux exposes no scrollbar API.
- **Periodic time checks in format loops** (`format.c`) — performance only, identical output.
- **`message-style` as the `message-format` default** (`status.c`) — `message_format` is a typed option field; libtmux never reads its default.
- **Unzoom before creating a floating pane** (`layout.c`) — behavior note below, no libtmux change.

Two further deltas show up in the diff but not the changelog, and neither touches libtmux:

- `spawn.c` restores empty window names.
- `cmd-split-window.c` treats a lone empty command string as `-E`.

### Behavior note for `new_pane()`

On 3.7c, creating a floating pane in a zoomed window unzooms it — `window_zoomed_flag` goes from `1` to `0`. tmux 3.7 through 3.7b left the window zoomed. Measured against local builds of all four:

```
3.7:  window_zoomed_flag before=1 after new-pane=1
3.7a: window_zoomed_flag before=1 after new-pane=1
3.7b: window_zoomed_flag before=1 after new-pane=1
3.7c: window_zoomed_flag before=1 after new-pane=0
```

The upstream note says the fix avoids a crash. I could not reproduce a crash on 3.7, 3.7a, or 3.7b, either detached or with a client attached on a pty, so there is no libtmux-side guard to add.

### Why the 3.7a lane stays

3.7a and 3.7b are the only releases where an empty `-n` name falls back to the command name instead of staying empty. Probed across every matrix version:

```
3.2a  -n "" -> []
3.3a  -n "" -> []
3.4   -n "" -> []
3.5   -n "" -> []
3.6   -n "" -> []
3.7   -n "" -> rejected, server refuses to start
3.7a  -n "" -> [sleep]
3.7b  -n "" -> [sleep]
3.7c  -n "" -> []
```

3.7a is the older of the two and still in the wild, so it keeps its lane.

### Verification

Full suite against a locally built tmux 3.7c: **1455 passed, 1 skipped**.

Pre-commit gate clean: `ruff check`, `ruff format`, `mypy`, `pytest --reruns 0`, `just build-docs`.
