### PR TITLE
Document structured logging and define failure ownership

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -65,6 +65,10 @@ query_logger = logging.getLogger("libtmux.neo")
 query_logger = logging.getLogger("libtmux.common")
 ```
 
+`libtmux.common` carries every tmux subprocess rather than list queries alone.
+Filter a handler on the `tmux_subcommand` field to isolate queries again;
+{ref}`logging` shows the filter.
+
 #### Raised failures stay in the exception channel (#748)
 
 A failure that libtmux propagates or translates no longer emits an `ERROR`

--- a/CHANGES
+++ b/CHANGES
@@ -45,6 +45,83 @@ $ uvx --from 'libtmux' --prerelease allow python
 _Notes on the upcoming release will go here._
 <!-- END PLACEHOLDER - ADD NEW CHANGELOG ENTRIES BELOW THIS LINE -->
 
+### Breaking changes
+
+#### Raised failures stay in the exception channel (#748)
+
+A failure that libtmux propagates or translates no longer emits an `ERROR`
+record first. Applications that consumed those records now log at their own
+exception boundary.
+
+```python
+import logging
+
+from libtmux import exc
+
+logger = logging.getLogger(__name__)
+
+# Before
+operation()
+
+# After
+try:
+    operation()
+except exc.LibTmuxException:
+    logger.exception("libtmux operation failed")
+    raise
+```
+
+#### Unusable tmux executables share one exception (#748)
+
+Missing, non-executable, and malformed tmux executables now raise
+{exc}`~libtmux.exc.TmuxCommandNotFound` from
+{class}`~libtmux.common.tmux_cmd` and
+{meth}`Server.raise_if_dead() <libtmux.Server.raise_if_dead>`. Attempted
+launches preserve the operating-system message and cause. Other launch
+failures remain native `OSError` values.
+
+```python
+available = True
+try:
+    server.raise_if_dead()
+# Before: except (exc.TmuxCommandNotFound, OSError):
+# After:
+except exc.TmuxCommandNotFound:
+    available = False
+```
+
+### What's new
+
+#### Structured records identify tmux work (#748)
+
+Command `DEBUG` records add best-effort subcommand and socket fields while
+retaining the complete command, exit status, bounded output snapshots, and
+line counts. Lifecycle `INFO` records consistently identify affected sockets,
+sessions, windows, panes, and targets.
+
+Applications can route and format these fields independently through
+standard-library handlers without modifying the original records.
+
+#### Handled failures produce one diagnostic (#748)
+
+{attr}`Server.sessions <libtmux.Server.sessions>`,
+{attr}`Server.attached_sessions <libtmux.Server.attached_sessions>`, and
+{attr}`Server.clients <libtmux.Server.clients>` now emit one `ERROR` record
+when they convert a tmux execution failure to an empty result. Expected probes
+and failures returned to callers stay quiet.
+
+Malformed `terminal-features`, `terminal-overrides`, and `command-alias`
+entries produce one aggregate `WARNING` per option with the skipped-entry
+count.
+
+### Fixes
+
+#### Caller-controlled log context stays on one line (#748)
+
+Command arguments, socket labels, object identities, targets, and failed
+lookup paths escape control characters before rendering, so one value cannot
+forge additional log lines.
+
 ### Documentation
 
 #### Cleaner `from_env` examples (#719)
@@ -56,6 +133,12 @@ its {meth}`Server <libtmux.Server.from_env>`,
 environment-setup plumbing, so each example leads with the constructor call it
 demonstrates instead of the socket-path and `$TMUX` boilerplate needed to run
 it.
+
+#### Logging configuration and record reference (#748)
+
+{ref}`logging` documents logger ownership, levels, structured fields, failure
+routing, payload policy, handler filtering and formatting, and `caplog`
+assertions.
 
 ### Development
 

--- a/CHANGES
+++ b/CHANGES
@@ -47,6 +47,24 @@ _Notes on the upcoming release will go here._
 
 ### Breaking changes
 
+#### Query records use the command logger (#748)
+
+Calls through {func}`~libtmux.neo.fetch_objs` no longer emit the `tmux list
+queried` and `tmux list parsed` `DEBUG` records from `libtmux.neo`. They produce
+`tmux command dispatched` and `tmux command completed` records from
+`libtmux.common` instead. Applications that configure module-specific logging
+now select the command logger:
+
+```python
+import logging
+
+# Before
+query_logger = logging.getLogger("libtmux.neo")
+
+# After
+query_logger = logging.getLogger("libtmux.common")
+```
+
 #### Raised failures stay in the exception channel (#748)
 
 A failure that libtmux propagates or translates no longer emits an `ERROR`

--- a/MIGRATION
+++ b/MIGRATION
@@ -113,6 +113,111 @@ sections below for detailed migration examples and code samples.
 _Detailed migration steps for the next version will be posted here._
 <!-- END PLACEHOLDER - ADD NEW MIGRATION ENTRIES BELOW THIS LINE -->
 
+## libtmux 0.63.x: Failure and logging channels (#748)
+
+### An unusable tmux binary raises `TmuxCommandNotFound`
+
+{class}`~libtmux.common.tmux_cmd` and
+{meth}`Server.raise_if_dead() <libtmux.Server.raise_if_dead>` translate a
+missing, non-executable, or malformed tmux executable into
+{exc}`~libtmux.exc.TmuxCommandNotFound`. That exception subclasses
+{exc}`~libtmux.exc.LibTmuxException`, not `OSError`. Through 0.62.0 a
+non-executable binary surfaced as `PermissionError` and a malformed one as
+`OSError`, so a handler written for either class stops firing.
+
+**Who is affected:** code catching `OSError` or `PermissionError` around a
+tmux launch. Launch failures carrying any other errno still propagate as a
+native `OSError`.
+
+**Before:**
+
+```python
+try:
+    server.raise_if_dead()
+except OSError:
+    available = False
+```
+
+**After:**
+
+```python
+from libtmux import exc
+
+try:
+    server.raise_if_dead()
+except exc.TmuxCommandNotFound:
+    available = False
+```
+
+The operating system's diagnostic survives the translation whenever the launch
+was attempted: the message carries it and `__cause__` holds the original
+`OSError`. A tmux binary absent from `PATH` is never launched, so its
+`__cause__` is `None`.
+
+```python
+from libtmux import exc
+
+try:
+    server.raise_if_dead()
+except exc.TmuxCommandNotFound as error:
+    errno = getattr(error.__cause__, "errno", None)
+```
+
+### Raised failures no longer emit an `ERROR` record
+
+Through 0.62.0 libtmux logged an `ERROR` record before propagating or
+translating a failure. A raised failure now reaches the caller through the
+exception channel alone. `ERROR` records mark the opposite case, a boundary
+that swallowed a failure and returned an empty result:
+{attr}`Server.sessions <libtmux.Server.sessions>`,
+{attr}`Server.attached_sessions <libtmux.Server.attached_sessions>`, and
+{attr}`Server.clients <libtmux.Server.clients>`.
+
+**Who is affected:** alerting and log scraping that counted libtmux `ERROR`
+records to detect failed operations. Log at your own exception boundary:
+
+```python
+import logging
+
+from libtmux import exc
+
+logger = logging.getLogger(__name__)
+
+try:
+    operation()
+except exc.LibTmuxException:
+    logger.exception("libtmux operation failed")
+    raise
+```
+
+### Query `DEBUG` records come from `libtmux.common`
+
+{func}`~libtmux.neo.fetch_objs`, the query path behind the object list
+accessors, emitted `tmux list queried` and `tmux list parsed` on `libtmux.neo`
+through 0.62.0. The shared command producer emits `tmux command dispatched`
+and `tmux command completed` on `libtmux.common` in their place.
+
+**Who is affected:** logging configuration naming `libtmux.neo`, and
+assertions on the old message text. `libtmux.common` carries every tmux
+subprocess rather than list queries alone; filter a handler on the
+`tmux_subcommand` field to isolate queries. See {ref}`logging`.
+
+**Before:**
+
+```python
+import logging
+
+logging.getLogger("libtmux.neo").setLevel(logging.DEBUG)
+```
+
+**After:**
+
+```python
+import logging
+
+logging.getLogger("libtmux.common").setLevel(logging.DEBUG)
+```
+
 ## libtmux 0.62.0: Query exceptions join the hierarchy (#718)
 
 {exc}`~libtmux.exc.ObjectDoesNotExist` and

--- a/conftest.py
+++ b/conftest.py
@@ -11,6 +11,7 @@ https://docs.pytest.org/en/stable/deprecations.html
 from __future__ import annotations
 
 import functools
+import logging
 import shutil
 import typing as t
 
@@ -58,6 +59,8 @@ def add_doctest_fixtures(
             session=session,
         )
         doctest_namespace["monkeypatch"] = request.getfixturevalue("monkeypatch")
+        doctest_namespace["caplog"] = request.getfixturevalue("caplog")
+        doctest_namespace["logging"] = logging
 
 
 @pytest.fixture(autouse=True)

--- a/conftest.py
+++ b/conftest.py
@@ -11,7 +11,6 @@ https://docs.pytest.org/en/stable/deprecations.html
 from __future__ import annotations
 
 import functools
-import logging
 import shutil
 import typing as t
 
@@ -60,7 +59,6 @@ def add_doctest_fixtures(
         )
         doctest_namespace["monkeypatch"] = request.getfixturevalue("monkeypatch")
         doctest_namespace["caplog"] = request.getfixturevalue("caplog")
-        doctest_namespace["logging"] = logging
 
 
 @pytest.fixture(autouse=True)

--- a/docs/topics/index.md
+++ b/docs/topics/index.md
@@ -58,8 +58,8 @@ Common patterns for scripting and automation.
 :::{grid-item-card} Logging
 :link: logging
 :link-type: doc
-Structured log records, the `tmux_` field schema, and reading them with
-`caplog`.
+Structured log records, the `tmux_` field schema, and application-owned
+handlers.
 :::
 
 :::{grid-item-card} Context Managers

--- a/docs/topics/index.md
+++ b/docs/topics/index.md
@@ -55,6 +55,13 @@ Create sessions, windows, and panes programmatically.
 Common patterns for scripting and automation.
 :::
 
+:::{grid-item-card} Logging
+:link: logging
+:link-type: doc
+Structured log records, the `tmux_` field schema, and reading them with
+`caplog`.
+:::
+
 :::{grid-item-card} Context Managers
 :link: context_managers
 :link-type: doc
@@ -96,6 +103,7 @@ floating_panes
 workspace_setup
 automation_patterns
 context_managers
+logging
 options_and_hooks
 clients
 format-tokens

--- a/docs/topics/logging.md
+++ b/docs/topics/logging.md
@@ -376,26 +376,33 @@ nothing, and says nothing about it. Attach it to a **handler**:
 
 >>> handler = Capture()
 >>> libtmux_logger = logging.getLogger("libtmux")
+>>> previous_level = libtmux_logger.level
 >>> libtmux_logger.addHandler(handler)
 >>> libtmux_logger.setLevel(logging.DEBUG)
 >>> pane = session.active_window.active_pane
+>>> on_logger = RedactFilter("hunter2")
 
 On the logger, it never runs:
 
->>> libtmux_logger.addFilter(RedactFilter("hunter2"))
+>>> libtmux_logger.addFilter(on_logger)
 >>> pane.send_keys("login hunter2", enter=False)
 >>> any("hunter2" in r.tmux_cmd for r in records if hasattr(r, "tmux_cmd"))
 True
 
 On the handler, it does:
 
->>> libtmux_logger.removeFilter(libtmux_logger.filters[0])
+>>> libtmux_logger.removeFilter(on_logger)
 >>> handler.addFilter(RedactFilter("hunter2"))
 >>> records.clear()
 >>> pane.send_keys("login hunter2", enter=False)
 >>> any("hunter2" in r.tmux_cmd for r in records if hasattr(r, "tmux_cmd"))
 False
+
+Put the logger back as you found it — a level set on a shared logger outlives
+the code that set it:
+
 >>> libtmux_logger.removeHandler(handler)
+>>> libtmux_logger.setLevel(previous_level)
 ```
 
 The command line also reaches the process table, so it is visible to `ps` for

--- a/docs/topics/logging.md
+++ b/docs/topics/logging.md
@@ -51,6 +51,7 @@ The main emitters are:
 | `libtmux.window` | window lifecycle |
 | `libtmux.pane` | pane lifecycle |
 | `libtmux.options` | aggregated option parsing warnings |
+| `libtmux.hooks` | hook parsing warnings |
 
 ## Command records
 

--- a/docs/topics/logging.md
+++ b/docs/topics/logging.md
@@ -311,14 +311,92 @@ This covers `environment=` on {meth}`Server.new_session()
 well as {meth}`set_environment()
 <libtmux.common.EnvironmentMixin.set_environment>`.
 
-Two things libtmux cannot redact for you, because it cannot tell a secret from a
-keystroke:
+tmux hands those values straight back, so the output side is covered too:
+{meth}`getenv() <libtmux.common.EnvironmentMixin.getenv>` and
+{meth}`show_environment() <libtmux.common.EnvironmentMixin.show_environment>`
+return what you asked for while their records show only the names.
+
+```python
+>>> import logging
+>>> caplog.clear()
+>>> server = session.server
+>>> server.set_environment("DEPLOY_KEY", "hunter2")
+>>> with caplog.at_level(logging.DEBUG, logger="libtmux.common"):
+...     server.getenv("DEPLOY_KEY")
+'hunter2'
+>>> completed = next(
+...     r for r in caplog.records
+...     if r.getMessage() == "tmux command completed"
+... )
+>>> any("hunter2" in line for line in completed.tmux_stdout)
+False
+```
+
+### What libtmux cannot redact
+
+libtmux hides what tmux's own grammar marks as an environment value. It cannot
+classify content you compose yourself:
 
 - **{meth}`Pane.send_keys() <libtmux.Pane.send_keys>` payloads.** What you type
-  into a pane appears verbatim in `tmux_cmd` at `DEBUG`. If you send
-  credentials, do not ship `DEBUG` records off the host.
-- **Anything you pass as a `start_directory`, `window_command`, or shell
-  command**, for the same reason.
+  into a pane appears in `tmux_cmd` at `DEBUG`.
+- **A `start_directory`, `window_command`, or shell command.**
+- **A format string that prints a variable**, such as
+  `display-message -p '#{q:DEPLOY_KEY}'`.
+
+Only your application knows which of those carry secrets, so redacting them is
+its job — with a {class}`~logging.Filter` that rewrites the fields you care
+about.
+
+Placement matters more than the filter does. A filter on a logger runs only for
+records that logger made; {meth}`Logger.callHandlers()
+<logging.Logger.callHandlers>` walks to ancestor loggers for their *handlers*
+and never consults their filters. Since every record comes from a child such as
+`libtmux.common`, attaching one to `logging.getLogger("libtmux")` protects
+nothing, and says nothing about it. Attach it to a **handler**:
+
+```python
+>>> import logging
+>>> import re
+
+>>> class RedactFilter(logging.Filter):
+...     def __init__(self, *patterns: str) -> None:
+...         super().__init__()
+...         self.patterns = [re.compile(p) for p in patterns]
+...
+...     def filter(self, record: logging.LogRecord) -> bool:
+...         for pattern in self.patterns:
+...             if isinstance(getattr(record, "tmux_cmd", None), str):
+...                 record.tmux_cmd = pattern.sub("REDACTED", record.tmux_cmd)
+...         return True
+
+>>> records = []
+>>> class Capture(logging.Handler):
+...     def emit(self, record):
+...         records.append(record)
+
+>>> handler = Capture()
+>>> libtmux_logger = logging.getLogger("libtmux")
+>>> libtmux_logger.addHandler(handler)
+>>> libtmux_logger.setLevel(logging.DEBUG)
+>>> pane = session.active_window.active_pane
+
+On the logger, it never runs:
+
+>>> libtmux_logger.addFilter(RedactFilter("hunter2"))
+>>> pane.send_keys("login hunter2", enter=False)
+>>> any("hunter2" in r.tmux_cmd for r in records if hasattr(r, "tmux_cmd"))
+True
+
+On the handler, it does:
+
+>>> libtmux_logger.removeFilter(libtmux_logger.filters[0])
+>>> handler.addFilter(RedactFilter("hunter2"))
+>>> records.clear()
+>>> pane.send_keys("login hunter2", enter=False)
+>>> any("hunter2" in r.tmux_cmd for r in records if hasattr(r, "tmux_cmd"))
+False
+>>> libtmux_logger.removeHandler(handler)
+```
 
 The command line also reaches the process table, so it is visible to `ps` for
 the same user regardless of logging. Logs differ in that they travel.
@@ -369,7 +447,8 @@ class TmuxJsonFormatter(logging.Formatter):
 ### Route one server's records somewhere else
 
 `tmux_socket` identifies the server, so a {class}`~logging.Filter` can split a
-multi-server application's logs:
+multi-server application's logs. Attach it to the handler, for the reason
+[above](#what-libtmux-cannot-redact):
 
 ```python
 class SocketFilter(logging.Filter):

--- a/docs/topics/logging.md
+++ b/docs/topics/logging.md
@@ -87,7 +87,7 @@ logging.getLogger("libtmux.common").setLevel(logging.INFO)
 | Level | You get |
 |---|---|
 | `ERROR` | A tmux command libtmux treated as a failure, and subprocess errors |
-| `WARNING` | Option and hook output libtmux could not parse |
+| `WARNING` | Option and hook output libtmux could not parse; a control-mode client killed after declining to exit |
 | `INFO` | Object lifecycle: created, renamed, killed |
 | `DEBUG` | Every tmux command line, exit code, stdout, and stderr |
 

--- a/docs/topics/logging.md
+++ b/docs/topics/logging.md
@@ -2,689 +2,208 @@
 
 # Logging
 
-libtmux narrates itself through the standard {mod}`logging` module. Every tmux
-command it runs, and every object it creates, renames, or kills, becomes a log
-record — with the tmux context attached as structured fields rather than baked
-into the message text. That means you filter on `tmux_session == "deploy"`
-instead of running a regular expression over prose.
+libtmux emits structured records through Python's {mod}`logging` module. It
+does not install handlers or choose a level. Configure the `libtmux` logger in
+your application; `INFO` reports object lifecycle events, while `DEBUG` adds
+tmux subprocess boundaries.
 
-libtmux never configures logging for you. It attaches a
-{class}`~logging.NullHandler` and nothing else, so a library import stays silent
-until your application asks for output.
+Command records identify the operation without retaining its operands, stdout,
+or stderr. This keeps shell commands, keystrokes, environment values, buffer
+contents, and pane contents out of logs by default.
 
-Most readers need only the next two sections: turn it on, and read a failure.
-The field schema and the testing and formatting sections below are for when you
-route these records somewhere — a test assertion, a log aggregator, a trace.
+## Enable records
 
-## Running the examples
+The `libtmux` logger is the parent of every package logger. A handler attached
+there receives records from `libtmux.common`, `libtmux.server`, and the
+object modules.
 
-Every Python block in this topic executes in the documentation test suite. The
-standard-library-only blocks paste directly into a Python shell. Blocks using
-`caplog`, `server`, or `session` run in pytest: request those fixtures in a test
-function, then paste the block's statements into its body. `caplog` comes from
-pytest; `server` and `session` come from libtmux's pytest plugin. Any `pane` or
-`window` used below is derived inside its block or from `session`.
-
-## Turn it on
-
-The shortest thing that works — lifecycle events, no tmux command noise:
-
-```python
->>> import logging
->>> logging.basicConfig(level=logging.INFO)
-```
-
-To see the tmux commands themselves, including their output, drop only libtmux
-to `DEBUG` and leave the rest of your application alone:
-
-```python
->>> import logging
->>> libtmux_logger = logging.getLogger("libtmux")
->>> previous_level = libtmux_logger.level
->>> libtmux_logger.setLevel(logging.DEBUG)
->>> libtmux_logger.getEffectiveLevel() == logging.DEBUG
-True
->>> libtmux_logger.setLevel(previous_level)
-```
-
-## Diagnosing a failure
-
-When libtmux is not doing what you expect, this shows every tmux command it
-runs, the exit code, and whatever tmux wrote back. It installs a real handler
-with safe defaults for records that carry no command outcome. The final three
-lines restore the shared documentation process; keep the handler installed in
-your application:
-
-```python
->>> import logging
->>> handler = logging.StreamHandler()
->>> formatter = logging.Formatter(
-...     "%(levelname)s %(name)s %(message)s | %(tmux_cmd)s -> %(tmux_exit_code)s",
-...     defaults={"tmux_cmd": "-", "tmux_exit_code": "-"},
-... )
->>> handler.setFormatter(formatter)
->>> libtmux_logger = logging.getLogger("libtmux")
->>> previous_level = libtmux_logger.level
->>> libtmux_logger.addHandler(handler)
->>> libtmux_logger.setLevel(logging.DEBUG)
->>> record = logging.LogRecord(
-...     "libtmux.common", logging.DEBUG, "common.py", 1,
-...     "tmux command completed", None, None,
-... )
->>> record.tmux_cmd = "tmux -Ldemo list-sessions"
->>> record.tmux_exit_code = 0
->>> formatter.format(record)
-'DEBUG libtmux.common tmux command completed | tmux -Ldemo list-sessions -> 0'
->>> libtmux_logger.removeHandler(handler)
->>> handler.close()
->>> libtmux_logger.setLevel(previous_level)
-```
-
-Then read `tmux_cmd` off the record. It is shell-quoted and includes the
-`-L` or `-S` flag that selects the right server. It reproduces the command
-unless libtmux replaced sensitive content with `REDACTED` or shortened an
-oversized rendering.
-
-An argument holding control characters appears in `$'…'` form. Shell escapes
-keep the rendering familiar and pasteable for ordinary tmux arguments without
-placing a literal line boundary in the record, so nothing in a command line can
-pose as a log record of its own:
-
-```python
->>> import logging
->>> caplog.clear()
->>> pane = session.active_window.active_pane
->>> with caplog.at_level(logging.DEBUG, logger="libtmux.common"):
-...     pane.send_keys("echo one\necho two", enter=False)
->>> record = next(
-...     r for r in caplog.records
-...     if getattr(r, "tmux_subcommand", None) == "send-keys"
-... )
->>> "\n" in record.tmux_cmd
-False
->>> record.tmux_cmd.endswith("$'echo one\\necho two'")
-True
-```
-
-## Where records come from
-
-Loggers are named after their module, so the package name is a prefix you can
-configure as one unit:
-
-| Logger | Emits |
-|---|---|
-| `libtmux.common` | Every tmux command: dispatch, completion, failure |
-| `libtmux.server` | Server and session lifecycle |
-| `libtmux.session` | Window lifecycle, session rename and kill |
-| `libtmux.window` | Window rename and kill |
-| `libtmux.pane` | Pane split, floating pane creation, pane kill |
-| `libtmux.options` | Option values tmux returned that libtmux could not parse |
-| `libtmux.hooks` | Hook lines tmux returned that libtmux could not parse |
-| `libtmux.neo` | Rows of tmux output libtmux could not parse |
-| `libtmux._internal.control_mode` | The `tmux -C` client used by the test fixtures |
-
-Silence the command chatter while keeping lifecycle events:
+Use your application's normal logging configuration. For a short script,
+`logging.basicConfig(level=logging.INFO)` is enough. To inspect command
+metadata without changing other libraries, set only `libtmux.common` to
+`DEBUG`.
 
 ```python
 >>> import logging
 >>> command_logger = logging.getLogger("libtmux.common")
 >>> previous_level = command_logger.level
->>> command_logger.setLevel(logging.INFO)
+>>> command_logger.setLevel(logging.DEBUG)
 >>> command_logger.isEnabledFor(logging.DEBUG)
-False
+True
 >>> command_logger.setLevel(previous_level)
 ```
 
-## What each level gives you
+## Records by level
 
-| Level | You get |
-|---|---|
-| `ERROR` | A tmux command libtmux treated as a failure, and subprocess errors |
-| `WARNING` | Option and hook output libtmux could not parse; a control-mode client killed after declining to exit |
-| `INFO` | Object lifecycle: created, renamed, killed |
-| `DEBUG` | Every tmux command line, exit code, stdout, and stderr |
+| Level | What libtmux records |
+| ----- | -------------------- |
+| `DEBUG` | tmux command dispatch and completion; internal lookup details |
+| `INFO` | successful server, session, window, and pane lifecycle events |
+| `WARNING` | recoverable problems libtmux handled |
+| `ERROR` | a failure libtmux intentionally converted to a fallback result |
 
-`ERROR` records are worth wiring up even if you catch libtmux's exceptions,
-because libtmux's list accessors deliberately swallow tmux errors. {attr}`Server.sessions
-<libtmux.Server.sessions>` returns an empty {class}`~libtmux._internal.query_list.QueryList`
-when tmux is unreachable, which is otherwise indistinguishable from a server
-that genuinely has no sessions. The `ERROR` record is how you tell those two
-apart without changing your code:
+The main emitters are:
 
-```python
->>> import logging
->>> from libtmux.server import Server
->>> unreachable = Server(socket_name="no-such-socket")
->>> caplog.clear()
->>> with caplog.at_level(logging.ERROR, logger="libtmux.common"):
-...     sessions = unreachable.sessions
->>> sessions
-[]
->>> record = caplog.records[-1]
->>> record.getMessage()
-'tmux command failed'
->>> record.tmux_subcommand
-'list-sessions'
->>> record.tmux_socket
-'no-such-socket'
-```
+| Logger | Records |
+| ------ | ------- |
+| `libtmux.common` | subprocess dispatch and completion |
+| `libtmux.server` | server/session lifecycle and swallowed list failures |
+| `libtmux.session` | session/window lifecycle |
+| `libtmux.window` | window lifecycle |
+| `libtmux.pane` | pane lifecycle |
+| `libtmux.options` | aggregated option parsing warnings |
 
-Polling with {meth}`Server.is_alive() <libtmux.Server.is_alive>` stays quiet,
-including when the configured tmux executable is missing or unusable, so a
-health check loop does not fill your logs with errors.
+## Command records
 
-A failure record is attributed to the libtmux method that ran the command, not
-to the helper that raised. So `%(filename)s:%(lineno)d` in a format string —
-and `code.filepath` in OpenTelemetry — point at the operation you called:
+Each tmux subprocess can produce two `DEBUG` records:
+
+- `tmux command dispatched` before execution;
+- `tmux command completed` after execution.
+
+Both carry a safe `tmux_cmd` summary. It contains the executable, effective
+socket selector, subcommand, and the number of operands omitted after the
+subcommand. The completion record adds the exit code and stdout/stderr line
+counts.
 
 ```python
 >>> import logging
->>> caplog.clear()
->>> from libtmux import exc
->>> with caplog.at_level(logging.ERROR, logger="libtmux.common"):
-...     try:
-...         session.kill_window(target_window="no_such_window")
-...     except exc.LibTmuxException:
-...         pass
->>> caplog.records[-1].funcName
-'kill_window'
-```
-
-An option whose value libtmux cannot parse warns once for that option, with
-`tmux_option_skipped` counting the entries it dropped, rather than once per
-entry.
-
-Not every failure comes from tmux. When libtmux cannot parse a row tmux returned
-successfully, the exception mentions only the parsing primitive that raised, so
-an `ERROR` record on `libtmux.neo` carries what the exception cannot: the
-subcommand, and how many fields the row held against how many it should have.
-A count one higher than expected means a value contained the character libtmux
-splits rows on.
-
-## What does not come through logging
-
-libtmux raises about as many advisories through {mod}`warnings` as it logs — a
-deprecated method, a flag your tmux is too old for, an argument being ignored.
-Those never reach a logging handler, so an application configured exactly as
-above receives none of them.
-
-Route them in with {func}`logging.captureWarnings`, which sends them to the
-`py.warnings` logger at `WARNING`:
-
-```python
->>> import logging
->>> import warnings
->>> records = []
->>> class Capture(logging.Handler):
-...     def emit(self, record):
-...         records.append(record)
->>> handler = Capture()
->>> warnings_logger = logging.getLogger("py.warnings")
->>> warnings_logger.addHandler(handler)
-
-Without the bridge, nothing arrives:
-
->>> with warnings.catch_warnings(record=True):
-...     warnings.simplefilter("always")
-...     warnings.warn("a tmux flag was ignored", stacklevel=2)
->>> len(records)
-0
-
-With it, the advisory becomes a record:
-
->>> logging.captureWarnings(True)
->>> with warnings.catch_warnings():
-...     warnings.simplefilter("always")
-...     warnings.warn("a tmux flag was ignored", stacklevel=2)
->>> [(r.name, r.levelname) for r in records]
-[('py.warnings', 'WARNING')]
-
->>> logging.captureWarnings(False)
->>> warnings_logger.removeHandler(handler)
-```
-
-The two channels do not behave alike, and the difference bites. Python delivers
-a given warning **once per source location** by default, while a logger emits
-every call. An advisory you see once may have fired on every iteration, so treat
-a warning as "this happened at least once" rather than as a count.
-
-## The `extra` schema
-
-Every field is attached under `extra`, which makes it an attribute on the
-{class}`~logging.LogRecord`. Keys are `snake_case` and prefixed `tmux_`.
-Context and count fields are scalars; bounded stdout and stderr fields are
-lists of strings.
-
-### Context, on any record that knows it
-
-| Key | Type | Meaning |
-|---|---|---|
-| `tmux_cmd` | `str` | Rendered command line: shell-quoted, single-line, secrets redacted |
-| `tmux_subcommand` | `str` | tmux subcommand, e.g. `new-session` |
-| `tmux_socket` | `str` | Socket name or path identifying which tmux server |
-| `tmux_target` | `str` | tmux target the operation addressed |
-| `tmux_session` | `str` | Session name |
-| `tmux_window` | `str` | Window name or index |
-| `tmux_pane` | `str` | Pane identifier |
-| `tmux_option_key` | `str` | Option name, on `libtmux.options` warnings |
-| `tmux_option_skipped` | `int` | Entries libtmux could not parse under that option |
-| `tmux_fields_expected` | `int` | Fields a row of tmux output should have held |
-| `tmux_fields_received` | `int` | Fields it actually held |
-
-### Outcome, on completion and failure records
-
-| Key | Type | Meaning |
-|---|---|---|
-| `tmux_exit_code` | `int` | tmux process exit code |
-| `tmux_stdout` | `list[str]` | stdout lines, capped; empty for sensitive output commands |
-| `tmux_stderr` | `list[str]` | stderr lines, capped |
-| `tmux_stdout_len` | `int` | Total stdout line count before capping |
-| `tmux_stderr_len` | `int` | Total stderr line count before capping |
-
-A key is absent when libtmux does not know it, never present-and-`None`. So
-test with {func}`getattr` and a default, or {func}`hasattr`, rather than
-comparing to `None`.
-
-`tmux_socket` is what distinguishes servers when one process drives several.
-`tmux_exit_code` is not an error signal on its own: libtmux probes with
-`has-session`, which exits non-zero as its normal way of saying "no". Match on
-the `ERROR` level, not on a non-zero exit code.
-
-## Reading records in tests
-
-Assert on `caplog.records`, not on `caplog.text`. The structured fields are what
-you actually care about, and `caplog.record_tuples` cannot reach them at all.
-
-```python
->>> import logging
->>> caplog.clear()
->>> with caplog.at_level(logging.INFO, logger="libtmux.session"):
-...     window = session.new_window(window_name="deploy")
->>> record = next(
-...     r for r in caplog.records
-...     if getattr(r, "tmux_subcommand", None) == "new-window"
-... )
->>> record.getMessage()
-'window created'
->>> record.tmux_window
-'deploy'
-```
-
-Scope the capture to the logger you mean, and filter the records rather than
-indexing by position — libtmux may add records between the one you want and the
-end of the list:
-
-```python
->>> import logging
->>> caplog.clear()
->>> release = session.new_window(window_name="release")
+>>> marker = "caller-secret"
 >>> with caplog.at_level(logging.DEBUG, logger="libtmux.common"):
-...     release.rename_window("released")
-Window(@... ...:released, Session($... ...))
->>> completed = [
-...     r for r in caplog.records
-...     if r.getMessage() == "tmux command completed"
-...     and getattr(r, "tmux_subcommand", None) == "rename-window"
+...     proc = session.server.cmd("list-sessions", "-F", marker)
+>>> marker in proc.stdout
+True
+>>> command_records = [
+...     record for record in caplog.records
+...     if record.getMessage().startswith("tmux command")
 ... ]
->>> completed[0].tmux_exit_code
-0
+>>> dispatched, completed = command_records[-2:]
+>>> dispatched.tmux_subcommand
+'list-sessions'
+>>> dispatched.tmux_socket == session.server.socket_name
+True
+>>> dispatched.tmux_cmd.endswith("list-sessions <2 arguments omitted>")
+True
+>>> marker in dispatched.tmux_cmd
+False
+>>> completed.tmux_stdout_len == len(proc.stdout)
+True
+>>> hasattr(completed, "tmux_stdout") or hasattr(completed, "tmux_stderr")
+False
 ```
 
-## Formatting records safely
+The result object still returns stdout and stderr normally. Only the record
+omits their bodies.
 
-A format string that names a `tmux_` key will fail on records that do not carry
-it. {mod}`logging` catches the error, prints it to stderr, and **drops the
-record** — so a formatter written against `DEBUG` records silently loses your
-`INFO` ones.
+## Failures
 
-Give every custom key a default:
+libtmux does not log an error and then raise it. Propagated and translated
+failures remain exception data, so callers decide whether and where to log
+them. Expected probes such as {meth}`Server.is_alive()
+<libtmux.Server.is_alive>` also stay quiet.
+
+Three list-shaped accessors intentionally hide
+{exc}`~libtmux.exc.LibTmuxException`:
+
+- {attr}`Server.sessions <libtmux.Server.sessions>`;
+- {attr}`Server.attached_sessions <libtmux.Server.attached_sessions>`;
+- {attr}`Server.clients <libtmux.Server.clients>`.
+
+They return an empty collection and emit one `ERROR` record on
+`libtmux.server`. The record carries the subcommand, socket, and error line
+count, but not the error text. Use {meth}`Server.raise_if_dead()
+<libtmux.Server.raise_if_dead>` when an unreachable server must be loud.
+
+A non-zero exit code alone does not produce an `ERROR`; tmux also uses
+non-zero status to answer probes with “no.”
+
+## Structured fields
+
+Records contain only fields relevant to their event.
+
+| Field | Type | Meaning |
+| ----- | ---- | ------- |
+| `tmux_cmd` | `str` | executable/socket/subcommand summary |
+| `tmux_subcommand` | `str` | tmux subcommand |
+| `tmux_socket` | `str` | socket name or path |
+| `tmux_target` | `str` | target specifier |
+| `tmux_session` | `str` | session name |
+| `tmux_window` | `str` | window name or index |
+| `tmux_pane` | `str` | pane identifier |
+| `tmux_exit_code` | `int` | subprocess exit status |
+| `tmux_stdout_len` | `int` | stdout line count |
+| `tmux_stderr_len` | `int` | stderr or swallowed-error line count |
+| `tmux_option_key` | `str` | option whose entries could not be parsed |
+| `tmux_option_skipped` | `int` | entries skipped for that option |
+
+All identity fields are strings. Unknown identities are omitted rather than
+set to `None`.
+
+## Format records safely
+
+Not every record carries every field. A formatter that requires
+`%(tmux_cmd)s` drops lifecycle records unless it supplies a default. Python
+3.10 and later accept defaults directly:
 
 ```python
 >>> import logging
 >>> formatter = logging.Formatter(
-...     "%(levelname)s %(message)s cmd=%(tmux_cmd)s",
-...     defaults={"tmux_cmd": "-"},
+...     "%(levelname)s %(message)s subcommand=%(tmux_subcommand)s exit=%(tmux_exit_code)s",
+...     defaults={"tmux_subcommand": "-", "tmux_exit_code": "-"},
 ... )
 >>> record = logging.LogRecord(
-...     "libtmux.session", logging.INFO, "session.py", 1,
-...     "session created", None, None,
+...     "libtmux.server", logging.INFO, "server.py", 1,
+...     "session created", (), None,
 ... )
 >>> formatter.format(record)
-'INFO session created cmd=-'
+'INFO session created subcommand=- exit=-'
 ```
 
-`tmux_stdout` and `tmux_stderr` hold lists, and a `%s` renders a list as its
-Python repr rather than as lines. Join them yourself when you want them
-readable:
+Use the same defaulting rule in JSON formatters and telemetry exporters.
+
+## Assert on records in tests
+
+Use pytest's `caplog.records` so assertions read structured fields instead of
+rendered text:
 
 ```python
 >>> import logging
->>> record = logging.LogRecord(
-...     "libtmux.common", logging.DEBUG, "common.py", 1,
-...     "tmux command completed", None, None,
-... )
->>> record.tmux_stdout = ["line one", "line two"]
->>> logging.Formatter("%(message)s out=%(tmux_stdout)s").format(record)
-"tmux command completed out=['line one', 'line two']"
-```
-
-## What libtmux does not log
-
-Environment values passed through tmux's environment options never reach a log
-record. libtmux redacts them where the command line is turned into text, so the
-variable names stay visible for debugging while the values do not:
-
-```python
->>> import logging
->>> caplog.clear()
->>> with caplog.at_level(logging.DEBUG, logger="libtmux.common"):
-...     env_session = server.new_session(
-...         session_name="env-demo",
-...         environment={"API_TOKEN": "hunter2"},
-...     )
->>> dispatched = next(
-...     r for r in caplog.records
-...     if getattr(r, "tmux_subcommand", None) == "new-session"
-...     and r.getMessage() == "tmux command dispatched"
-... )
->>> "hunter2" in dispatched.tmux_cmd
-False
->>> "-eAPI_TOKEN=REDACTED" in dispatched.tmux_cmd
+>>> with caplog.at_level(logging.INFO, logger="libtmux.session"):
+...     logged_window = session.new_window(window_name="logged")
+>>> records = [
+...     record for record in caplog.records
+...     if getattr(record, "tmux_subcommand", None) == "new-window"
+... ]
+>>> len(records) >= 1
 True
->>> env_session.kill()
-```
-
-This covers `environment=` on {meth}`Server.new_session()
-<libtmux.Server.new_session>`, {meth}`Session.new_window()
-<libtmux.Session.new_window>`, and {meth}`Pane.split() <libtmux.Pane.split>`, as
-well as {meth}`set_environment()
-<libtmux.common.EnvironmentMixin.set_environment>`. Boolean options may be
-bundled before tmux's value-taking `-e`; those forms are redacted too.
-
-tmux hands those values straight back, and a value may span output lines.
-{meth}`getenv() <libtmux.common.EnvironmentMixin.getenv>` and
-{meth}`show_environment() <libtmux.common.EnvironmentMixin.show_environment>`
-keep their existing API results, but their records omit `tmux_stdout` content
-and retain `tmux_stdout_len`.
-
-```python
->>> import logging
->>> caplog.clear()
->>> server = session.server
->>> server.set_environment("DEPLOY_KEY", "hunter2")
->>> with caplog.at_level(logging.DEBUG, logger="libtmux.common"):
-...     server.getenv("DEPLOY_KEY")
-'hunter2'
->>> completed = next(
-...     r for r in caplog.records
-...     if r.getMessage() == "tmux command completed"
-... )
->>> completed.tmux_stdout
-[]
->>> completed.tmux_stdout_len
-1
-```
-
-Paste-buffer data follows the same body-versus-metadata boundary. The payload
-passed to {meth}`Server.set_buffer() <libtmux.Server.set_buffer>` is replaced
-with `REDACTED` in `tmux_cmd`, and buffer contents returned by tmux stay
-off the record.
-
-### What libtmux cannot redact
-
-libtmux hides what tmux's own grammar marks as an environment value. It cannot
-classify content you compose yourself:
-
-- **{meth}`Pane.send_keys() <libtmux.Pane.send_keys>` payloads.** What you type
-  into a pane appears in `tmux_cmd` at `DEBUG`.
-- **A `start_directory`, `window_command`, or shell command.**
-- **A format string that prints a variable**, such as
-  `display-message -p '#{q:DEPLOY_KEY}'`.
-
-The protected command names, their built-in aliases, tmux's relevant default
-`command-alias` entries, and policy-safe abbreviations are covered. A custom
-`command-alias` has server-specific grammar that libtmux cannot inspect on this
-path. An alias name that shares a protected command prefix is handled
-conservatively; any other custom alias remains unclassified.
-
-Only your application knows which of those carry secrets, so redacting them is
-its job — with a {class}`~logging.Filter` that rewrites the fields you care
-about.
-
-Placement matters more than the filter does. A filter on a logger runs only for
-records that logger made; {meth}`Logger.callHandlers()
-<logging.Logger.callHandlers>` walks to ancestor loggers for their *handlers*
-and never consults their filters. Since every record comes from a child such as
-`libtmux.common`, a filter on `logging.getLogger("libtmux")` never sees those
-records. Attach the redacting filter to a **handler**:
-
-```python
->>> import logging
->>> import re
-
->>> class RedactFilter(logging.Filter):
-...     def __init__(self, *patterns: str) -> None:
-...         super().__init__()
-...         self.patterns = [re.compile(p) for p in patterns]
-...
-...     def _redact(self, value: str | list[str]) -> str | list[str]:
-...         for pattern in self.patterns:
-...             if isinstance(value, str):
-...                 value = pattern.sub("REDACTED", value)
-...             else:
-...                 value = [pattern.sub("REDACTED", item) for item in value]
-...         return value
-...
-...     def filter(self, record: logging.LogRecord) -> bool:
-...         for field in ("tmux_cmd", "tmux_stdout", "tmux_stderr"):
-...             value = getattr(record, field, None)
-...             if isinstance(value, (str, list)):
-...                 setattr(record, field, self._redact(value))
-...         return True
-
->>> records = []
->>> class Capture(logging.Handler):
-...     def emit(self, record):
-...         records.append(record)
-
->>> handler = Capture()
->>> libtmux_logger = logging.getLogger("libtmux")
->>> previous_level = libtmux_logger.level
->>> libtmux_logger.addHandler(handler)
->>> libtmux_logger.setLevel(logging.DEBUG)
->>> pane = session.active_window.active_pane
->>> on_logger = RedactFilter("hunter2")
-
-On the logger, it never runs:
-
->>> libtmux_logger.addFilter(on_logger)
->>> pane.send_keys("login hunter2", enter=False)
->>> any("hunter2" in r.tmux_cmd for r in records if hasattr(r, "tmux_cmd"))
+>>> records[-1].tmux_socket == session.server.socket_name
 True
-
-On the handler, it does:
-
->>> libtmux_logger.removeFilter(on_logger)
->>> handler.addFilter(RedactFilter("hunter2"))
->>> records.clear()
->>> result = server.cmd("display-message", "-p", "login hunter2")
->>> result.stdout
-['login hunter2']
->>> any(
-...     "hunter2" in str(getattr(r, field, ""))
-...     for r in records
-...     for field in ("tmux_cmd", "tmux_stdout", "tmux_stderr")
-... )
-False
-
-Put the logger back as you found it — a level set on a shared logger outlives
-the code that set it:
-
->>> libtmux_logger.removeHandler(handler)
->>> libtmux_logger.setLevel(previous_level)
+>>> logged_window.kill()
 ```
 
-The command line also reaches the process table, so it is visible to `ps` for
-the same user regardless of logging. Logs differ in that they travel.
+Scope capture to the logger under test and filter by message or subcommand;
+fixture setup may have emitted earlier records.
 
-## Cost
+## Warnings are separate
 
-libtmux guards the expensive work — quoting the command line and slicing tmux's
-output — behind {meth}`Logger.isEnabledFor() <logging.Logger.isEnabledFor>`, so
-leaving `DEBUG` off costs a level comparison per command. Messages use lazy
-`%s` interpolation, which keeps a given event under one message template in an
-aggregator instead of producing a distinct string per occurrence.
-
-`DEBUG` is dominated by `tmux_cmd`, because libtmux queries tmux with large
-`-F` format templates and each command is recorded twice — once on dispatch,
-once on completion — so that either line stands on its own. If you want object
-lifecycle without that, leave `libtmux` at `DEBUG` and raise just the command
-logger:
+Deprecations, ignored arguments, and version advisories use
+{mod}`warnings`, not logging. Applications that need one stream can route
+them through the `py.warnings` logger:
 
 ```python
 >>> import logging
->>> command_logger = logging.getLogger("libtmux.common")
->>> previous_level = command_logger.level
->>> command_logger.setLevel(logging.INFO)
->>> command_logger.isEnabledFor(logging.DEBUG)
-False
->>> command_logger.setLevel(previous_level)
+>>> logging.captureWarnings(True)
+>>> logging.captureWarnings(False)
 ```
 
-At `DEBUG`, `tmux_stdout` and `tmux_stderr` are capped, and the untruncated
-counts stay available as `tmux_stdout_len` and `tmux_stderr_len`. A
-`list-panes` against a large server can still be a lot of text — prefer the
-`_len` fields when you only need volume.
+libtmux does not duplicate a warning as a log record.
 
-Commands that return content rather than control data — pane capture, buffer
-inspection, message history, prompt history, and environment inspection —
-report only `tmux_stdout_len`. The output may contain terminal text, commands,
-or multiline values, and the caller already has it as a return value. This is
-the same line HTTP clients draw when they log a status and a content length but
-never a response body.
+## Privacy and cost
 
-`tmux_cmd` is bounded too, at a practical rendered-character ceiling derived
-from tmux's transport limit, and a shortened one ends in an ellipsis. tmux
-counts transport bytes while log quoting expands some characters, so this cap
-deliberately does not claim to be the exact largest command tmux accepts.
+Command operands and process output bodies never enter libtmux records. Socket
+identities, executable paths, object names, and target specifiers do, because
+they identify the operation. Choose handler destinations and retention with
+that metadata in mind.
 
-## Threads and async
-
-libtmux adds no locking of its own and needs none. {mod}`logging` serialises
-handler output behind a lock, and libtmux never hands the same list or dict to
-two records, so concurrent tmux calls cannot interleave into one another's
-fields. Records name the server they came from through `tmux_socket`, which is
-what tells apart several servers driven at once.
-
-Blocking work belongs off the event loop, and a handler writing to a file or a
-socket is blocking work. The standard answer is
-{class}`~logging.handlers.QueueHandler` with a
-{class}`~logging.handlers.QueueListener`, and every `tmux_` field survives that
-round trip — including through a {mod}`multiprocessing` queue, since records
-pickle cleanly.
-
-One trap comes with it. `QueueHandler` runs **its own formatter** when it
-enqueues, so a format string there that names a field some records lack drops
-those records *before they reach the queue* — the listener's handlers never see
-them. Leave the `QueueHandler` unformatted and format in the listener, or give
-it the same `defaults` as any other formatter.
-
-```python
->>> import logging
->>> import logging.handlers
->>> import queue
->>> log_queue: queue.Queue[logging.LogRecord] = queue.Queue()
->>> handler = logging.handlers.QueueHandler(log_queue)
->>> handler.formatter is None
-True
->>> handler.close()
-```
-
-An `asyncio` task name does not follow work into
-{func}`asyncio.to_thread`, so records made there carry no `taskName`. Bind your
-own identifier if you need to correlate tmux calls back to a task.
-
-## Recipes
-
-### Structured JSON output
-
-Emit one JSON object per record, promoting the tmux fields to top level:
-
-```python
->>> import json
->>> import logging
->>> class TmuxJsonFormatter(logging.Formatter):
-...     def format(self, record: logging.LogRecord) -> str:
-...         payload = {
-...             "level": record.levelname,
-...             "logger": record.name,
-...             "message": record.getMessage(),
-...         }
-...         payload.update(
-...             {k: v for k, v in record.__dict__.items() if k.startswith("tmux_")}
-...         )
-...         return json.dumps(payload)
->>> record = logging.LogRecord(
-...     "libtmux.server", logging.INFO, "server.py", 1,
-...     "session created", None, None,
-... )
->>> record.tmux_socket = "demo"
->>> TmuxJsonFormatter().format(record)
-'{"level": "INFO", "logger": "libtmux.server", "message": "session created", "tmux_socket": "demo"}'
-```
-
-### Route one server's records somewhere else
-
-`tmux_socket` identifies the server, so a {class}`~logging.Filter` can split a
-multi-server application's logs. Attach it to the handler, for the reason
-[above](#what-libtmux-cannot-redact):
-
-```python
->>> import logging
->>> class SocketFilter(logging.Filter):
-...     def __init__(self, socket: str) -> None:
-...         super().__init__()
-...         self.socket = socket
-...
-...     def filter(self, record: logging.LogRecord) -> bool:
-...         return getattr(record, "tmux_socket", None) == self.socket
->>> record = logging.LogRecord(
-...     "libtmux.server", logging.INFO, "server.py", 1,
-...     "session created", None, None,
-... )
->>> record.tmux_socket = "deploy"
->>> SocketFilter("deploy").filter(record)
-True
->>> SocketFilter("staging").filter(record)
-False
-```
-
-### Attach records to an OpenTelemetry span
-
-The scalar `tmux_` keys map onto span attributes without transformation. The
-bounded stdout and stderr lists are intentionally left out of this compact
-recipe:
-
-```python
->>> import logging
->>> class Span:
-...     def __init__(self) -> None:
-...         self.attributes = {}
-...
-...     def set_attribute(self, key, value) -> None:
-...         self.attributes[key] = value
->>> def annotate(span, record: logging.LogRecord) -> None:
-...     for key, value in record.__dict__.items():
-...         if key.startswith("tmux_") and isinstance(value, (str, int)):
-...             span.set_attribute(key, value)
->>> span = Span()
->>> record = logging.LogRecord(
-...     "libtmux.common", logging.DEBUG, "common.py", 1,
-...     "tmux command completed", None, None,
-... )
->>> record.tmux_socket = "deploy"
->>> record.tmux_exit_code = 0
->>> annotate(span, record)
->>> span.attributes
-{'tmux_socket': 'deploy', 'tmux_exit_code': 0}
-```
+When `DEBUG` is disabled, command-context construction is skipped. With it
+enabled, records contain scalars and counts only; their size does not grow with
+command payloads or terminal output. libtmux keeps no shared logging state, so
+threads and async callers rely on the standard library's logging guarantees.

--- a/docs/topics/logging.md
+++ b/docs/topics/logging.md
@@ -7,9 +7,9 @@ does not install handlers or choose a level. Configure the `libtmux` logger in
 your application; `INFO` reports object lifecycle events, while `DEBUG` adds
 tmux subprocess boundaries.
 
-Command records identify the operation without retaining its operands, stdout,
-or stderr. This keeps shell commands, keystrokes, environment values, buffer
-contents, and pane contents out of logs by default.
+Command records include the complete tmux command. Completion records also
+include bounded stdout and stderr snapshots. Applications choose which fields
+reach each destination through standard-library handlers and formatters.
 
 ## Enable records
 
@@ -59,14 +59,14 @@ Each tmux subprocess can produce two `DEBUG` records:
 - `tmux command dispatched` before execution;
 - `tmux command completed` after execution.
 
-Both carry a safe `tmux_cmd` summary. It contains the executable, effective
-socket selector, subcommand, and the number of operands omitted after the
-subcommand. The completion record adds the exit code and stdout/stderr line
-counts.
+Both carry `tmux_cmd`, a one-line rendering of the complete argv. Printable
+values use shell quoting; control characters use escaped representations. The
+completion record adds the exit code, the first 100 stdout and stderr lines,
+and the total line counts.
 
 ```python
 >>> import logging
->>> marker = "caller-secret"
+>>> marker = "caller-payload"
 >>> with caplog.at_level(logging.DEBUG, logger="libtmux.common"):
 ...     proc = session.server.cmd("list-sessions", "-F", marker)
 >>> marker in proc.stdout
@@ -80,18 +80,23 @@ True
 'list-sessions'
 >>> dispatched.tmux_socket == session.server.socket_name
 True
->>> dispatched.tmux_cmd.endswith("list-sessions <2 arguments omitted>")
+>>> dispatched.tmux_cmd.endswith("list-sessions -F caller-payload")
 True
 >>> marker in dispatched.tmux_cmd
-False
+True
+>>> completed.tmux_stdout == proc.stdout
+True
+>>> completed.tmux_stderr == proc.stderr
+True
 >>> completed.tmux_stdout_len == len(proc.stdout)
 True
->>> hasattr(completed, "tmux_stdout") or hasattr(completed, "tmux_stderr")
-False
 ```
 
-The result object still returns stdout and stderr normally. Only the record
-omits their bodies.
+The result object retains every output line. The completion record snapshots
+at most 100 lines from each stream and reports the full lengths separately.
+`tmux_subcommand` and `tmux_socket` are best-effort conveniences. An unknown
+global option leaves uncertain derived fields absent; `tmux_cmd` remains
+complete.
 
 ## Failures
 
@@ -108,8 +113,8 @@ Three list-shaped accessors intentionally hide
 - {attr}`Server.clients <libtmux.Server.clients>`.
 
 They return an empty collection and emit one `ERROR` record on
-`libtmux.server`. The record carries the subcommand, socket, and error line
-count, but not the error text. Use {meth}`Server.raise_if_dead()
+`libtmux.server`. The record carries the subcommand, socket, the first 100 lines
+of exception text, and the total line count. Use {meth}`Server.raise_if_dead()
 <libtmux.Server.raise_if_dead>` when an unreachable server must be loud.
 
 A non-zero exit code alone does not produce an `ERROR`; tmux also uses
@@ -121,7 +126,7 @@ Records contain only fields relevant to their event.
 
 | Field | Type | Meaning |
 | ----- | ---- | ------- |
-| `tmux_cmd` | `str` | executable/socket/subcommand summary |
+| `tmux_cmd` | `str` | quoted, one-line complete command |
 | `tmux_subcommand` | `str` | tmux subcommand |
 | `tmux_socket` | `str` | socket name or path |
 | `tmux_target` | `str` | target specifier |
@@ -129,6 +134,8 @@ Records contain only fields relevant to their event.
 | `tmux_window` | `str` | window name or index |
 | `tmux_pane` | `str` | pane identifier |
 | `tmux_exit_code` | `int` | subprocess exit status |
+| `tmux_stdout` | `list[str]` | first 100 stdout lines |
+| `tmux_stderr` | `list[str]` | first 100 stderr lines |
 | `tmux_stdout_len` | `int` | stdout line count |
 | `tmux_stderr_len` | `int` | stderr or swallowed-error line count |
 | `tmux_option_key` | `str` | option whose entries could not be parsed |
@@ -137,7 +144,7 @@ Records contain only fields relevant to their event.
 All identity fields are strings. Unknown identities are omitted rather than
 set to `None`.
 
-## Format records safely
+## Format records
 
 Not every record carries every field. A formatter that requires
 `%(tmux_cmd)s` drops lifecycle records unless it supplies a default. Python
@@ -158,6 +165,49 @@ Not every record carries every field. A formatter that requires
 ```
 
 Use the same defaulting rule in JSON formatters and telemetry exporters.
+
+### Select fields at the handler
+
+A handler's filter chooses its records, and its formatter chooses the fields
+written to that destination. This Python 3.10-compatible example retains the
+payload fields on each record but writes only event names and bounded metadata:
+
+```python
+>>> import io
+>>> import logging
+>>> stream = io.StringIO()
+>>> handler = logging.StreamHandler(stream)
+>>> handler.addFilter(
+...     lambda record: getattr(record, "tmux_subcommand", None) == "display-message"
+... )
+>>> handler.setFormatter(logging.Formatter(
+...     "%(levelname)s %(message)s subcommand=%(tmux_subcommand)s "
+...     "stdout_lines=%(tmux_stdout_len)s",
+...     defaults={"tmux_subcommand": "-", "tmux_stdout_len": "-"},
+... ))
+>>> command_logger = logging.getLogger("libtmux.common")
+>>> previous_level = command_logger.level
+>>> command_logger.setLevel(logging.DEBUG)
+>>> command_logger.addHandler(handler)
+>>> proc = session.server.cmd("display-message", "-p", "payload-marker")
+>>> _ = session.server.cmd("list-sessions")  # filtered from this handler
+>>> command_logger.removeHandler(handler)
+>>> command_logger.setLevel(previous_level)
+>>> handler.close()
+>>> "payload-marker" in proc.stdout
+True
+>>> "payload-marker" in stream.getvalue()
+False
+>>> "list-sessions" in stream.getvalue()
+False
+>>> stream.getvalue().count("tmux command")
+2
+```
+
+The standard library documents handler-level
+[filters](https://docs.python.org/3/library/logging.html#filter-objects).
+Its [Logging Cookbook](https://docs.python.org/3/howto/logging-cookbook.html)
+covers contextual fields, routing, handlers, and custom formatting.
 
 ## Assert on records in tests
 
@@ -196,14 +246,16 @@ them through the `py.warnings` logger:
 
 libtmux does not duplicate a warning as a log record.
 
-## Privacy and cost
+## Payload size and application policy
 
-Command operands and process output bodies never enter libtmux records. Socket
-identities, executable paths, object names, and target specifiers do, because
-they identify the operation. Choose handler destinations and retention with
-that metadata in mind.
+`DEBUG` records contain caller-provided command operands and output lines.
+Choose handler destinations, formatting, and retention for the data your
+application sends through tmux. libtmux does not redact command or output
+payloads; use a handler formatter such as the example above when a destination
+needs metadata only.
 
 When `DEBUG` is disabled, command-context construction is skipped. With it
-enabled, records contain scalars and counts only; their size does not grow with
-command payloads or terminal output. libtmux keeps no shared logging state, so
-threads and async callers rely on the standard library's logging guarantees.
+enabled, `tmux_cmd` grows with argv, and each completion record retains up to
+100 lines from each stream. Individual lines are not truncated. libtmux keeps
+no shared logging state, so threads and async callers rely on the standard
+library's logging guarantees.

--- a/docs/topics/logging.md
+++ b/docs/topics/logging.md
@@ -12,6 +12,10 @@ libtmux never configures logging for you. It attaches a
 {class}`~logging.NullHandler` and nothing else, so a library import stays silent
 until your application asks for output.
 
+Most readers need only the next two sections: turn it on, and read a failure.
+The field schema and the testing and formatting sections below are for when you
+route these records somewhere — a test assertion, a log aggregator, a trace.
+
 ## Turn it on
 
 The shortest thing that works — lifecycle events, no tmux command noise:
@@ -70,6 +74,7 @@ configure as one unit:
 | `libtmux.pane` | Pane split, floating pane creation, pane kill |
 | `libtmux.options` | Option values tmux returned that libtmux could not parse |
 | `libtmux.hooks` | Hook lines tmux returned that libtmux could not parse |
+| `libtmux._internal.control_mode` | The `tmux -C` client used by the test fixtures |
 
 Silence the command chatter while keeping lifecycle events:
 
@@ -114,6 +119,27 @@ apart without changing your code:
 Polling with {meth}`Server.is_alive() <libtmux.Server.is_alive>` stays quiet, so
 a health check loop does not fill your logs with errors.
 
+A failure record is attributed to the libtmux method that ran the command, not
+to the helper that raised. So `%(filename)s:%(lineno)d` in a format string —
+and `code.filepath` in OpenTelemetry — point at the operation you called:
+
+```python
+>>> import logging
+>>> caplog.clear()
+>>> from libtmux import exc
+>>> with caplog.at_level(logging.ERROR, logger="libtmux.common"):
+...     try:
+...         session.kill_window(target_window="no_such_window")
+...     except exc.LibTmuxException:
+...         pass
+>>> caplog.records[-1].funcName
+'kill_window'
+```
+
+An option whose value libtmux cannot parse warns once for that option, with
+`tmux_option_skipped` counting the entries it dropped, rather than once per
+entry.
+
 ## The `extra` schema
 
 Every field is attached under `extra`, which makes it an attribute on the
@@ -132,6 +158,7 @@ scalars.
 | `tmux_window` | `str` | Window name or index |
 | `tmux_pane` | `str` | Pane identifier |
 | `tmux_option_key` | `str` | Option name, on `libtmux.options` warnings |
+| `tmux_option_skipped` | `int` | Entries libtmux could not parse under that option |
 
 ### Outcome, on completion and failure records
 
@@ -158,6 +185,7 @@ Assert on `caplog.records`, not on `caplog.text`. The structured fields are what
 you actually care about, and `caplog.record_tuples` cannot reach them at all.
 
 ```python
+>>> import logging
 >>> caplog.clear()
 >>> with caplog.at_level(logging.INFO, logger="libtmux.session"):
 ...     window = session.new_window(window_name="deploy")
@@ -176,9 +204,12 @@ indexing by position — libtmux may add records between the one you want and th
 end of the list:
 
 ```python
+>>> import logging
 >>> caplog.clear()
+>>> release = session.new_window(window_name="release")
 >>> with caplog.at_level(logging.DEBUG, logger="libtmux.common"):
-...     _ = window.rename_window("release")
+...     release.rename_window("released")
+Window(@... ...:released, Session($... ...))
 >>> completed = [
 ...     r for r in caplog.records
 ...     if r.getMessage() == "tmux command completed"
@@ -186,7 +217,6 @@ end of the list:
 ... ]
 >>> completed[0].tmux_exit_code
 0
->>> window.kill()
 ```
 
 ## Formatting records safely
@@ -199,6 +229,7 @@ record** — so a formatter written against `DEBUG` records silently loses your
 Give every custom key a default:
 
 ```python
+>>> import logging
 >>> formatter = logging.Formatter(
 ...     "%(levelname)s %(message)s cmd=%(tmux_cmd)s",
 ...     defaults={"tmux_cmd": "-"},
@@ -218,6 +249,7 @@ command line is turned into text, so the variable names stay visible for
 debugging while the values do not:
 
 ```python
+>>> import logging
 >>> caplog.clear()
 >>> with caplog.at_level(logging.DEBUG, logger="libtmux.common"):
 ...     env_session = server.new_session(

--- a/docs/topics/logging.md
+++ b/docs/topics/logging.md
@@ -261,6 +261,21 @@ Give every custom key a default:
 'INFO session created cmd=-'
 ```
 
+`tmux_stdout` and `tmux_stderr` hold lists, and a `%s` renders a list as its
+Python repr rather than as lines. Join them yourself when you want them
+readable:
+
+```python
+>>> import logging
+>>> record = logging.LogRecord(
+...     "libtmux.common", logging.DEBUG, "common.py", 1,
+...     "tmux command completed", None, None,
+... )
+>>> record.tmux_stdout = ["line one", "line two"]
+>>> logging.Formatter("%(message)s out=%(tmux_stdout)s").format(record)
+"tmux command completed out=['line one', 'line two']"
+```
+
 ## What libtmux does not log
 
 Environment values never reach a log record. libtmux redacts them where the

--- a/docs/topics/logging.md
+++ b/docs/topics/logging.md
@@ -1,0 +1,319 @@
+(logging)=
+
+# Logging
+
+libtmux narrates itself through the standard {mod}`logging` module. Every tmux
+command it runs, and every object it creates, renames, or kills, becomes a log
+record — with the tmux context attached as structured fields rather than baked
+into the message text. That means you filter on `tmux_session == "deploy"`
+instead of running a regular expression over prose.
+
+libtmux never configures logging for you. It attaches a
+{class}`~logging.NullHandler` and nothing else, so a library import stays silent
+until your application asks for output.
+
+## Turn it on
+
+The shortest thing that works — lifecycle events, no tmux command noise:
+
+```python
+import logging
+
+logging.basicConfig(level=logging.INFO)
+```
+
+To see the tmux commands themselves, including their output, drop only libtmux
+to `DEBUG` and leave the rest of your application alone:
+
+```python
+logging.getLogger("libtmux").setLevel(logging.DEBUG)
+```
+
+## Diagnosing a failure
+
+When libtmux is not doing what you expect, this shows every tmux command it
+runs, the exit code, and whatever tmux wrote back:
+
+```python
+import logging
+
+logging.basicConfig(
+    level=logging.DEBUG,
+    format="%(levelname)s %(name)s %(message)s | %(tmux_cmd)s -> %(tmux_exit_code)s",
+)
+```
+
+That format string names two keys that not every record carries, so pair it
+with defaults or you will lose records — see
+[Formatting records safely](#formatting-records-safely). The version that will
+not drop anything:
+
+```python
+logging.basicConfig(level=logging.DEBUG)
+```
+
+Then read `tmux_cmd` off the record and run it yourself. It is shell-quoted, so
+it pastes into a terminal as-is and reproduces what libtmux did — including the
+`-L` or `-S` flag that selects the right server.
+
+## Where records come from
+
+Loggers are named after their module, so the package name is a prefix you can
+configure as one unit:
+
+| Logger | Emits |
+|---|---|
+| `libtmux.common` | Every tmux command: dispatch, completion, failure |
+| `libtmux.server` | Server and session lifecycle |
+| `libtmux.session` | Window lifecycle, session rename and kill |
+| `libtmux.window` | Window rename and kill |
+| `libtmux.pane` | Pane split, floating pane creation, pane kill |
+| `libtmux.options` | Option values tmux returned that libtmux could not parse |
+| `libtmux.hooks` | Hook lines tmux returned that libtmux could not parse |
+
+Silence the command chatter while keeping lifecycle events:
+
+```python
+logging.getLogger("libtmux.common").setLevel(logging.INFO)
+```
+
+## What each level gives you
+
+| Level | You get |
+|---|---|
+| `ERROR` | A tmux command libtmux treated as a failure, and subprocess errors |
+| `WARNING` | Option and hook output libtmux could not parse |
+| `INFO` | Object lifecycle: created, renamed, killed |
+| `DEBUG` | Every tmux command line, exit code, stdout, and stderr |
+
+`ERROR` records are worth wiring up even if you catch libtmux's exceptions,
+because libtmux's list accessors deliberately swallow tmux errors. {attr}`Server.sessions
+<libtmux.Server.sessions>` returns an empty {class}`~libtmux._internal.query_list.QueryList`
+when tmux is unreachable, which is otherwise indistinguishable from a server
+that genuinely has no sessions. The `ERROR` record is how you tell those two
+apart without changing your code:
+
+```python
+>>> import logging
+>>> from libtmux.server import Server
+>>> unreachable = Server(socket_name="no-such-socket")
+>>> caplog.clear()
+>>> with caplog.at_level(logging.ERROR, logger="libtmux.common"):
+...     sessions = unreachable.sessions
+>>> sessions
+[]
+>>> record = caplog.records[-1]
+>>> record.getMessage()
+'tmux command failed'
+>>> record.tmux_subcommand
+'list-sessions'
+>>> record.tmux_socket
+'no-such-socket'
+```
+
+Polling with {meth}`Server.is_alive() <libtmux.Server.is_alive>` stays quiet, so
+a health check loop does not fill your logs with errors.
+
+## The `extra` schema
+
+Every field is attached under `extra`, which makes it an attribute on the
+{class}`~logging.LogRecord`. Keys are `snake_case`, prefixed `tmux_`, and hold
+scalars.
+
+### Context, on any record that knows it
+
+| Key | Type | Meaning |
+|---|---|---|
+| `tmux_cmd` | `str` | Full command line, shell-quoted, secrets redacted |
+| `tmux_subcommand` | `str` | tmux subcommand, e.g. `new-session` |
+| `tmux_socket` | `str` | Socket name or path identifying which tmux server |
+| `tmux_target` | `str` | tmux target the operation addressed |
+| `tmux_session` | `str` | Session name |
+| `tmux_window` | `str` | Window name or index |
+| `tmux_pane` | `str` | Pane identifier |
+| `tmux_option_key` | `str` | Option name, on `libtmux.options` warnings |
+
+### Outcome, on completion and failure records
+
+| Key | Type | Meaning |
+|---|---|---|
+| `tmux_exit_code` | `int` | tmux process exit code |
+| `tmux_stdout` | `list[str]` | stdout lines, capped |
+| `tmux_stderr` | `list[str]` | stderr lines, capped |
+| `tmux_stdout_len` | `int` | Total stdout line count before capping |
+| `tmux_stderr_len` | `int` | Total stderr line count before capping |
+
+A key is absent when libtmux does not know it, never present-and-`None`. So
+test with {func}`getattr` and a default, or {func}`hasattr`, rather than
+comparing to `None`.
+
+`tmux_socket` is what distinguishes servers when one process drives several.
+`tmux_exit_code` is not an error signal on its own: libtmux probes with
+`has-session`, which exits non-zero as its normal way of saying "no". Match on
+the `ERROR` level, not on a non-zero exit code.
+
+## Reading records in tests
+
+Assert on `caplog.records`, not on `caplog.text`. The structured fields are what
+you actually care about, and `caplog.record_tuples` cannot reach them at all.
+
+```python
+>>> caplog.clear()
+>>> with caplog.at_level(logging.INFO, logger="libtmux.session"):
+...     window = session.new_window(window_name="deploy")
+>>> record = next(
+...     r for r in caplog.records
+...     if getattr(r, "tmux_subcommand", None) == "new-window"
+... )
+>>> record.getMessage()
+'window created'
+>>> record.tmux_window
+'deploy'
+```
+
+Scope the capture to the logger you mean, and filter the records rather than
+indexing by position — libtmux may add records between the one you want and the
+end of the list:
+
+```python
+>>> caplog.clear()
+>>> with caplog.at_level(logging.DEBUG, logger="libtmux.common"):
+...     _ = window.rename_window("release")
+>>> completed = [
+...     r for r in caplog.records
+...     if r.getMessage() == "tmux command completed"
+...     and getattr(r, "tmux_subcommand", None) == "rename-window"
+... ]
+>>> completed[0].tmux_exit_code
+0
+>>> window.kill()
+```
+
+## Formatting records safely
+
+A format string that names a `tmux_` key will fail on records that do not carry
+it. {mod}`logging` catches the error, prints it to stderr, and **drops the
+record** — so a formatter written against `DEBUG` records silently loses your
+`INFO` ones.
+
+Give every custom key a default:
+
+```python
+>>> formatter = logging.Formatter(
+...     "%(levelname)s %(message)s cmd=%(tmux_cmd)s",
+...     defaults={"tmux_cmd": "-"},
+... )
+>>> record = logging.LogRecord(
+...     "libtmux.session", logging.INFO, "session.py", 1,
+...     "session created", None, None,
+... )
+>>> formatter.format(record)
+'INFO session created cmd=-'
+```
+
+## What libtmux does not log
+
+Environment values never reach a log record. libtmux redacts them where the
+command line is turned into text, so the variable names stay visible for
+debugging while the values do not:
+
+```python
+>>> caplog.clear()
+>>> with caplog.at_level(logging.DEBUG, logger="libtmux.common"):
+...     env_session = server.new_session(
+...         session_name="env-demo",
+...         environment={"API_TOKEN": "hunter2"},
+...     )
+>>> dispatched = next(
+...     r for r in caplog.records
+...     if getattr(r, "tmux_subcommand", None) == "new-session"
+...     and r.getMessage() == "tmux command dispatched"
+... )
+>>> "hunter2" in dispatched.tmux_cmd
+False
+>>> "-eAPI_TOKEN=REDACTED" in dispatched.tmux_cmd
+True
+>>> env_session.kill()
+```
+
+This covers `environment=` on {meth}`Server.new_session()
+<libtmux.Server.new_session>`, {meth}`Session.new_window()
+<libtmux.Session.new_window>`, and {meth}`Pane.split() <libtmux.Pane.split>`, as
+well as {meth}`set_environment()
+<libtmux.common.EnvironmentMixin.set_environment>`.
+
+Two things libtmux cannot redact for you, because it cannot tell a secret from a
+keystroke:
+
+- **{meth}`Pane.send_keys() <libtmux.Pane.send_keys>` payloads.** What you type
+  into a pane appears verbatim in `tmux_cmd` at `DEBUG`. If you send
+  credentials, do not ship `DEBUG` records off the host.
+- **Anything you pass as a `start_directory`, `window_command`, or shell
+  command**, for the same reason.
+
+The command line also reaches the process table, so it is visible to `ps` for
+the same user regardless of logging. Logs differ in that they travel.
+
+## Cost
+
+libtmux guards the expensive work — quoting the command line and slicing tmux's
+output — behind {meth}`Logger.isEnabledFor() <logging.Logger.isEnabledFor>`, so
+leaving `DEBUG` off costs a level comparison per command. Messages use lazy
+`%s` interpolation, which keeps a given event under one message template in an
+aggregator instead of producing a distinct string per occurrence.
+
+At `DEBUG`, `tmux_stdout` and `tmux_stderr` are capped, and the untruncated
+counts stay available as `tmux_stdout_len` and `tmux_stderr_len`. A
+`list-panes` against a large server can still be a lot of text — prefer the
+`_len` fields when you only need volume.
+
+## Recipes
+
+### Structured JSON output
+
+Emit one JSON object per record, promoting the tmux fields to top level:
+
+```python
+import json
+import logging
+
+
+class TmuxJsonFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        payload = {
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+        payload.update(
+            {k: v for k, v in record.__dict__.items() if k.startswith("tmux_")}
+        )
+        return json.dumps(payload)
+```
+
+### Route one server's records somewhere else
+
+`tmux_socket` identifies the server, so a {class}`~logging.Filter` can split a
+multi-server application's logs:
+
+```python
+class SocketFilter(logging.Filter):
+    def __init__(self, socket: str) -> None:
+        super().__init__()
+        self.socket = socket
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        return getattr(record, "tmux_socket", None) == self.socket
+```
+
+### Attach records to an OpenTelemetry span
+
+The `tmux_` keys map onto span attributes without transformation, since they are
+already flat scalars:
+
+```python
+def annotate(span, record: logging.LogRecord) -> None:
+    for key, value in record.__dict__.items():
+        if key.startswith("tmux_") and isinstance(value, (str, int)):
+            span.set_attribute(key, value)
+```

--- a/docs/topics/logging.md
+++ b/docs/topics/logging.md
@@ -185,6 +185,7 @@ scalars.
 | `tmux_exit_code` | `int` | tmux process exit code |
 | `tmux_stdout` | `list[str]` | stdout lines, capped |
 | `tmux_stderr` | `list[str]` | stderr lines, capped |
+| `tmux_cmd_len` | `int` | Command-line length before capping |
 | `tmux_stdout_len` | `int` | Total stdout line count before capping |
 | `tmux_stderr_len` | `int` | Total stderr line count before capping |
 
@@ -316,6 +317,11 @@ At `DEBUG`, `tmux_stdout` and `tmux_stderr` are capped, and the untruncated
 counts stay available as `tmux_stdout_len` and `tmux_stderr_len`. A
 `list-panes` against a large server can still be a lot of text — prefer the
 `_len` fields when you only need volume.
+
+`tmux_cmd` is capped too, at the largest command tmux itself will accept. So a
+command tmux ran is always reproducible from its record, and only a command
+tmux refused as too long arrives shortened, with `tmux_cmd_len` reporting what
+the caller actually passed.
 
 ## Recipes
 

--- a/docs/topics/logging.md
+++ b/docs/topics/logging.md
@@ -186,7 +186,7 @@ scalars.
 | Key | Type | Meaning |
 |---|---|---|
 | `tmux_exit_code` | `int` | tmux process exit code |
-| `tmux_stdout` | `list[str]` | stdout lines, capped |
+| `tmux_stdout` | `list[str]` | stdout lines, capped; empty for content commands |
 | `tmux_stderr` | `list[str]` | stderr lines, capped |
 | `tmux_cmd_len` | `int` | Command-line length before capping |
 | `tmux_stdout_len` | `int` | Total stdout line count before capping |
@@ -413,6 +413,12 @@ At `DEBUG`, `tmux_stdout` and `tmux_stderr` are capped, and the untruncated
 counts stay available as `tmux_stdout_len` and `tmux_stderr_len`. A
 `list-panes` against a large server can still be a lot of text — prefer the
 `_len` fields when you only need volume.
+
+Commands that return content rather than control data — `capture-pane`,
+`show-buffer`, `list-buffers` — report only `tmux_stdout_len`. Their output is
+whatever happened to be on a screen or in a paste buffer, it can be large, and
+the caller already has it as a return value. This is the same line HTTP clients
+draw when they log a status and a content length but never a response body.
 
 `tmux_cmd` is capped too, at the size of the largest command tmux itself will
 run. Quoting expands what it measures — a single quote becomes five characters

--- a/docs/topics/logging.md
+++ b/docs/topics/logging.md
@@ -21,49 +21,65 @@ route these records somewhere — a test assertion, a log aggregator, a trace.
 The shortest thing that works — lifecycle events, no tmux command noise:
 
 ```python
-import logging
-
-logging.basicConfig(level=logging.INFO)
+>>> import logging
+>>> logging.basicConfig(level=logging.INFO)
 ```
 
 To see the tmux commands themselves, including their output, drop only libtmux
 to `DEBUG` and leave the rest of your application alone:
 
 ```python
-logging.getLogger("libtmux").setLevel(logging.DEBUG)
+>>> import logging
+>>> libtmux_logger = logging.getLogger("libtmux")
+>>> previous_level = libtmux_logger.level
+>>> libtmux_logger.setLevel(logging.DEBUG)
+>>> libtmux_logger.getEffectiveLevel() == logging.DEBUG
+True
+>>> libtmux_logger.setLevel(previous_level)
 ```
 
 ## Diagnosing a failure
 
 When libtmux is not doing what you expect, this shows every tmux command it
-runs, the exit code, and whatever tmux wrote back:
+runs, the exit code, and whatever tmux wrote back. It installs a real handler
+with safe defaults for records that carry no command outcome. The final three
+lines restore the shared documentation process; keep the handler installed in
+your application:
 
 ```python
-import logging
-
-logging.basicConfig(
-    level=logging.DEBUG,
-    format="%(levelname)s %(name)s %(message)s | %(tmux_cmd)s -> %(tmux_exit_code)s",
-)
+>>> import logging
+>>> handler = logging.StreamHandler()
+>>> formatter = logging.Formatter(
+...     "%(levelname)s %(name)s %(message)s | %(tmux_cmd)s -> %(tmux_exit_code)s",
+...     defaults={"tmux_cmd": "-", "tmux_exit_code": "-"},
+... )
+>>> handler.setFormatter(formatter)
+>>> libtmux_logger = logging.getLogger("libtmux")
+>>> previous_level = libtmux_logger.level
+>>> libtmux_logger.addHandler(handler)
+>>> libtmux_logger.setLevel(logging.DEBUG)
+>>> record = logging.LogRecord(
+...     "libtmux.common", logging.DEBUG, "common.py", 1,
+...     "tmux command completed", None, None,
+... )
+>>> record.tmux_cmd = "tmux -Ldemo list-sessions"
+>>> record.tmux_exit_code = 0
+>>> formatter.format(record)
+'DEBUG libtmux.common tmux command completed | tmux -Ldemo list-sessions -> 0'
+>>> libtmux_logger.removeHandler(handler)
+>>> handler.close()
+>>> libtmux_logger.setLevel(previous_level)
 ```
 
-That format string names two keys that not every record carries, so pair it
-with defaults or you will lose records — see
-[Formatting records safely](#formatting-records-safely). The version that will
-not drop anything:
+Then read `tmux_cmd` off the record. It is shell-quoted and includes the
+`-L` or `-S` flag that selects the right server. It reproduces the command
+unless libtmux replaced sensitive content with `REDACTED` or shortened an
+oversized rendering.
 
-```python
-logging.basicConfig(level=logging.DEBUG)
-```
-
-Then read `tmux_cmd` off the record and run it yourself. It is shell-quoted, so
-it pastes into `bash` or `zsh` as-is and reproduces what libtmux did — including
-the `-L` or `-S` flag that selects the right server.
-
-An argument holding control characters appears in `$'…'` form, which those
-shells expand back to the original bytes. That keeps a record on one line even
-when a caller sends a multi-line payload, so nothing in a command line can pose
-as a log record of its own:
+An argument holding control characters appears in `$'…'` form. Shell escapes
+keep the rendering familiar and pasteable for ordinary tmux arguments without
+placing a literal line boundary in the record, so nothing in a command line can
+pose as a log record of its own:
 
 ```python
 >>> import logging
@@ -101,7 +117,13 @@ configure as one unit:
 Silence the command chatter while keeping lifecycle events:
 
 ```python
-logging.getLogger("libtmux.common").setLevel(logging.INFO)
+>>> import logging
+>>> command_logger = logging.getLogger("libtmux.common")
+>>> previous_level = command_logger.level
+>>> command_logger.setLevel(logging.INFO)
+>>> command_logger.isEnabledFor(logging.DEBUG)
+False
+>>> command_logger.setLevel(previous_level)
 ```
 
 ## What each level gives you
@@ -219,14 +241,15 @@ a warning as "this happened at least once" rather than as a count.
 ## The `extra` schema
 
 Every field is attached under `extra`, which makes it an attribute on the
-{class}`~logging.LogRecord`. Keys are `snake_case`, prefixed `tmux_`, and hold
-scalars.
+{class}`~logging.LogRecord`. Keys are `snake_case` and prefixed `tmux_`.
+Context and count fields are scalars; bounded stdout and stderr fields are
+lists of strings.
 
 ### Context, on any record that knows it
 
 | Key | Type | Meaning |
 |---|---|---|
-| `tmux_cmd` | `str` | Full command line: shell-quoted, single-line, secrets redacted |
+| `tmux_cmd` | `str` | Rendered command line: shell-quoted, single-line, secrets redacted |
 | `tmux_subcommand` | `str` | tmux subcommand, e.g. `new-session` |
 | `tmux_socket` | `str` | Socket name or path identifying which tmux server |
 | `tmux_target` | `str` | tmux target the operation addressed |
@@ -236,14 +259,14 @@ scalars.
 | `tmux_option_key` | `str` | Option name, on `libtmux.options` warnings |
 | `tmux_option_skipped` | `int` | Entries libtmux could not parse under that option |
 | `tmux_fields_expected` | `int` | Fields a row of tmux output should have held |
-| `tmux_fields_received` | `int` | Fields it actually held
+| `tmux_fields_received` | `int` | Fields it actually held |
 
 ### Outcome, on completion and failure records
 
 | Key | Type | Meaning |
 |---|---|---|
 | `tmux_exit_code` | `int` | tmux process exit code |
-| `tmux_stdout` | `list[str]` | stdout lines, capped; empty for content commands |
+| `tmux_stdout` | `list[str]` | stdout lines, capped; empty for sensitive output commands |
 | `tmux_stderr` | `list[str]` | stderr lines, capped |
 | `tmux_stdout_len` | `int` | Total stdout line count before capping |
 | `tmux_stderr_len` | `int` | Total stderr line count before capping |
@@ -337,9 +360,9 @@ readable:
 
 ## What libtmux does not log
 
-Environment values never reach a log record. libtmux redacts them where the
-command line is turned into text, so the variable names stay visible for
-debugging while the values do not:
+Environment values passed through tmux's environment options never reach a log
+record. libtmux redacts them where the command line is turned into text, so the
+variable names stay visible for debugging while the values do not:
 
 ```python
 >>> import logging
@@ -367,10 +390,11 @@ This covers `environment=` on {meth}`Server.new_session()
 well as {meth}`set_environment()
 <libtmux.common.EnvironmentMixin.set_environment>`.
 
-tmux hands those values straight back, so the output side is covered too:
+tmux hands those values straight back, and a value may span output lines.
 {meth}`getenv() <libtmux.common.EnvironmentMixin.getenv>` and
 {meth}`show_environment() <libtmux.common.EnvironmentMixin.show_environment>`
-return what you asked for while their records show only the names.
+keep their existing API results, but their records omit `tmux_stdout` content
+and retain `tmux_stdout_len`.
 
 ```python
 >>> import logging
@@ -384,9 +408,16 @@ return what you asked for while their records show only the names.
 ...     r for r in caplog.records
 ...     if r.getMessage() == "tmux command completed"
 ... )
->>> any("hunter2" in line for line in completed.tmux_stdout)
-False
+>>> completed.tmux_stdout
+[]
+>>> completed.tmux_stdout_len
+1
 ```
+
+Paste-buffer data follows the same body-versus-metadata boundary. The payload
+passed to {meth}`Server.set_buffer() <libtmux.Server.set_buffer>` is replaced
+with `REDACTED` in `tmux_cmd`, and buffer contents returned by tmux stay
+off the record.
 
 ### What libtmux cannot redact
 
@@ -398,6 +429,11 @@ classify content you compose yourself:
 - **A `start_directory`, `window_command`, or shell command.**
 - **A format string that prints a variable**, such as
   `display-message -p '#{q:DEPLOY_KEY}'`.
+
+The built-in names, aliases, and command abbreviations are covered. A command
+defined in `command-alias` has server-specific grammar that libtmux cannot
+inspect on this path. An alias name that shares a protected command prefix is
+handled conservatively; any other custom alias remains unclassified.
 
 Only your application knows which of those carry secrets, so redacting them is
 its job — with a {class}`~logging.Filter` that rewrites the fields you care
@@ -419,10 +455,19 @@ nothing, and says nothing about it. Attach it to a **handler**:
 ...         super().__init__()
 ...         self.patterns = [re.compile(p) for p in patterns]
 ...
-...     def filter(self, record: logging.LogRecord) -> bool:
+...     def _redact(self, value: str | list[str]) -> str | list[str]:
 ...         for pattern in self.patterns:
-...             if isinstance(getattr(record, "tmux_cmd", None), str):
-...                 record.tmux_cmd = pattern.sub("REDACTED", record.tmux_cmd)
+...             if isinstance(value, str):
+...                 value = pattern.sub("REDACTED", value)
+...             else:
+...                 value = [pattern.sub("REDACTED", item) for item in value]
+...         return value
+...
+...     def filter(self, record: logging.LogRecord) -> bool:
+...         for field in ("tmux_cmd", "tmux_stdout", "tmux_stderr"):
+...             value = getattr(record, field, None)
+...             if isinstance(value, (str, list)):
+...                 setattr(record, field, self._redact(value))
 ...         return True
 
 >>> records = []
@@ -450,8 +495,14 @@ On the handler, it does:
 >>> libtmux_logger.removeFilter(on_logger)
 >>> handler.addFilter(RedactFilter("hunter2"))
 >>> records.clear()
->>> pane.send_keys("login hunter2", enter=False)
->>> any("hunter2" in r.tmux_cmd for r in records if hasattr(r, "tmux_cmd"))
+>>> result = server.cmd("display-message", "-p", "login hunter2")
+>>> result.stdout
+['login hunter2']
+>>> any(
+...     "hunter2" in str(getattr(r, field, ""))
+...     for r in records
+...     for field in ("tmux_cmd", "tmux_stdout", "tmux_stderr")
+... )
 False
 
 Put the logger back as you found it — a level set on a shared logger outlives
@@ -479,7 +530,13 @@ lifecycle without that, leave `libtmux` at `DEBUG` and raise just the command
 logger:
 
 ```python
-logging.getLogger("libtmux.common").setLevel(logging.INFO)
+>>> import logging
+>>> command_logger = logging.getLogger("libtmux.common")
+>>> previous_level = command_logger.level
+>>> command_logger.setLevel(logging.INFO)
+>>> command_logger.isEnabledFor(logging.DEBUG)
+False
+>>> command_logger.setLevel(previous_level)
 ```
 
 At `DEBUG`, `tmux_stdout` and `tmux_stderr` are capped, and the untruncated
@@ -487,16 +544,17 @@ counts stay available as `tmux_stdout_len` and `tmux_stderr_len`. A
 `list-panes` against a large server can still be a lot of text — prefer the
 `_len` fields when you only need volume.
 
-Commands that return content rather than control data — `capture-pane`,
-`show-buffer`, `list-buffers` — report only `tmux_stdout_len`. Their output is
-whatever happened to be on a screen or in a paste buffer, it can be large, and
-the caller already has it as a return value. This is the same line HTTP clients
-draw when they log a status and a content length but never a response body.
+Commands that return content rather than control data — pane capture, buffer
+inspection, message history, prompt history, and environment inspection —
+report only `tmux_stdout_len`. The output may contain terminal text, commands,
+or multiline values, and the caller already has it as a return value. This is
+the same line HTTP clients draw when they log a status and a content length but
+never a response body.
 
-`tmux_cmd` is capped too, at the size of the largest command tmux itself will
-run, and a shortened one ends in an ellipsis. Quoting expands what the cap
-measures — a single quote becomes five characters — so a command built almost
-entirely of quotes can be one tmux accepts whose record still shortens.
+`tmux_cmd` is bounded too, at a practical rendered-character ceiling derived
+from tmux's transport limit, and a shortened one ends in an ellipsis. tmux
+counts transport bytes while log quoting expands some characters, so this cap
+deliberately does not claim to be the exact largest command tmux accepts.
 
 ## Threads and async
 
@@ -520,11 +578,14 @@ them. Leave the `QueueHandler` unformatted and format in the listener, or give
 it the same `defaults` as any other formatter.
 
 ```python
-import logging.handlers
-import queue
-
-log_queue: queue.Queue = queue.Queue()
-handler = logging.handlers.QueueHandler(log_queue)  # no formatter here
+>>> import logging
+>>> import logging.handlers
+>>> import queue
+>>> log_queue: queue.Queue[logging.LogRecord] = queue.Queue()
+>>> handler = logging.handlers.QueueHandler(log_queue)
+>>> handler.formatter is None
+True
+>>> handler.close()
 ```
 
 An `asyncio` task name does not follow work into
@@ -538,21 +599,26 @@ own identifier if you need to correlate tmux calls back to a task.
 Emit one JSON object per record, promoting the tmux fields to top level:
 
 ```python
-import json
-import logging
-
-
-class TmuxJsonFormatter(logging.Formatter):
-    def format(self, record: logging.LogRecord) -> str:
-        payload = {
-            "level": record.levelname,
-            "logger": record.name,
-            "message": record.getMessage(),
-        }
-        payload.update(
-            {k: v for k, v in record.__dict__.items() if k.startswith("tmux_")}
-        )
-        return json.dumps(payload)
+>>> import json
+>>> import logging
+>>> class TmuxJsonFormatter(logging.Formatter):
+...     def format(self, record: logging.LogRecord) -> str:
+...         payload = {
+...             "level": record.levelname,
+...             "logger": record.name,
+...             "message": record.getMessage(),
+...         }
+...         payload.update(
+...             {k: v for k, v in record.__dict__.items() if k.startswith("tmux_")}
+...         )
+...         return json.dumps(payload)
+>>> record = logging.LogRecord(
+...     "libtmux.server", logging.INFO, "server.py", 1,
+...     "session created", None, None,
+... )
+>>> record.tmux_socket = "demo"
+>>> TmuxJsonFormatter().format(record)
+'{"level": "INFO", "logger": "libtmux.server", "message": "session created", "tmux_socket": "demo"}'
 ```
 
 ### Route one server's records somewhere else
@@ -562,23 +628,51 @@ multi-server application's logs. Attach it to the handler, for the reason
 [above](#what-libtmux-cannot-redact):
 
 ```python
-class SocketFilter(logging.Filter):
-    def __init__(self, socket: str) -> None:
-        super().__init__()
-        self.socket = socket
-
-    def filter(self, record: logging.LogRecord) -> bool:
-        return getattr(record, "tmux_socket", None) == self.socket
+>>> import logging
+>>> class SocketFilter(logging.Filter):
+...     def __init__(self, socket: str) -> None:
+...         super().__init__()
+...         self.socket = socket
+...
+...     def filter(self, record: logging.LogRecord) -> bool:
+...         return getattr(record, "tmux_socket", None) == self.socket
+>>> record = logging.LogRecord(
+...     "libtmux.server", logging.INFO, "server.py", 1,
+...     "session created", None, None,
+... )
+>>> record.tmux_socket = "deploy"
+>>> SocketFilter("deploy").filter(record)
+True
+>>> SocketFilter("staging").filter(record)
+False
 ```
 
 ### Attach records to an OpenTelemetry span
 
-The `tmux_` keys map onto span attributes without transformation, since they are
-already flat scalars:
+The scalar `tmux_` keys map onto span attributes without transformation. The
+bounded stdout and stderr lists are intentionally left out of this compact
+recipe:
 
 ```python
-def annotate(span, record: logging.LogRecord) -> None:
-    for key, value in record.__dict__.items():
-        if key.startswith("tmux_") and isinstance(value, (str, int)):
-            span.set_attribute(key, value)
+>>> import logging
+>>> class Span:
+...     def __init__(self) -> None:
+...         self.attributes = {}
+...
+...     def set_attribute(self, key, value) -> None:
+...         self.attributes[key] = value
+>>> def annotate(span, record: logging.LogRecord) -> None:
+...     for key, value in record.__dict__.items():
+...         if key.startswith("tmux_") and isinstance(value, (str, int)):
+...             span.set_attribute(key, value)
+>>> span = Span()
+>>> record = logging.LogRecord(
+...     "libtmux.common", logging.DEBUG, "common.py", 1,
+...     "tmux command completed", None, None,
+... )
+>>> record.tmux_socket = "deploy"
+>>> record.tmux_exit_code = 0
+>>> annotate(span, record)
+>>> span.attributes
+{'tmux_socket': 'deploy', 'tmux_exit_code': 0}
 ```

--- a/docs/topics/logging.md
+++ b/docs/topics/logging.md
@@ -57,8 +57,26 @@ logging.basicConfig(level=logging.DEBUG)
 ```
 
 Then read `tmux_cmd` off the record and run it yourself. It is shell-quoted, so
-it pastes into a terminal as-is and reproduces what libtmux did — including the
-`-L` or `-S` flag that selects the right server.
+it pastes into `bash` or `zsh` as-is and reproduces what libtmux did — including
+the `-L` or `-S` flag that selects the right server.
+
+An argument holding control characters appears in `$'…'` form, which those
+shells expand back to the original bytes. That keeps a record on one line even
+when a caller sends a multi-line payload, so nothing in a command line can pose
+as a log record of its own:
+
+```python
+>>> import logging
+>>> caplog.clear()
+>>> pane = session.active_window.active_pane
+>>> with caplog.at_level(logging.DEBUG, logger="libtmux.common"):
+...     pane.send_keys("echo one\necho two", enter=False)
+>>> record = caplog.records[0]
+>>> "\n" in record.tmux_cmd
+False
+>>> record.tmux_cmd.endswith("$'echo one\\necho two'")
+True
+```
 
 ## Where records come from
 
@@ -150,7 +168,7 @@ scalars.
 
 | Key | Type | Meaning |
 |---|---|---|
-| `tmux_cmd` | `str` | Full command line, shell-quoted, secrets redacted |
+| `tmux_cmd` | `str` | Full command line: shell-quoted, single-line, secrets redacted |
 | `tmux_subcommand` | `str` | tmux subcommand, e.g. `new-session` |
 | `tmux_socket` | `str` | Socket name or path identifying which tmux server |
 | `tmux_target` | `str` | tmux target the operation addressed |

--- a/docs/topics/logging.md
+++ b/docs/topics/logging.md
@@ -409,6 +409,16 @@ leaving `DEBUG` off costs a level comparison per command. Messages use lazy
 `%s` interpolation, which keeps a given event under one message template in an
 aggregator instead of producing a distinct string per occurrence.
 
+`DEBUG` is dominated by `tmux_cmd`, because libtmux queries tmux with large
+`-F` format templates and each command is recorded twice — once on dispatch,
+once on completion — so that either line stands on its own. If you want object
+lifecycle without that, leave `libtmux` at `DEBUG` and raise just the command
+logger:
+
+```python
+logging.getLogger("libtmux.common").setLevel(logging.INFO)
+```
+
 At `DEBUG`, `tmux_stdout` and `tmux_stderr` are capped, and the untruncated
 counts stay available as `tmux_stdout_len` and `tmux_stderr_len`. A
 `list-panes` against a large server can still be a lot of text — prefer the

--- a/docs/topics/logging.md
+++ b/docs/topics/logging.md
@@ -105,13 +105,15 @@ failures remain exception data, so callers decide whether and where to log
 them. Expected probes such as {meth}`Server.is_alive()
 <libtmux.Server.is_alive>` also stay quiet.
 
-Executable launch failures use {exc}`~libtmux.exc.TmuxCommandNotFound`.
-When the operating system attempted the launch, the exception retains its
-message and cause. A failed `PATH` lookup has a factual message without a
-synthetic cause.
+Missing, non-executable, and malformed tmux executables use
+{exc}`~libtmux.exc.TmuxCommandNotFound`. When the operating system attempted
+the launch, the exception retains its message and cause. A failed `PATH`
+lookup has a factual message without a synthetic cause. Other operating-system
+launch errors remain native exceptions at direct APIs.
 
-Three list-shaped accessors intentionally hide
-{exc}`~libtmux.exc.LibTmuxException`:
+Three list-shaped accessors intentionally hide tmux execution failures,
+including {exc}`~libtmux.exc.LibTmuxException` and operating-system launch
+errors:
 
 - {attr}`Server.sessions <libtmux.Server.sessions>`;
 - {attr}`Server.attached_sessions <libtmux.Server.attached_sessions>`;

--- a/docs/topics/logging.md
+++ b/docs/topics/logging.md
@@ -71,7 +71,10 @@ as a log record of its own:
 >>> pane = session.active_window.active_pane
 >>> with caplog.at_level(logging.DEBUG, logger="libtmux.common"):
 ...     pane.send_keys("echo one\necho two", enter=False)
->>> record = caplog.records[0]
+>>> record = next(
+...     r for r in caplog.records
+...     if getattr(r, "tmux_subcommand", None) == "send-keys"
+... )
 >>> "\n" in record.tmux_cmd
 False
 >>> record.tmux_cmd.endswith("$'echo one\\necho two'")
@@ -333,10 +336,11 @@ counts stay available as `tmux_stdout_len` and `tmux_stderr_len`. A
 `list-panes` against a large server can still be a lot of text — prefer the
 `_len` fields when you only need volume.
 
-`tmux_cmd` is capped too, at the largest command tmux itself will accept. So a
-command tmux ran is always reproducible from its record, and only a command
-tmux refused as too long arrives shortened, with `tmux_cmd_len` reporting what
-the caller actually passed.
+`tmux_cmd` is capped too, at the size of the largest command tmux itself will
+run. Quoting expands what it measures — a single quote becomes five characters
+— so a command built almost entirely of quotes can be one tmux accepts and the
+record still shortens. Compare `tmux_cmd_len` against the string you got to
+know: they differ only when the record was shortened.
 
 ## Recipes
 

--- a/docs/topics/logging.md
+++ b/docs/topics/logging.md
@@ -245,7 +245,6 @@ scalars.
 | `tmux_exit_code` | `int` | tmux process exit code |
 | `tmux_stdout` | `list[str]` | stdout lines, capped; empty for content commands |
 | `tmux_stderr` | `list[str]` | stderr lines, capped |
-| `tmux_cmd_len` | `int` | Command-line length before capping |
 | `tmux_stdout_len` | `int` | Total stdout line count before capping |
 | `tmux_stderr_len` | `int` | Total stderr line count before capping |
 
@@ -495,10 +494,42 @@ the caller already has it as a return value. This is the same line HTTP clients
 draw when they log a status and a content length but never a response body.
 
 `tmux_cmd` is capped too, at the size of the largest command tmux itself will
-run. Quoting expands what it measures — a single quote becomes five characters
-— so a command built almost entirely of quotes can be one tmux accepts and the
-record still shortens. Compare `tmux_cmd_len` against the string you got to
-know: they differ only when the record was shortened.
+run, and a shortened one ends in an ellipsis. Quoting expands what the cap
+measures — a single quote becomes five characters — so a command built almost
+entirely of quotes can be one tmux accepts whose record still shortens.
+
+## Threads and async
+
+libtmux adds no locking of its own and needs none. {mod}`logging` serialises
+handler output behind a lock, and libtmux never hands the same list or dict to
+two records, so concurrent tmux calls cannot interleave into one another's
+fields. Records name the server they came from through `tmux_socket`, which is
+what tells apart several servers driven at once.
+
+Blocking work belongs off the event loop, and a handler writing to a file or a
+socket is blocking work. The standard answer is
+{class}`~logging.handlers.QueueHandler` with a
+{class}`~logging.handlers.QueueListener`, and every `tmux_` field survives that
+round trip — including through a {mod}`multiprocessing` queue, since records
+pickle cleanly.
+
+One trap comes with it. `QueueHandler` runs **its own formatter** when it
+enqueues, so a format string there that names a field some records lack drops
+those records *before they reach the queue* — the listener's handlers never see
+them. Leave the `QueueHandler` unformatted and format in the listener, or give
+it the same `defaults` as any other formatter.
+
+```python
+import logging.handlers
+import queue
+
+log_queue: queue.Queue = queue.Queue()
+handler = logging.handlers.QueueHandler(log_queue)  # no formatter here
+```
+
+An `asyncio` task name does not follow work into
+{func}`asyncio.to_thread`, so records made there carry no `taskName`. Bind your
+own identifier if you need to correlate tmux calls back to a task.
 
 ## Recipes
 

--- a/docs/topics/logging.md
+++ b/docs/topics/logging.md
@@ -105,6 +105,11 @@ failures remain exception data, so callers decide whether and where to log
 them. Expected probes such as {meth}`Server.is_alive()
 <libtmux.Server.is_alive>` also stay quiet.
 
+Executable launch failures use {exc}`~libtmux.exc.TmuxCommandNotFound`.
+When the operating system attempted the launch, the exception retains its
+message and cause. A failed `PATH` lookup has a factual message without a
+synthetic cause.
+
 Three list-shaped accessors intentionally hide
 {exc}`~libtmux.exc.LibTmuxException`:
 

--- a/docs/topics/logging.md
+++ b/docs/topics/logging.md
@@ -95,6 +95,7 @@ configure as one unit:
 | `libtmux.pane` | Pane split, floating pane creation, pane kill |
 | `libtmux.options` | Option values tmux returned that libtmux could not parse |
 | `libtmux.hooks` | Hook lines tmux returned that libtmux could not parse |
+| `libtmux.neo` | Rows of tmux output libtmux could not parse |
 | `libtmux._internal.control_mode` | The `tmux -C` client used by the test fixtures |
 
 Silence the command chatter while keeping lifecycle events:
@@ -161,6 +162,13 @@ An option whose value libtmux cannot parse warns once for that option, with
 `tmux_option_skipped` counting the entries it dropped, rather than once per
 entry.
 
+Not every failure comes from tmux. When libtmux cannot parse a row tmux returned
+successfully, the exception mentions only the parsing primitive that raised, so
+an `ERROR` record on `libtmux.neo` carries what the exception cannot: the
+subcommand, and how many fields the row held against how many it should have.
+A count one higher than expected means a value contained the character libtmux
+splits rows on.
+
 ## The `extra` schema
 
 Every field is attached under `extra`, which makes it an attribute on the
@@ -180,6 +188,8 @@ scalars.
 | `tmux_pane` | `str` | Pane identifier |
 | `tmux_option_key` | `str` | Option name, on `libtmux.options` warnings |
 | `tmux_option_skipped` | `int` | Entries libtmux could not parse under that option |
+| `tmux_fields_expected` | `int` | Fields a row of tmux output should have held |
+| `tmux_fields_received` | `int` | Fields it actually held
 
 ### Outcome, on completion and failure records
 

--- a/docs/topics/logging.md
+++ b/docs/topics/logging.md
@@ -16,6 +16,15 @@ Most readers need only the next two sections: turn it on, and read a failure.
 The field schema and the testing and formatting sections below are for when you
 route these records somewhere — a test assertion, a log aggregator, a trace.
 
+## Running the examples
+
+Every Python block in this topic executes in the documentation test suite. The
+standard-library-only blocks paste directly into a Python shell. Blocks using
+`caplog`, `server`, or `session` run in pytest: request those fixtures in a test
+function, then paste the block's statements into its body. `caplog` comes from
+pytest; `server` and `session` come from libtmux's pytest plugin. Any `pane` or
+`window` used below is derived inside its block or from `session`.
+
 ## Turn it on
 
 The shortest thing that works — lifecycle events, no tmux command noise:
@@ -160,8 +169,9 @@ apart without changing your code:
 'no-such-socket'
 ```
 
-Polling with {meth}`Server.is_alive() <libtmux.Server.is_alive>` stays quiet, so
-a health check loop does not fill your logs with errors.
+Polling with {meth}`Server.is_alive() <libtmux.Server.is_alive>` stays quiet,
+including when the configured tmux executable is missing or unusable, so a
+health check loop does not fill your logs with errors.
 
 A failure record is attributed to the libtmux method that ran the command, not
 to the helper that raised. So `%(filename)s:%(lineno)d` in a format string —
@@ -388,7 +398,8 @@ This covers `environment=` on {meth}`Server.new_session()
 <libtmux.Server.new_session>`, {meth}`Session.new_window()
 <libtmux.Session.new_window>`, and {meth}`Pane.split() <libtmux.Pane.split>`, as
 well as {meth}`set_environment()
-<libtmux.common.EnvironmentMixin.set_environment>`.
+<libtmux.common.EnvironmentMixin.set_environment>`. Boolean options may be
+bundled before tmux's value-taking `-e`; those forms are redacted too.
 
 tmux hands those values straight back, and a value may span output lines.
 {meth}`getenv() <libtmux.common.EnvironmentMixin.getenv>` and
@@ -430,10 +441,11 @@ classify content you compose yourself:
 - **A format string that prints a variable**, such as
   `display-message -p '#{q:DEPLOY_KEY}'`.
 
-The built-in names, aliases, and command abbreviations are covered. A command
-defined in `command-alias` has server-specific grammar that libtmux cannot
-inspect on this path. An alias name that shares a protected command prefix is
-handled conservatively; any other custom alias remains unclassified.
+The protected command names, their built-in aliases, tmux's relevant default
+`command-alias` entries, and policy-safe abbreviations are covered. A custom
+`command-alias` has server-specific grammar that libtmux cannot inspect on this
+path. An alias name that shares a protected command prefix is handled
+conservatively; any other custom alias remains unclassified.
 
 Only your application knows which of those carry secrets, so redacting them is
 its job — with a {class}`~logging.Filter` that rewrites the fields you care
@@ -443,8 +455,8 @@ Placement matters more than the filter does. A filter on a logger runs only for
 records that logger made; {meth}`Logger.callHandlers()
 <logging.Logger.callHandlers>` walks to ancestor loggers for their *handlers*
 and never consults their filters. Since every record comes from a child such as
-`libtmux.common`, attaching one to `logging.getLogger("libtmux")` protects
-nothing, and says nothing about it. Attach it to a **handler**:
+`libtmux.common`, a filter on `logging.getLogger("libtmux")` never sees those
+records. Attach the redacting filter to a **handler**:
 
 ```python
 >>> import logging

--- a/docs/topics/logging.md
+++ b/docs/topics/logging.md
@@ -3,9 +3,9 @@
 # Logging
 
 libtmux emits structured records through Python's {mod}`logging` module. It
-does not install handlers or choose a level. Configure the `libtmux` logger in
-your application; `INFO` reports object lifecycle events, while `DEBUG` adds
-tmux subprocess boundaries.
+does not install an output handler or choose a level. Configure the `libtmux`
+logger in your application; `INFO` reports object lifecycle events, while
+`DEBUG` adds tmux subprocess boundaries.
 
 Command records include the complete tmux command. Completion records also
 include bounded stdout and stderr snapshots. Applications choose which fields
@@ -192,13 +192,14 @@ payload fields on each record but writes only event names and bounded metadata:
 ...     "stdout_lines=%(tmux_stdout_len)s",
 ...     defaults={"tmux_subcommand": "-", "tmux_stdout_len": "-"},
 ... ))
+>>> package_logger = logging.getLogger("libtmux")
 >>> command_logger = logging.getLogger("libtmux.common")
 >>> previous_level = command_logger.level
 >>> command_logger.setLevel(logging.DEBUG)
->>> command_logger.addHandler(handler)
+>>> package_logger.addHandler(handler)
 >>> proc = session.server.cmd("display-message", "-p", "payload-marker")
 >>> _ = session.server.cmd("list-sessions")  # filtered from this handler
->>> command_logger.removeHandler(handler)
+>>> package_logger.removeHandler(handler)
 >>> command_logger.setLevel(previous_level)
 >>> handler.close()
 >>> "payload-marker" in proc.stdout

--- a/docs/topics/logging.md
+++ b/docs/topics/logging.md
@@ -169,6 +169,53 @@ subcommand, and how many fields the row held against how many it should have.
 A count one higher than expected means a value contained the character libtmux
 splits rows on.
 
+## What does not come through logging
+
+libtmux raises about as many advisories through {mod}`warnings` as it logs — a
+deprecated method, a flag your tmux is too old for, an argument being ignored.
+Those never reach a logging handler, so an application configured exactly as
+above receives none of them.
+
+Route them in with {func}`logging.captureWarnings`, which sends them to the
+`py.warnings` logger at `WARNING`:
+
+```python
+>>> import logging
+>>> import warnings
+>>> records = []
+>>> class Capture(logging.Handler):
+...     def emit(self, record):
+...         records.append(record)
+>>> handler = Capture()
+>>> warnings_logger = logging.getLogger("py.warnings")
+>>> warnings_logger.addHandler(handler)
+
+Without the bridge, nothing arrives:
+
+>>> with warnings.catch_warnings(record=True):
+...     warnings.simplefilter("always")
+...     warnings.warn("a tmux flag was ignored", stacklevel=2)
+>>> len(records)
+0
+
+With it, the advisory becomes a record:
+
+>>> logging.captureWarnings(True)
+>>> with warnings.catch_warnings():
+...     warnings.simplefilter("always")
+...     warnings.warn("a tmux flag was ignored", stacklevel=2)
+>>> [(r.name, r.levelname) for r in records]
+[('py.warnings', 'WARNING')]
+
+>>> logging.captureWarnings(False)
+>>> warnings_logger.removeHandler(handler)
+```
+
+The two channels do not behave alike, and the difference bites. Python delivers
+a given warning **once per source location** by default, while a logger emits
+every call. An advisory you see once may have fired on every iteration, so treat
+a warning as "this happened at least once" rather than as a count.
+
 ## The `extra` schema
 
 Every field is attached under `extra`, which makes it an attribute on the

--- a/src/libtmux/AGENTS.md
+++ b/src/libtmux/AGENTS.md
@@ -43,17 +43,13 @@ for loud failure rather than changing an existing accessor's contract.
 ### Command records
 
 `tmux_cmd` emits `DEBUG` before and after a subprocess. The
-`tmux_cmd` field contains only:
-
-- executable;
-- effective `-L` socket name or `-S` socket path;
-- subcommand;
-- the number of operands omitted after the subcommand.
-
-Never add command operands, stdout, or stderr bodies to records. Keep
-`tmux_stdout_len` and `tmux_stderr_len` on completion records.
-This omission is the privacy boundary: do not add command-specific
-redaction tables, alias maps, or output classifiers.
+`tmux_cmd` field contains a quoted, one-line rendering of the complete argv.
+Printable values use shell quoting; control characters use escaped forms.
+Completion records retain the first 100 stdout and stderr lines alongside
+`tmux_stdout_len` and `tmux_stderr_len`. Keep command-specific redaction,
+alias maps, and output classifiers out of the producer; applications select
+fields through standard-library handlers and formatters. Treat derived
+subcommand and socket fields as best effort and stop parsing unknown options.
 
 Guard command-context construction with
 `logger.isEnabledFor(logging.DEBUG)`. Use lazy interpolation for any
@@ -77,7 +73,7 @@ an `ERROR` because probes use it to answer false.
 `libtmux.server` when they convert `LibTmuxException` to an empty
 result. `Server.attached_sessions` inherits that behavior through
 `Server.sessions`. The boundary record includes the subcommand,
-socket, and stderr line count, not stderr text.
+socket, first 100 stderr lines, and total stderr line count.
 
 Deprecations and ignored arguments use `warnings.warn`, not a second
 log record. Applications can route them through
@@ -90,7 +86,7 @@ context.
 
 | Field | Type | Meaning |
 | ----- | ---- | ------- |
-| `tmux_cmd` | `str` | Safe operation summary |
+| `tmux_cmd` | `str` | Quoted, one-line complete command |
 | `tmux_subcommand` | `str` | tmux subcommand |
 | `tmux_socket` | `str` | Socket name or path |
 | `tmux_target` | `str` | Target specifier |
@@ -98,13 +94,16 @@ context.
 | `tmux_window` | `str` | Window name or index |
 | `tmux_pane` | `str` | Pane identifier |
 | `tmux_exit_code` | `int` | Subprocess exit status |
+| `tmux_stdout` | `list[str]` | First 100 stdout lines |
+| `tmux_stderr` | `list[str]` | First 100 stderr lines |
 | `tmux_stdout_len` | `int` | stdout line count |
 | `tmux_stderr_len` | `int` | stderr or error line count |
 | `tmux_option_key` | `str` | Option whose entries could not be parsed |
 | `tmux_option_skipped` | `int` | Entries skipped for that option |
 
 Treat field names and types as compatibility-sensitive. Omit unknown
-values instead of storing `None`. Keep context scalar.
+values instead of storing `None`. Keep identity and count fields scalar;
+stdout and stderr snapshots are lists of lines.
 
 ### Messages and tests
 

--- a/src/libtmux/AGENTS.md
+++ b/src/libtmux/AGENTS.md
@@ -45,6 +45,45 @@ conform.
 - Add `NullHandler` in library `__init__.py` files.
 - Never configure handlers, levels, or formatters in library code —
   that's the application's job.
+- Define a logger only in modules that log; an unused one is dead
+  code.
+
+### Where the schema is built
+
+`_internal/log_context.py` owns both producers. Reuse them instead of
+hand-rolling an `extra` dict:
+
+- `describe_command(argv)` derives `tmux_cmd`, `tmux_subcommand`, and
+  `tmux_socket` from a tmux command line, redacting environment values.
+  It parses tmux's global flags per the `getopt` string in tmux's
+  `tmux.c`; a flag that takes a value must never be read as the
+  subcommand.
+- `object_extra(subcommand, ...)` builds lifecycle records, enforcing
+  that every value is a `str` and an unknown key is omitted rather than
+  set to `None`.
+
+`tmux_cmd` carries the command line for every command record, so no
+other layer should log one — a second producer means two shapes under
+one key.
+
+Redaction is two-directional. `describe_command()` covers what libtmux
+sends and `redact_output()` covers what tmux returns; a subcommand that
+carries a secret one way almost always carries it back the other.
+`redact_output()` also decides control data from content: a subcommand
+returning screen or buffer contents reports `tmux_stdout_len` and
+nothing else, since the caller already holds the value and the log
+would only duplicate it at size. Neither can classify content a caller
+composed — `send_keys` payloads, shell commands, format queries — so
+that boundary is documented rather than guessed at.
+
+A `logging.Filter` belongs on a handler. `Logger.callHandlers()` walks
+ancestor loggers for their handlers and never consults their filters,
+so a filter on `libtmux` never sees a record from `libtmux.common`. It
+quotes control characters into shell `$'…'` form: a caller controls
+much of what reaches a command line, and a raw newline there would let
+the tail of an argument pose as its own record. Object names need no
+such guard — tmux rejects control characters in them before libtmux
+logs anything.
 
 ### Structured context via `extra`
 
@@ -63,6 +102,8 @@ searching, or test assertions.
 | `tmux_window` | `str` | window name or index |
 | `tmux_pane` | `str` | pane identifier |
 | `tmux_option_key` | `str` | tmux option name |
+| `tmux_option_skipped` | `int` | entries skipped under one option |
+| `tmux_socket` | `str` | socket name or path identifying the tmux server |
 
 **Heavy/optional keys** (DEBUG only, potentially large):
 
@@ -115,7 +156,7 @@ with the portable pattern (override `process()` to merge);
 |-------|---------|----------|
 | `DEBUG` | Internal mechanics, tmux I/O | tmux command + stdout, format queries |
 | `INFO` | Object lifecycle, user-visible operations | Session created, window added |
-| `WARNING` | Recoverable issues, deprecation | Deprecated method, missing optional program |
+| `WARNING` | Recoverable issues libtmux resolved itself | Output it could not parse, a client it had to kill |
 | `ERROR` | Failures that stop an operation | tmux command failed, invalid target |
 
 ### Message style
@@ -124,6 +165,44 @@ with the portable pattern (override `process()` to merge);
   command failed"`.
 - No trailing punctuation.
 - Keep messages short; put details in `extra`, not the message string.
+
+Deprecations and ignored arguments go through `warnings.warn`, not a
+logger — that is the Python mechanism for them, and
+`logging.captureWarnings(True)` is how an application routes them into
+the same stream. Do not log a deprecation as well; a warning already
+deduplicates per source location and a log record would not.
+
+### Thread safety
+
+`logging` locks handler output, so the only race libtmux could add is
+handing one mutable value to two records. Keep every list and dict
+per-record — slice before you pass it — and no lock is needed anywhere
+on this path.
+
+### Failure records
+
+`raise_if_stderr()` is where libtmux decides a tmux command *failed*,
+so it is the one place that logs `ERROR` for that. A command tmux ran
+successfully can still fail libtmux — `parse_output()` logs the field
+counts when a row does not match the template, because the `zip()`
+message names neither tmux nor the subcommand. Converting such an error
+to `LibTmuxException` would be worse than leaving it: the lenient list
+accessors catch that type, so a loud failure would become a silent
+empty result. Paths that tolerate a non-zero exit — `has-session`
+probes, `is_alive()` — do not route through it and stay quiet. Do not
+log `ERROR` on a non-zero exit code alone; tmux uses one to answer
+"no".
+
+It logs with `stacklevel=2` so the record names the wrapper that ran
+the command. Verify that whenever call depth changes: with the wrong
+value, all of its call sites collapse onto one file and line.
+
+`tmux_stderr` rides on the failure record despite being a heavy key,
+because a failure without tmux's own message is not actionable. It
+stays capped.
+
+A per-item parse loop reports once for the whole item, with a count,
+rather than once per entry — see `_warn_skipped()` in `options.py`.
 
 ### Exception logging
 
@@ -158,4 +237,7 @@ Assert on `caplog.records` attributes, not string matching on
 - Logging secret env var values (log key names only).
 - Non-scalar ad-hoc objects in `extra`.
 - Requiring custom `extra` fields in format strings without safe
-  defaults (missing keys raise `KeyError`).
+  defaults. A missing field makes `Formatter.format()` raise
+  `ValueError`, which `handleError()` prints to stderr before dropping
+  the record; with `logging.raiseExceptions = False` even that goes
+  away. Pass `defaults=` (Python 3.10+).

--- a/src/libtmux/AGENTS.md
+++ b/src/libtmux/AGENTS.md
@@ -71,14 +71,14 @@ an `ERROR` because probes use it to answer false.
 
 Normalize executable-launch `ENOENT`, `EACCES`, and `ENOEXEC` errors to
 `TmuxCommandNotFound`, preserving the operating-system message and cause.
-Keep unrelated `OSError` behavior caller-specific. A failed `PATH` preflight
-uses a factual message without inventing a cause.
+Keep unrelated `OSError` values native at direct loud APIs. A failed `PATH`
+preflight uses a factual message without inventing a cause.
 
 `Server.sessions` and `Server.clients` log once in
-`libtmux.server` when they convert `LibTmuxException` to an empty
-result. `Server.attached_sessions` inherits that behavior through
-`Server.sessions`. The boundary record includes the subcommand,
-socket, first 100 stderr lines, and total stderr line count.
+`libtmux.server` when they convert `LibTmuxException` or an OS launch failure
+to an empty result. `Server.attached_sessions` inherits that behavior through
+`Server.sessions`. The boundary record includes the subcommand, socket, first
+100 stderr lines, and total stderr line count.
 
 Deprecations and ignored arguments use `warnings.warn`, not a second
 log record. Applications can route them through

--- a/src/libtmux/AGENTS.md
+++ b/src/libtmux/AGENTS.md
@@ -12,232 +12,106 @@ facts specific to this package.
   method.
 - tmux's format-string system (`#{session_id}`, `#{window_name}`, …)
   is libtmux's query mechanism; format constants live in `formats.py`.
-- An object can go stale when tmux state changes externally (another
-  client kills a window, a session gets renamed). Call `.refresh()` to
-  reconcile it, or use the `neo` query interface, which always queries
-  fresh.
+- An object can go stale when tmux state changes externally. Call
+  `.refresh()` to reconcile it, or use the `neo` query interface,
+  which always queries fresh.
 
 ## List-returning accessors: empty by default on tmux errors
 
 `Server.sessions`, `Server.clients`, and `Server.attached_sessions`
 return an empty `QueryList` when tmux's underlying list command fails
-for any reason — no running daemon, a missing socket, a permission
-error, a subprocess crash. This is a deliberate API contract:
-list-shaped accessors are lenient by default. Callers that need to
-distinguish "no rows" from "tmux unreachable" use the explicit
-`Server.is_alive()` or `Server.raise_if_dead()` primitives.
+for any reason. Callers that need to distinguish an empty server from
+an unreachable one use `Server.is_alive()` or `Server.raise_if_dead()`.
 
-When adding a new list-returning accessor, follow this convention. If a
-future feature genuinely benefits from loud-failure semantics, expose
-it as a scoped opt-in (e.g. a `Server.raise_server_errors()` context
-manager) rather than changing the default contract of an existing
-accessor or hard-coding raise-on-tmux-error into a new one.
-Empty-on-tmux-error stays the default; raise is opt-in.
+Keep list-shaped accessors lenient by default. Add an explicit opt-in
+for loud failure rather than changing an existing accessor's contract.
 
 ## Logging
 
-These rules guide future logging changes; existing code may not yet
-conform.
+### Ownership
 
-### Logger setup
+- Use `logging.getLogger(__name__)` only in modules that emit records.
+- Keep handlers, levels, and formatters under application control.
+- `_internal/log_context.py` owns structured context:
+  `command_extra(argv)` describes a command and
+  `object_extra(subcommand, ...)` describes an object operation.
+- `tmux_cmd` is the sole producer of subprocess dispatch and
+  completion records. Do not duplicate them in query or object layers.
+- Control mode uses the same command context, then retains it for its
+  client lifecycle.
 
-- Use `logging.getLogger(__name__)` in every module.
-- Add `NullHandler` in library `__init__.py` files.
-- Never configure handlers, levels, or formatters in library code —
-  that's the application's job.
-- Define a logger only in modules that log; an unused one is dead
-  code.
+### Command records
 
-### Where the schema is built
+`tmux_cmd` emits `DEBUG` before and after a subprocess. The
+`tmux_cmd` field contains only:
 
-`_internal/log_context.py` owns both producers. Reuse them instead of
-hand-rolling an `extra` dict:
+- executable;
+- effective `-L` socket name or `-S` socket path;
+- subcommand;
+- the number of operands omitted after the subcommand.
 
-- `describe_command(argv)` derives `tmux_cmd`, `tmux_subcommand`, and
-  `tmux_socket` from a tmux command line, redacting environment values.
-  It parses tmux's global flags per the `getopt` string in tmux's
-  `tmux.c`; a flag that takes a value must never be read as the
-  subcommand.
-- `object_extra(subcommand, ...)` builds lifecycle records, enforcing
-  that every value is a `str` and an unknown key is omitted rather than
-  set to `None`.
+Never add command operands, stdout, or stderr bodies to records. Keep
+`tmux_stdout_len` and `tmux_stderr_len` on completion records.
+This omission is the privacy boundary: do not add command-specific
+redaction tables, alias maps, or output classifiers.
 
-`tmux_cmd` carries the command line for every command record, so no
-other layer should log one — a second producer means two shapes under
-one key.
+Guard command-context construction with
+`logger.isEnabledFor(logging.DEBUG)`. Use lazy interpolation for any
+message arguments.
 
-Redaction is two-directional. `describe_command()` covers what libtmux
-sends and `redact_output()` covers what tmux returns; a subcommand that
-carries a secret one way almost always carries it back the other.
-`redact_output()` also decides control data from content: a subcommand
-returning screen or buffer contents reports `tmux_stdout_len` and
-nothing else, since the caller already holds the value and the log
-would only duplicate it at size. Neither can classify content a caller
-composed — `send_keys` payloads, shell commands, format queries — so
-that boundary is documented rather than guessed at.
+### Levels and failures
 
-A `logging.Filter` belongs on a handler. `Logger.callHandlers()` walks
-ancestor loggers for their handlers and never consults their filters,
-so a filter on `libtmux` never sees a record from `libtmux.common`. It
-quotes control characters into shell `$'…'` form: a caller controls
-much of what reaches a command line, and a raw newline there would let
-the tail of an argument pose as its own record. Object names need no
-such guard — tmux rejects control characters in them before libtmux
-logs anything.
+| Level | Contract |
+| ----- | -------- |
+| `DEBUG` | Subprocess dispatch/completion and internal lookup details |
+| `INFO` | Successful server, session, window, and pane lifecycle events |
+| `WARNING` | A recoverable problem libtmux handled, aggregated once per item |
+| `ERROR` | A failure libtmux intentionally swallowed |
 
-### Structured context via `extra`
+Propagated or translated failures stay in their exceptions; do not
+catch, log, and re-raise. A non-zero tmux exit is not enough to justify
+an `ERROR` because probes use it to answer false.
+`Server.is_alive()` stays quiet.
 
-Pass structured data on every log call where useful for filtering,
-searching, or test assertions.
+`Server.sessions` and `Server.clients` log once in
+`libtmux.server` when they convert `LibTmuxException` to an empty
+result. `Server.attached_sessions` inherits that behavior through
+`Server.sessions`. The boundary record includes the subcommand,
+socket, and stderr line count, not stderr text.
 
-**Core keys** (stable, scalar, safe at any log level):
+Deprecations and ignored arguments use `warnings.warn`, not a second
+log record. Applications can route them through
+`logging.captureWarnings(True)`.
 
-| Key | Type | Context |
-|-----|------|---------|
-| `tmux_cmd` | `str` | tmux command line |
-| `tmux_subcommand` | `str` | tmux subcommand (e.g. `new-session`) |
-| `tmux_target` | `str` | tmux target specifier (e.g. `mysession:1.2`) |
-| `tmux_exit_code` | `int` | tmux process exit code |
-| `tmux_session` | `str` | session name |
-| `tmux_window` | `str` | window name or index |
-| `tmux_pane` | `str` | pane identifier |
-| `tmux_option_key` | `str` | tmux option name |
-| `tmux_option_skipped` | `int` | entries skipped under one option |
-| `tmux_socket` | `str` | socket name or path identifying the tmux server |
+### Structured fields
 
-**Heavy/optional keys** (DEBUG only, potentially large):
+All fields are optional because each record carries only relevant
+context.
 
-| Key | Type | Context |
-|-----|------|---------|
-| `tmux_stdout` | `list[str]` | tmux stdout lines (truncate or cap; `%(tmux_stdout)s` produces repr) |
-| `tmux_stderr` | `list[str]` | tmux stderr lines (same caveats) |
-| `tmux_stdout_len` | `int` | number of stdout lines |
-| `tmux_stderr_len` | `int` | number of stderr lines |
+| Field | Type | Meaning |
+| ----- | ---- | ------- |
+| `tmux_cmd` | `str` | Safe operation summary |
+| `tmux_subcommand` | `str` | tmux subcommand |
+| `tmux_socket` | `str` | Socket name or path |
+| `tmux_target` | `str` | Target specifier |
+| `tmux_session` | `str` | Session name |
+| `tmux_window` | `str` | Window name or index |
+| `tmux_pane` | `str` | Pane identifier |
+| `tmux_exit_code` | `int` | Subprocess exit status |
+| `tmux_stdout_len` | `int` | stdout line count |
+| `tmux_stderr_len` | `int` | stderr or error line count |
+| `tmux_option_key` | `str` | Option whose entries could not be parsed |
+| `tmux_option_skipped` | `int` | Entries skipped for that option |
 
-Treat established keys as compatibility-sensitive — downstream users
-may build dashboards and alerts on them. Change deliberately.
+Treat field names and types as compatibility-sensitive. Omit unknown
+values instead of storing `None`. Keep context scalar.
 
-### Key naming rules
+### Messages and tests
 
-- `snake_case`, not dotted; `tmux_` prefix.
-- Prefer stable scalars; avoid ad-hoc objects.
-- Heavy keys (`tmux_stdout`, `tmux_stderr`) are DEBUG-only; consider
-  companion `tmux_stdout_len` fields or hard truncation (e.g.
-  `stdout[:100]`).
-
-### Lazy formatting
-
-`logger.debug("msg %s", val)` not f-strings. Two rationales:
-
-- Deferred string interpolation: skipped entirely when level is
-  filtered.
-- Aggregator message template grouping: `"Running %s"` is one signature
-  grouped ×10,000; f-strings make each line unique.
-
-When computing `val` itself is expensive, guard with
-`if logger.isEnabledFor(logging.DEBUG)`.
-
-### `stacklevel` for wrappers
-
-Increment for each wrapper layer so `%(filename)s:%(lineno)d` and OTel
-`code.filepath` point to the real caller. Verify whenever call depth
-changes.
-
-### `LoggerAdapter` for persistent context
-
-For objects with stable identity (Session, Window, Pane), use
-`LoggerAdapter` to avoid repeating the same `extra` on every call. Lead
-with the portable pattern (override `process()` to merge);
-`merge_extra=True` simplifies this on Python 3.13+.
-
-### Log levels
-
-| Level | Use for | Examples |
-|-------|---------|----------|
-| `DEBUG` | Internal mechanics, tmux I/O | tmux command + stdout, format queries |
-| `INFO` | Object lifecycle, user-visible operations | Session created, window added |
-| `WARNING` | Recoverable issues libtmux resolved itself | Output it could not parse, a client it had to kill |
-| `ERROR` | Failures that stop an operation | tmux command failed, invalid target |
-
-### Message style
-
-- Lowercase, past tense for events: `"session created"`, `"tmux
-  command failed"`.
-- No trailing punctuation.
-- Keep messages short; put details in `extra`, not the message string.
-
-Deprecations and ignored arguments go through `warnings.warn`, not a
-logger — that is the Python mechanism for them, and
-`logging.captureWarnings(True)` is how an application routes them into
-the same stream. Do not log a deprecation as well; a warning already
-deduplicates per source location and a log record would not.
-
-### Thread safety
-
-`logging` locks handler output, so the only race libtmux could add is
-handing one mutable value to two records. Keep every list and dict
-per-record — slice before you pass it — and no lock is needed anywhere
-on this path.
-
-### Failure records
-
-`raise_if_stderr()` is where libtmux decides a tmux command *failed*,
-so it is the one place that logs `ERROR` for that. A command tmux ran
-successfully can still fail libtmux — `parse_output()` logs the field
-counts when a row does not match the template, because the `zip()`
-message names neither tmux nor the subcommand. Converting such an error
-to `LibTmuxException` would be worse than leaving it: the lenient list
-accessors catch that type, so a loud failure would become a silent
-empty result. Paths that tolerate a non-zero exit — `has-session`
-probes, `is_alive()` — do not route through it and stay quiet. Do not
-log `ERROR` on a non-zero exit code alone; tmux uses one to answer
-"no".
-
-It logs with `stacklevel=2` so the record names the wrapper that ran
-the command. Verify that whenever call depth changes: with the wrong
-value, all of its call sites collapse onto one file and line.
-
-`tmux_stderr` rides on the failure record despite being a heavy key,
-because a failure without tmux's own message is not actionable. It
-stays capped.
-
-A per-item parse loop reports once for the whole item, with a count,
-rather than once per entry — see `_warn_skipped()` in `options.py`.
-
-### Exception logging
-
-- Use `logger.exception()` only inside `except` blocks when you are
-  **not** re-raising.
-- Use `logger.error(..., exc_info=True)` when you need the traceback
-  outside an `except` block.
-- Avoid `logger.exception()` followed by `raise` — this duplicates the
-  traceback. Either add context via `extra` that would otherwise be
-  lost, or let the exception propagate.
-
-### Testing logs
-
-Assert on `caplog.records` attributes, not string matching on
-`caplog.text`:
-
-- Scope capture: `caplog.at_level(logging.DEBUG,
-  logger="libtmux.common")`.
-- Filter records rather than index by position: `[r for r in
-  caplog.records if hasattr(r, "tmux_cmd")]`.
-- Assert on schema: `record.tmux_exit_code == 0` not `"exit code 0" in
-  caplog.text`.
-- `caplog.record_tuples` cannot access extra fields — always use
-  `caplog.records`.
-
-### Avoid
-
-- f-strings/`.format()` in log calls.
-- Unguarded logging in hot loops (guard with `isEnabledFor()`).
-- Catch-log-reraise without adding new context.
-- `print()` for diagnostics.
-- Logging secret env var values (log key names only).
-- Non-scalar ad-hoc objects in `extra`.
-- Requiring custom `extra` fields in format strings without safe
-  defaults. A missing field makes `Formatter.format()` raise
-  `ValueError`, which `handleError()` prints to stderr before dropping
-  the record; with `logging.raiseExceptions = False` even that goes
-  away. Pass `defaults=` (Python 3.10+).
+- Use short lowercase event messages without trailing punctuation.
+- Assert on `caplog.records` fields, not rendered `caplog.text`.
+- Scope capture to the emitting logger.
+- Pair new record behavior with a deliberate break that proves the
+  assertion fails.
+- Give formatter examples safe `defaults=`; not every record carries
+  every field.

--- a/src/libtmux/AGENTS.md
+++ b/src/libtmux/AGENTS.md
@@ -69,6 +69,11 @@ catch, log, and re-raise. A non-zero tmux exit is not enough to justify
 an `ERROR` because probes use it to answer false.
 `Server.is_alive()` stays quiet.
 
+Normalize executable-launch `ENOENT`, `EACCES`, and `ENOEXEC` errors to
+`TmuxCommandNotFound`, preserving the operating-system message and cause.
+Keep unrelated `OSError` behavior caller-specific. A failed `PATH` preflight
+uses a factual message without inventing a cause.
+
 `Server.sessions` and `Server.clients` log once in
 `libtmux.server` when they convert `LibTmuxException` to an empty
 result. `Server.attached_sessions` inherits that behavior through

--- a/src/libtmux/_internal/control_mode.py
+++ b/src/libtmux/_internal/control_mode.py
@@ -7,10 +7,12 @@ requiring an attached client (e.g. ``display-popup``, ``detach-client``).
 
 from __future__ import annotations
 
+import logging
 import os
 import subprocess
 import typing as t
 
+from libtmux._internal.log_context import describe_command
 from libtmux.test.retry import retry_until
 
 if t.TYPE_CHECKING:
@@ -20,6 +22,10 @@ if t.TYPE_CHECKING:
 
     from libtmux.server import Server
     from libtmux.session import Session
+
+logger = logging.getLogger(__name__)
+
+_TERMINATE_TIMEOUT_SECONDS = 5
 
 
 class ControlMode:
@@ -80,6 +86,15 @@ class ControlMode:
             str(self.session.session_id),
         ]
 
+        context = describe_command(cmd)
+        self._log_extra = {
+            "tmux_cmd": context.command,
+            "tmux_subcommand": "attach-session",
+            "tmux_target": str(self.session.session_id),
+        }
+        if context.socket is not None:
+            self._log_extra["tmux_socket"] = context.socket
+
         try:
             try:
                 self._proc = subprocess.Popen(
@@ -97,6 +112,8 @@ class ControlMode:
             # __exit__ will not run if __enter__ fails
             os.close(self._write_fd)
             raise
+
+        logger.debug("control mode client started", extra=self._log_extra)
 
         self.stdout = self._proc.stdout  # type: ignore[assignment]
         client_pid = str(self._proc.pid)
@@ -118,12 +135,7 @@ class ControlMode:
             retry_until(client_registered, 3, raises=True)
         except Exception:
             os.close(self._write_fd)
-            self._proc.terminate()
-            try:
-                self._proc.wait(timeout=5)
-            except subprocess.TimeoutExpired:
-                self._proc.kill()
-                self._proc.wait()
+            self._terminate()
             raise
 
         return self
@@ -138,9 +150,17 @@ class ControlMode:
         # Close write end — causes the control-mode client to exit (EOF on stdin)
         os.close(self._write_fd)
 
+        self._terminate()
+
+    def _terminate(self) -> None:
+        """Stop the client, escalating to ``SIGKILL`` if it does not exit."""
         self._proc.terminate()
         try:
-            self._proc.wait(timeout=5)
+            self._proc.wait(timeout=_TERMINATE_TIMEOUT_SECONDS)
         except subprocess.TimeoutExpired:
+            logger.warning(
+                "control mode client killed after timeout",
+                extra=self._log_extra,
+            )
             self._proc.kill()
             self._proc.wait()

--- a/src/libtmux/_internal/control_mode.py
+++ b/src/libtmux/_internal/control_mode.py
@@ -12,7 +12,7 @@ import os
 import subprocess
 import typing as t
 
-from libtmux._internal.log_context import describe_command
+from libtmux._internal.log_context import command_extra
 from libtmux.test.retry import retry_until
 
 if t.TYPE_CHECKING:
@@ -86,14 +86,11 @@ class ControlMode:
             str(self.session.session_id),
         ]
 
-        context = describe_command(cmd)
         self._log_extra = {
-            "tmux_cmd": context.command,
+            **command_extra(cmd),
             "tmux_subcommand": "attach-session",
             "tmux_target": str(self.session.session_id),
         }
-        if context.socket is not None:
-            self._log_extra["tmux_socket"] = context.socket
 
         try:
             try:

--- a/src/libtmux/_internal/log_context.py
+++ b/src/libtmux/_internal/log_context.py
@@ -102,5 +102,5 @@ def object_extra(
         ("tmux_target", target),
     ):
         if value is not None:
-            extra[key] = str(value)
+            extra[key] = _safe_scalar(str(value))
     return extra

--- a/src/libtmux/_internal/log_context.py
+++ b/src/libtmux/_internal/log_context.py
@@ -18,6 +18,7 @@ __all__ = (
     "CommandContext",
     "describe_command",
     "object_extra",
+    "redact_output",
 )
 
 REDACTED = "REDACTED"
@@ -74,6 +75,9 @@ read as an environment pair.
 
 _SETENV_SUBCOMMANDS = frozenset({"set-environment", "setenv"})
 """Subcommands shaped ``[-Fhgru] [-t target] variable [value]``."""
+
+_ENV_OUTPUT_SUBCOMMANDS = frozenset({"show-environment", "showenv"})
+"""Subcommands whose stdout reports ``NAME=VALUE`` for environment variables."""
 
 
 def _quote(token: str) -> str:
@@ -299,6 +303,48 @@ def _redact_set_environment(tokens: list[str], subcommand_index: int) -> list[st
     if len(positions) >= 2:
         redacted[positions[-1]] = REDACTED
     return redacted
+
+
+def redact_output(subcommand: str | None, lines: list[str]) -> list[str]:
+    """Hide values in output that reports environment variables.
+
+    Redacting what libtmux sends is only half of it: ``show-environment`` hands
+    the same values straight back on stdout, so
+    :meth:`~libtmux.common.EnvironmentMixin.getenv` would log a secret that
+    :meth:`~libtmux.common.EnvironmentMixin.set_environment` was careful not to.
+
+    Parameters
+    ----------
+    subcommand : str | None
+        tmux subcommand that produced ``lines``.
+    lines : list[str]
+        Output lines as tmux wrote them.
+
+    Returns
+    -------
+    list[str]
+        The lines, with any environment value replaced by :data:`REDACTED`.
+
+    Examples
+    --------
+    >>> redact_output("show-environment", ["EDITOR=vim", "API_TOKEN=hunter2"])
+    ['EDITOR=REDACTED', 'API_TOKEN=REDACTED']
+
+    An unset variable carries no value to hide:
+
+    >>> redact_output("show-environment", ["-EDITOR"])
+    ['-EDITOR']
+
+    Output from anything else is left alone, so a debug record stays useful:
+
+    >>> redact_output("list-sessions", ["mysession: 1 windows"])
+    ['mysession: 1 windows']
+    """
+    if subcommand not in _ENV_OUTPUT_SUBCOMMANDS:
+        return lines
+    return [
+        f"{line.split('=', 1)[0]}={REDACTED}" if "=" in line else line for line in lines
+    ]
 
 
 def object_extra(

--- a/src/libtmux/_internal/log_context.py
+++ b/src/libtmux/_internal/log_context.py
@@ -23,9 +23,22 @@ __all__ = (
 REDACTED = "REDACTED"
 """Placeholder substituted for environment values in logged command lines.
 
-Chosen to survive :func:`shlex.join` unquoted, so quoting in a logged command
-line still marks a genuinely quoted argument.
+Chosen to survive quoting untouched, so quoting in a logged command line
+still marks a genuinely quoted argument.
 """
+
+_CONTROL_CHARS = frozenset(chr(code) for code in range(0x20)) | {"\x7f"}
+
+_CONTROL_ESCAPES = {
+    "\a": r"\a",
+    "\b": r"\b",
+    "\t": r"\t",
+    "\n": r"\n",
+    "\v": r"\v",
+    "\f": r"\f",
+    "\r": r"\r",
+    "\x1b": r"\e",
+}
 
 _VALUE_FLAGS = frozenset("cfLST")
 """tmux global flags that consume the argument after them.
@@ -53,6 +66,50 @@ read as an environment pair.
 
 _SETENV_SUBCOMMANDS = frozenset({"set-environment", "setenv"})
 """Subcommands shaped ``[-Fhgru] [-t target] variable [value]``."""
+
+
+def _quote(token: str) -> str:
+    r"""Quote one argument for a log record, keeping control characters out.
+
+    A caller controls much of what reaches a tmux command line — the keys
+    :meth:`Pane.send_keys` sends, a start directory, a window command. A
+    newline among them would end the log line early and let the remainder pose
+    as a record of its own, so a token carrying control characters is rendered
+    with shell ANSI-C quoting: ``bash`` and ``zsh`` still reproduce the exact
+    bytes when the line is pasted, but the line itself stays on one line.
+
+    Examples
+    --------
+    >>> _quote("plain")
+    'plain'
+
+    >>> _quote("has space")
+    "'has space'"
+
+    A newline cannot break out of the record:
+
+    >>> _quote("echo hi\nCRITICAL forged")
+    "$'echo hi\\nCRITICAL forged'"
+
+    Neither can an escape sequence reach the terminal reading the log:
+
+    >>> _quote("\x1b[31mred")
+    "$'\\e[31mred'"
+    """
+    if not _CONTROL_CHARS.intersection(token):
+        return shlex.quote(token)
+
+    escaped = []
+    for char in token:
+        if char in {"\\", "'"}:
+            escaped.append("\\" + char)
+        elif char in _CONTROL_ESCAPES:
+            escaped.append(_CONTROL_ESCAPES[char])
+        elif char in _CONTROL_CHARS:
+            escaped.append(f"\\x{ord(char):02x}")
+        else:
+            escaped.append(char)
+    return "$'" + "".join(escaped) + "'"
 
 
 class CommandContext(t.NamedTuple):
@@ -146,7 +203,9 @@ def describe_command(argv: Sequence[str]) -> CommandContext:
     return CommandContext(
         subcommand=subcommand,
         socket=socket,
-        command=shlex.join(_redact(tokens, subcommand, subcommand_index)),
+        command=" ".join(
+            _quote(token) for token in _redact(tokens, subcommand, subcommand_index)
+        ),
     )
 
 

--- a/src/libtmux/_internal/log_context.py
+++ b/src/libtmux/_internal/log_context.py
@@ -1,0 +1,275 @@
+"""Structured logging context for :mod:`libtmux`.
+
+Pure helpers that turn a tmux command line, or a tmux object's identity, into
+the ``extra`` mapping libtmux attaches to its log records. Nothing here runs
+tmux or touches a logger, so the record schema is testable without a server.
+"""
+
+from __future__ import annotations
+
+import shlex
+import typing as t
+
+if t.TYPE_CHECKING:
+    from collections.abc import Sequence
+
+__all__ = (
+    "REDACTED",
+    "CommandContext",
+    "describe_command",
+    "object_extra",
+)
+
+REDACTED = "REDACTED"
+"""Placeholder substituted for environment values in logged command lines.
+
+Chosen to survive :func:`shlex.join` unquoted, so quoting in a logged command
+line still marks a genuinely quoted argument.
+"""
+
+_VALUE_FLAGS = frozenset("cfLST")
+"""tmux global flags that consume the argument after them.
+
+Mirrors the ``getopt`` string in tmux's ``tmux.c`` (``2c:CDdf:hlL:NqS:T:uUvV``).
+Every other global flag is a boolean and may be bundled, as in ``-2q``.
+"""
+
+_SOCKET_FLAGS = frozenset("LS")
+
+_ENV_SUBCOMMANDS = frozenset(
+    {
+        "new-session",
+        "new-window",
+        "respawn-pane",
+        "respawn-window",
+        "split-window",
+    },
+)
+"""Subcommands whose ``-e`` carries a ``NAME=VALUE`` pair.
+
+``select-pane -e`` and ``copy-mode -e`` are booleans, so a bare ``-e`` is never
+read as an environment pair.
+"""
+
+_SETENV_SUBCOMMANDS = frozenset({"set-environment", "setenv"})
+"""Subcommands shaped ``[-Fhgru] [-t target] variable [value]``."""
+
+
+class CommandContext(t.NamedTuple):
+    """Logging context derived from a tmux command line.
+
+    Attributes
+    ----------
+    subcommand : str | None
+        tmux subcommand, e.g. ``"new-session"``. ``None`` when the command line
+        carries only global flags, as ``tmux -V`` does.
+    socket : str | None
+        Socket name (``-L``) or path (``-S``) identifying which tmux server the
+        command addressed. ``None`` when tmux would use its default socket.
+    command : str
+        Shell-quoted command line with environment values replaced by
+        :data:`REDACTED`.
+    """
+
+    subcommand: str | None
+    socket: str | None
+    command: str
+
+
+def describe_command(argv: Sequence[str]) -> CommandContext:
+    """Derive logging context from a tmux command line.
+
+    Parameters
+    ----------
+    argv : Sequence[str]
+        Full argument vector, beginning with the tmux binary.
+
+    Returns
+    -------
+    CommandContext
+        Subcommand, socket, and a redacted command string.
+
+    Examples
+    --------
+    Global flags are skipped to reach the subcommand:
+
+    >>> describe_command(["tmux", "-Lmysock", "new-session", "-d"])
+    CommandContext(subcommand='new-session', socket='mysock', command='tmux -Lmysock new-session -d')
+
+    Flags that take a value are understood in both joined and separated form,
+    so the value is never mistaken for the subcommand:
+
+    >>> describe_command(["tmux", "-L", "mysock", "kill-server"]).subcommand
+    'kill-server'
+
+    A command line with no subcommand reports ``None``:
+
+    >>> describe_command(["tmux", "-V"]).subcommand is None
+    True
+
+    Environment values are redacted, and their names kept:
+
+    >>> describe_command(
+    ...     ["tmux", "new-session", "-eAPI_TOKEN=hunter2"]
+    ... ).command
+    'tmux new-session -eAPI_TOKEN=REDACTED'
+    """  # noqa: E501
+    tokens = [str(arg) for arg in argv]
+    subcommand: str | None = None
+    socket: str | None = None
+    subcommand_index = len(tokens)
+
+    index = 1
+    while index < len(tokens):
+        token = tokens[index]
+        body = token[1:]
+        if not token.startswith("-") or not body:
+            subcommand = token
+            subcommand_index = index
+            break
+        flag, joined_value = body[0], body[1:]
+        if flag in _VALUE_FLAGS:
+            value = joined_value or (
+                tokens[index + 1] if index + 1 < len(tokens) else None
+            )
+            if flag in _SOCKET_FLAGS:
+                socket = value
+            index += 1 if joined_value else 2
+        else:
+            index += 1
+
+    return CommandContext(
+        subcommand=subcommand,
+        socket=socket,
+        command=shlex.join(_redact(tokens, subcommand, subcommand_index)),
+    )
+
+
+def _redact(
+    tokens: list[str],
+    subcommand: str | None,
+    subcommand_index: int,
+) -> list[str]:
+    """Return ``tokens`` with environment values replaced.
+
+    Examples
+    --------
+    >>> _redact(["tmux", "new-session", "-eK=v"], "new-session", 1)
+    ['tmux', 'new-session', '-eK=REDACTED']
+
+    A boolean ``-e`` keeps the argument that follows it:
+
+    >>> _redact(["tmux", "select-pane", "-e", "-t%1"], "select-pane", 1)
+    ['tmux', 'select-pane', '-e', '-t%1']
+    """
+    if subcommand in _SETENV_SUBCOMMANDS:
+        return _redact_set_environment(tokens, subcommand_index)
+
+    redacted = list(tokens)
+    separated_pairs = subcommand in _ENV_SUBCOMMANDS
+    index = subcommand_index + 1
+    while index < len(redacted):
+        token = redacted[index]
+        if token.startswith("-e") and "=" in token[2:]:
+            name = token[2:].split("=", 1)[0]
+            redacted[index] = f"-e{name}={REDACTED}"
+        elif separated_pairs and token == "-e" and index + 1 < len(redacted):
+            following = redacted[index + 1]
+            if "=" in following:
+                redacted[index + 1] = f"{following.split('=', 1)[0]}={REDACTED}"
+            index += 1
+        index += 1
+    return redacted
+
+
+def _redact_set_environment(tokens: list[str], subcommand_index: int) -> list[str]:
+    """Return ``tokens`` with a ``set-environment`` value replaced.
+
+    tmux reads ``set-environment [-Fhgru] [-t target-session] variable [value]``,
+    so only a trailing second positional is a value worth hiding.
+
+    Examples
+    --------
+    >>> _redact_set_environment(["tmux", "set-environment", "K", "v"], 1)
+    ['tmux', 'set-environment', 'K', 'REDACTED']
+
+    Unsetting passes a name and no value, which stays visible:
+
+    >>> _redact_set_environment(["tmux", "set-environment", "-u", "K"], 1)
+    ['tmux', 'set-environment', '-u', 'K']
+    """
+    redacted = list(tokens)
+    positions: list[int] = []
+    index = subcommand_index + 1
+    while index < len(redacted):
+        token = redacted[index]
+        if token == "-t":
+            index += 2
+            continue
+        if token.startswith("-") and len(token) > 1:
+            index += 1
+            continue
+        positions.append(index)
+        index += 1
+
+    if len(positions) >= 2:
+        redacted[positions[-1]] = REDACTED
+    return redacted
+
+
+def object_extra(
+    subcommand: str,
+    *,
+    session: str | None = None,
+    window: str | None = None,
+    pane: str | None = None,
+    target: str | int | None = None,
+) -> dict[str, str]:
+    """Build the ``extra`` mapping for a tmux object lifecycle record.
+
+    Keeps the schema's two invariants in one place: every value is a ``str``,
+    and a key absent from tmux is absent from the record rather than ``None``.
+
+    Parameters
+    ----------
+    subcommand : str
+        tmux subcommand the operation ran, e.g. ``"kill-pane"``.
+    session : str, optional
+        Session name.
+    window : str, optional
+        Window name or index.
+    pane : str, optional
+        Pane identifier.
+    target : str | int, optional
+        tmux target specifier the operation addressed.
+
+    Returns
+    -------
+    dict[str, str]
+        Mapping suitable for a logger's ``extra`` argument.
+
+    Examples
+    --------
+    >>> object_extra("kill-pane", pane="%1", target="%1")
+    {'tmux_subcommand': 'kill-pane', 'tmux_pane': '%1', 'tmux_target': '%1'}
+
+    Omitted context stays out of the record:
+
+    >>> object_extra("kill-server")
+    {'tmux_subcommand': 'kill-server'}
+
+    Non-string targets are coerced, so a formatter never sees an ``int``:
+
+    >>> object_extra("kill-window", target=3)["tmux_target"]
+    '3'
+    """
+    extra = {"tmux_subcommand": subcommand}
+    for key, value in (
+        ("tmux_session", session),
+        ("tmux_window", window),
+        ("tmux_pane", pane),
+        ("tmux_target", target),
+    ):
+        if value is not None:
+            extra[key] = str(value)
+    return extra

--- a/src/libtmux/_internal/log_context.py
+++ b/src/libtmux/_internal/log_context.py
@@ -146,15 +146,13 @@ class CommandContext(t.NamedTuple):
         command addressed. ``None`` when tmux would use its default socket.
     command : str
         Shell-quoted command line with environment values replaced by
-        :data:`REDACTED`, shortened to :data:`_COMMAND_CAP`.
-    length : int
-        Length of the command line before shortening.
+        :data:`REDACTED`. A line longer than :data:`_COMMAND_CAP` is shortened
+        and ends in an ellipsis.
     """
 
     subcommand: str | None
     socket: str | None
     command: str
-    length: int
 
 
 def describe_command(argv: Sequence[str]) -> CommandContext:
@@ -238,7 +236,6 @@ def describe_command(argv: Sequence[str]) -> CommandContext:
             if len(command) <= _COMMAND_CAP
             else command[: _COMMAND_CAP - 1] + "\N{HORIZONTAL ELLIPSIS}"
         ),
-        length=len(command),
     )
 
 

--- a/src/libtmux/_internal/log_context.py
+++ b/src/libtmux/_internal/log_context.py
@@ -9,6 +9,12 @@ from collections.abc import Sequence
 _VALUE_FLAGS = frozenset("cfLST")
 """tmux global flags that consume a value."""
 
+_BOOLEAN_FLAGS = frozenset("2CDdhlNquUvV")
+"""tmux global flags that do not consume a value."""
+
+LOG_OUTPUT_LINE_LIMIT = 100
+"""Maximum output lines attached to one log record."""
+
 
 def _safe_scalar(value: str) -> str:
     """Keep printable identities readable and escape control characters."""
@@ -21,17 +27,10 @@ def _quote(value: str) -> str:
 
 
 def command_extra(argv: Sequence[str]) -> dict[str, str]:
-    """Describe a tmux operation without logging its operands.
-
-    The rendered compatibility field contains only the executable, effective
-    socket selection, and subcommand. A marker reports how many arguments after
-    the subcommand were omitted. This operation/parameter split makes unknown
-    tmux commands safe without knowing their argument grammar.
-    """
+    """Describe a tmux command and derive best-effort structured context."""
     tokens = [str(arg) for arg in argv]
     executable = tokens[0] if tokens else "tmux"
     subcommand: str | None = None
-    subcommand_index = len(tokens)
     socket_label: str | None = None
     socket_path: str | None = None
 
@@ -42,17 +41,19 @@ def command_extra(argv: Sequence[str]) -> dict[str, str]:
             index += 1
             if index < len(tokens):
                 subcommand = tokens[index]
-                subcommand_index = index
             break
         if not token.startswith("-") or token == "-":
             subcommand = token
-            subcommand_index = index
             break
 
+        known_option = True
         takes_next = False
         for position, flag in enumerate(token[1:]):
-            if flag not in _VALUE_FLAGS:
+            if flag in _BOOLEAN_FLAGS:
                 continue
+            if flag not in _VALUE_FLAGS:
+                known_option = False
+                break
             attached = token[position + 2 :]
             value = attached or (tokens[index + 1] if index + 1 < len(tokens) else None)
             if flag == "L":
@@ -61,20 +62,12 @@ def command_extra(argv: Sequence[str]) -> dict[str, str]:
                 socket_path = value
             takes_next = not attached
             break
+        if not known_option:
+            break
         index += 2 if takes_next else 1
 
-    socket_flag = "S" if socket_path is not None else "L"
     socket = socket_path if socket_path is not None else socket_label
-    operation = [_quote(executable)]
-    if socket is not None:
-        operation.extend((f"-{socket_flag}", _quote(socket)))
-    if subcommand is not None:
-        operation.append(_quote(subcommand))
-        omitted = len(tokens) - subcommand_index - 1
-        if omitted:
-            operation.append(f"<{omitted} arguments omitted>")
-
-    extra = {"tmux_cmd": " ".join(operation)}
+    extra = {"tmux_cmd": " ".join(_quote(token) for token in (tokens or [executable]))}
     if subcommand is not None:
         extra["tmux_subcommand"] = _safe_scalar(subcommand)
     if socket is not None:

--- a/src/libtmux/_internal/log_context.py
+++ b/src/libtmux/_internal/log_context.py
@@ -127,16 +127,21 @@ def describe_command(argv: Sequence[str]) -> CommandContext:
             subcommand = token
             subcommand_index = index
             break
-        flag, joined_value = body[0], body[1:]
-        if flag in _VALUE_FLAGS:
+        # Booleans bundle, so a value flag can sit anywhere in the token and
+        # takes the remainder of it — or the next token when it ends there.
+        takes_next_token = False
+        for position, flag in enumerate(body):
+            if flag not in _VALUE_FLAGS:
+                continue
+            joined_value = body[position + 1 :]
             value = joined_value or (
                 tokens[index + 1] if index + 1 < len(tokens) else None
             )
             if flag in _SOCKET_FLAGS:
                 socket = value
-            index += 1 if joined_value else 2
-        else:
-            index += 1
+            takes_next_token = not joined_value
+            break
+        index += 2 if takes_next_token else 1
 
     return CommandContext(
         subcommand=subcommand,

--- a/src/libtmux/_internal/log_context.py
+++ b/src/libtmux/_internal/log_context.py
@@ -356,6 +356,8 @@ def redact_output(subcommand: str | None, lines: list[str]) -> list[str]:
     >>> redact_output("list-sessions", ["mysession: 1 windows"])
     ['mysession: 1 windows']
     """
+    # Dropping beats redacting: a subcommand in both sets returns content, and
+    # content is withheld whole rather than pattern-matched.
     if subcommand in _CONTENT_SUBCOMMANDS:
         return []
     if subcommand not in _ENV_OUTPUT_SUBCOMMANDS:

--- a/src/libtmux/_internal/log_context.py
+++ b/src/libtmux/_internal/log_context.py
@@ -27,6 +27,14 @@ Chosen to survive quoting untouched, so quoting in a logged command line
 still marks a genuinely quoted argument.
 """
 
+_COMMAND_CAP = 16384
+"""Longest command line kept on a record, in characters.
+
+tmux refuses a command larger than ``MAX_IMSGSIZE`` (16384) in ``compat/imsg.h``,
+so anything tmux was willing to run survives intact and only a rejected command
+is shortened.
+"""
+
 _CONTROL_CHARS = frozenset(chr(code) for code in range(0x20)) | {"\x7f"}
 
 _CONTROL_ESCAPES = {
@@ -125,12 +133,15 @@ class CommandContext(t.NamedTuple):
         command addressed. ``None`` when tmux would use its default socket.
     command : str
         Shell-quoted command line with environment values replaced by
-        :data:`REDACTED`.
+        :data:`REDACTED`, shortened to :data:`_COMMAND_CAP`.
+    length : int
+        Length of the command line before shortening.
     """
 
     subcommand: str | None
     socket: str | None
     command: str
+    length: int
 
 
 def describe_command(argv: Sequence[str]) -> CommandContext:
@@ -150,8 +161,11 @@ def describe_command(argv: Sequence[str]) -> CommandContext:
     --------
     Global flags are skipped to reach the subcommand:
 
-    >>> describe_command(["tmux", "-Lmysock", "new-session", "-d"])
-    CommandContext(subcommand='new-session', socket='mysock', command='tmux -Lmysock new-session -d')
+    >>> describe_command(["tmux", "-Lmysock", "new-session", "-d"]).subcommand
+    'new-session'
+
+    >>> describe_command(["tmux", "-Lmysock", "new-session", "-d"]).socket
+    'mysock'
 
     Flags that take a value are understood in both joined and separated form,
     so the value is never mistaken for the subcommand:
@@ -170,7 +184,7 @@ def describe_command(argv: Sequence[str]) -> CommandContext:
     ...     ["tmux", "new-session", "-eAPI_TOKEN=hunter2"]
     ... ).command
     'tmux new-session -eAPI_TOKEN=REDACTED'
-    """  # noqa: E501
+    """
     tokens = [str(arg) for arg in argv]
     subcommand: str | None = None
     socket: str | None = None
@@ -200,12 +214,18 @@ def describe_command(argv: Sequence[str]) -> CommandContext:
             break
         index += 2 if takes_next_token else 1
 
+    command = " ".join(
+        _quote(token) for token in _redact(tokens, subcommand, subcommand_index)
+    )
     return CommandContext(
         subcommand=subcommand,
         socket=socket,
-        command=" ".join(
-            _quote(token) for token in _redact(tokens, subcommand, subcommand_index)
+        command=(
+            command
+            if len(command) <= _COMMAND_CAP
+            else command[: _COMMAND_CAP - 1] + "\N{HORIZONTAL ELLIPSIS}"
         ),
+        length=len(command),
     )
 
 

--- a/src/libtmux/_internal/log_context.py
+++ b/src/libtmux/_internal/log_context.py
@@ -7,6 +7,7 @@ tmux or touches a logger, so the record schema is testable without a server.
 
 from __future__ import annotations
 
+import os
 import shlex
 import typing as t
 
@@ -29,14 +30,16 @@ still marks a genuinely quoted argument.
 """
 
 _COMMAND_CAP = 16384
-"""Longest command line kept on a record, in characters.
+"""Practical rendered-character cap derived from tmux's message ceiling.
 
-tmux refuses a command larger than ``MAX_IMSGSIZE`` (16384) in ``compat/imsg.h``,
-so anything tmux was willing to run survives intact and only a rejected command
-is shortened.
+Quoting and UTF-8 mean this is not an exact model of tmux's transport bytes.
 """
 
-_CONTROL_CHARS = frozenset(chr(code) for code in range(0x20)) | {"\x7f"}
+_CONTROL_CHARS = (
+    frozenset(chr(code) for code in range(0x20))
+    | frozenset(chr(code) for code in range(0x7F, 0xA0))
+    | {"\u2028", "\u2029"}
+)
 
 _CONTROL_ESCAPES = {
     "\a": r"\a",
@@ -56,12 +59,34 @@ Mirrors the ``getopt`` string in tmux's ``tmux.c`` (``2c:CDdf:hlL:NqS:T:uUvV``).
 Every other global flag is a boolean and may be bundled, as in ``-2q``.
 """
 
-_SOCKET_FLAGS = frozenset("LS")
+_CANONICAL_SUBCOMMANDS = {
+    "new": "new-session",
+    "neww": "new-window",
+    "newp": "new-pane",
+    "popup": "display-popup",
+    "respawnp": "respawn-pane",
+    "respawnw": "respawn-window",
+    "splitw": "split-window",
+    "split-pane": "split-window",
+    "splitp": "split-window",
+    "setenv": "set-environment",
+    "showenv": "show-environment",
+    "capturep": "capture-pane",
+    "setb": "set-buffer",
+    "saveb": "save-buffer",
+    "showb": "show-buffer",
+    "lsb": "list-buffers",
+    "showmsgs": "show-messages",
+    "showphist": "show-prompt-history",
+}
+"""Relevant tmux aliases mapped to the policy command they execute."""
 
 _ENV_SUBCOMMANDS = frozenset(
     {
         "new-session",
         "new-window",
+        "new-pane",
+        "display-popup",
         "respawn-pane",
         "respawn-window",
         "split-window",
@@ -73,20 +98,44 @@ _ENV_SUBCOMMANDS = frozenset(
 read as an environment pair.
 """
 
-_SETENV_SUBCOMMANDS = frozenset({"set-environment", "setenv"})
+_SETENV_SUBCOMMANDS = frozenset({"set-environment"})
 """Subcommands shaped ``[-Fhgru] [-t target] variable [value]``."""
 
-_ENV_OUTPUT_SUBCOMMANDS = frozenset({"show-environment", "showenv"})
+_ENV_OUTPUT_SUBCOMMANDS = frozenset({"show-environment"})
 """Subcommands whose stdout reports ``NAME=VALUE`` for environment variables."""
 
+_BUFFER_INPUT_SUBCOMMANDS = frozenset({"set-buffer"})
+"""Subcommands whose positional data is caller-provided buffer content."""
+
 _CONTENT_SUBCOMMANDS = frozenset(
-    {"capture-pane", "list-buffers", "lsb", "show-buffer", "showb"},
+    {
+        "capture-pane",
+        "list-buffers",
+        "save-buffer",
+        "show-buffer",
+        "show-messages",
+        "show-prompt-history",
+    },
 )
 """Subcommands whose stdout is terminal or buffer content rather than control data.
 
 Their output is whatever happened to be on a screen or in a paste buffer, and it
 already reaches the caller as a return value, so a record reports how much came
 back instead of what it was."""
+
+_ENVIRONMENT_POLICY = "environment"
+_SETENV_POLICY = "set-environment"
+_BUFFER_INPUT_POLICY = "set-buffer"
+_SENSITIVE_OUTPUT_POLICY = "sensitive-output"
+
+_POLICY_BY_COMMAND = {
+    **dict.fromkeys(_ENV_SUBCOMMANDS, _ENVIRONMENT_POLICY),
+    **dict.fromkeys(_SETENV_SUBCOMMANDS, _SETENV_POLICY),
+    **dict.fromkeys(_BUFFER_INPUT_SUBCOMMANDS, _BUFFER_INPUT_POLICY),
+    **dict.fromkeys(_ENV_OUTPUT_SUBCOMMANDS, _SENSITIVE_OUTPUT_POLICY),
+    **dict.fromkeys(_CONTENT_SUBCOMMANDS, _SENSITIVE_OUTPUT_POLICY),
+}
+"""Canonical commands grouped by the log-safety policy they share."""
 
 
 def _quote(token: str) -> str:
@@ -96,8 +145,8 @@ def _quote(token: str) -> str:
     :meth:`Pane.send_keys` sends, a start directory, a window command. A
     newline among them would end the log line early and let the remainder pose
     as a record of its own, so a token carrying control characters is rendered
-    with shell ANSI-C quoting: ``bash`` and ``zsh`` still reproduce the exact
-    bytes when the line is pasted, but the line itself stays on one line.
+    with shell ANSI-C quoting. The result remains pasteable for ordinary tmux
+    arguments, but the log itself stays on one line.
 
     Examples
     --------
@@ -127,10 +176,78 @@ def _quote(token: str) -> str:
         elif char in _CONTROL_ESCAPES:
             escaped.append(_CONTROL_ESCAPES[char])
         elif char in _CONTROL_CHARS:
-            escaped.append(f"\\x{ord(char):02x}")
+            codepoint = ord(char)
+            if codepoint <= 0x7F:
+                escaped.append(f"\\x{codepoint:02x}")
+            elif codepoint <= 0xFFFF:
+                escaped.append(f"\\u{codepoint:04x}")
+            else:
+                escaped.append(f"\\U{codepoint:08x}")
         else:
             escaped.append(char)
     return "$'" + "".join(escaped) + "'"
+
+
+def _canonical_subcommand(subcommand: str | None) -> str | None:
+    """Return the command name used for logging policy decisions.
+
+    Examples
+    --------
+    >>> _canonical_subcommand("new")
+    'new-session'
+
+    >>> _canonical_subcommand("list-sessions")
+    'list-sessions'
+    """
+    if subcommand is None:
+        return None
+    return _CANONICAL_SUBCOMMANDS.get(subcommand, subcommand)
+
+
+def _policy_for_subcommand(subcommand: str | None) -> str | None:
+    """Return the safety policy for an exact command or tmux abbreviation.
+
+    A prefix is safe to classify when every protected command it matches uses
+    the same policy. Prefixes spanning incompatible argument grammars remain
+    unclassified.
+
+    Examples
+    --------
+    >>> _policy_for_subcommand("new-")
+    'environment'
+
+    >>> _policy_for_subcommand("set-") is None
+    True
+    """
+    canonical_subcommand = _canonical_subcommand(subcommand)
+    if canonical_subcommand is None:
+        return None
+    exact_policy = _POLICY_BY_COMMAND.get(canonical_subcommand)
+    if exact_policy is not None:
+        return exact_policy
+
+    policies = {
+        policy
+        for command, policy in _POLICY_BY_COMMAND.items()
+        if command.startswith(canonical_subcommand)
+    }
+    return policies.pop() if len(policies) == 1 else None
+
+
+def _safe_scalar(value: str | None) -> str | None:
+    r"""Quote control characters while preserving ordinary field values.
+
+    Examples
+    --------
+    >>> _safe_scalar("server")
+    'server'
+
+    >>> _safe_scalar("safe\nERROR forged")
+    "$'safe\\nERROR forged'"
+    """
+    if value is None or not _CONTROL_CHARS.intersection(value):
+        return value
+    return _quote(value)
 
 
 class CommandContext(t.NamedTuple):
@@ -198,7 +315,8 @@ def describe_command(argv: Sequence[str]) -> CommandContext:
     """
     tokens = [str(arg) for arg in argv]
     subcommand: str | None = None
-    socket: str | None = None
+    socket_label: str | None = None
+    socket_path: str | None = None
     subcommand_index = len(tokens)
 
     index = 1
@@ -219,8 +337,10 @@ def describe_command(argv: Sequence[str]) -> CommandContext:
             value = joined_value or (
                 tokens[index + 1] if index + 1 < len(tokens) else None
             )
-            if flag in _SOCKET_FLAGS:
-                socket = value
+            if flag == "L":
+                socket_label = value
+            elif flag == "S":
+                socket_path = value
             takes_next_token = not joined_value
             break
         index += 2 if takes_next_token else 1
@@ -230,7 +350,7 @@ def describe_command(argv: Sequence[str]) -> CommandContext:
     )
     return CommandContext(
         subcommand=subcommand,
-        socket=socket,
+        socket=_safe_scalar(socket_path if socket_path is not None else socket_label),
         command=(
             command
             if len(command) <= _COMMAND_CAP
@@ -256,15 +376,22 @@ def _redact(
     >>> _redact(["tmux", "select-pane", "-e", "-t%1"], "select-pane", 1)
     ['tmux', 'select-pane', '-e', '-t%1']
     """
-    if subcommand in _SETENV_SUBCOMMANDS:
+    policy = _policy_for_subcommand(subcommand)
+    if policy == _SETENV_POLICY:
         return _redact_set_environment(tokens, subcommand_index)
+    if policy == _BUFFER_INPUT_POLICY:
+        return _redact_set_buffer(tokens, subcommand_index)
 
     redacted = list(tokens)
-    separated_pairs = subcommand in _ENV_SUBCOMMANDS
+    separated_pairs = policy == _ENVIRONMENT_POLICY
     index = subcommand_index + 1
     while index < len(redacted):
         token = redacted[index]
-        if token.startswith("-e") and "=" in token[2:]:
+        if (
+            policy == _ENVIRONMENT_POLICY
+            and token.startswith("-e")
+            and "=" in token[2:]
+        ):
             name = token[2:].split("=", 1)[0]
             redacted[index] = f"-e{name}={REDACTED}"
         elif separated_pairs and token == "-e" and index + 1 < len(redacted):
@@ -293,21 +420,69 @@ def _redact_set_environment(tokens: list[str], subcommand_index: int) -> list[st
     ['tmux', 'set-environment', '-u', 'K']
     """
     redacted = list(tokens)
-    positions: list[int] = []
     index = subcommand_index + 1
     while index < len(redacted):
         token = redacted[index]
-        if token == "-t":
-            index += 2
-            continue
-        if token.startswith("-") and len(token) > 1:
+        if token == "--":
             index += 1
-            continue
-        positions.append(index)
-        index += 1
+            break
+        if token.startswith("-") and len(token) > 1:
+            takes_next = False
+            valid_option = True
+            for position, flag in enumerate(token[1:]):
+                if flag == "t":
+                    takes_next = position == len(token) - 2
+                    break
+                if flag not in "Fhgru":
+                    valid_option = False
+                    break
+            if valid_option:
+                index += 2 if takes_next else 1
+                continue
+        break
 
-    if len(positions) >= 2:
-        redacted[positions[-1]] = REDACTED
+    if index + 1 < len(redacted):
+        redacted[index + 1] = REDACTED
+    return redacted
+
+
+def _redact_set_buffer(tokens: list[str], subcommand_index: int) -> list[str]:
+    """Return ``tokens`` with ``set-buffer`` data replaced.
+
+    Examples
+    --------
+    >>> _redact_set_buffer(["tmux", "set-buffer", "-b", "name", "data"], 1)
+    ['tmux', 'set-buffer', '-b', 'name', 'REDACTED']
+
+    A command that only selects a buffer has no data to redact:
+
+    >>> _redact_set_buffer(["tmux", "set-buffer", "-b", "name"], 1)
+    ['tmux', 'set-buffer', '-b', 'name']
+    """
+    redacted = list(tokens)
+    index = subcommand_index + 1
+    while index < len(redacted):
+        token = redacted[index]
+        if token == "--":
+            index += 1
+            break
+        if token.startswith("-") and len(token) > 1:
+            takes_next = False
+            valid_option = True
+            for position, flag in enumerate(token[1:]):
+                if flag in "bnt":
+                    takes_next = position == len(token) - 2
+                    break
+                if flag not in "aw":
+                    valid_option = False
+                    break
+            if valid_option:
+                index += 2 if takes_next else 1
+                continue
+        break
+
+    if index < len(redacted):
+        redacted[index] = REDACTED
     return redacted
 
 
@@ -329,17 +504,12 @@ def redact_output(subcommand: str | None, lines: list[str]) -> list[str]:
     Returns
     -------
     list[str]
-        The lines, with any environment value replaced by :data:`REDACTED`.
+        Safe lines for a log record. Sensitive command output is withheld.
 
     Examples
     --------
-    >>> redact_output("show-environment", ["EDITOR=vim", "API_TOKEN=hunter2"])
-    ['EDITOR=REDACTED', 'API_TOKEN=REDACTED']
-
-    An unset variable carries no value to hide:
-
-    >>> redact_output("show-environment", ["-EDITOR"])
-    ['-EDITOR']
+    >>> redact_output("show-environment", ["EDITOR=vim", "continued value"])
+    []
 
     Terminal and buffer content is dropped rather than redacted — the caller
     already has it as a return value, and ``tmux_stdout_len`` still reports how
@@ -355,18 +525,15 @@ def redact_output(subcommand: str | None, lines: list[str]) -> list[str]:
     """
     # Dropping beats redacting: a subcommand in both sets returns content, and
     # content is withheld whole rather than pattern-matched.
-    if subcommand in _CONTENT_SUBCOMMANDS:
+    if _policy_for_subcommand(subcommand) == _SENSITIVE_OUTPUT_POLICY:
         return []
-    if subcommand not in _ENV_OUTPUT_SUBCOMMANDS:
-        return lines
-    return [
-        f"{line.split('=', 1)[0]}={REDACTED}" if "=" in line else line for line in lines
-    ]
+    return lines
 
 
 def object_extra(
     subcommand: str,
     *,
+    socket: str | os.PathLike[str] | None = None,
     session: str | None = None,
     window: str | None = None,
     pane: str | None = None,
@@ -381,6 +548,8 @@ def object_extra(
     ----------
     subcommand : str
         tmux subcommand the operation ran, e.g. ``"kill-pane"``.
+    socket : str | os.PathLike[str], optional
+        Socket name or path identifying the tmux server.
     session : str, optional
         Session name.
     window : str, optional
@@ -411,6 +580,8 @@ def object_extra(
     '3'
     """
     extra = {"tmux_subcommand": subcommand}
+    if socket is not None:
+        extra["tmux_socket"] = t.cast(str, _safe_scalar(str(socket)))
     for key, value in (
         ("tmux_session", session),
         ("tmux_window", window),

--- a/src/libtmux/_internal/log_context.py
+++ b/src/libtmux/_internal/log_context.py
@@ -79,6 +79,15 @@ _SETENV_SUBCOMMANDS = frozenset({"set-environment", "setenv"})
 _ENV_OUTPUT_SUBCOMMANDS = frozenset({"show-environment", "showenv"})
 """Subcommands whose stdout reports ``NAME=VALUE`` for environment variables."""
 
+_CONTENT_SUBCOMMANDS = frozenset(
+    {"capture-pane", "list-buffers", "lsb", "show-buffer", "showb"},
+)
+"""Subcommands whose stdout is terminal or buffer content rather than control data.
+
+Their output is whatever happened to be on a screen or in a paste buffer, and it
+already reaches the caller as a return value, so a record reports how much came
+back instead of what it was."""
+
 
 def _quote(token: str) -> str:
     r"""Quote one argument for a log record, keeping control characters out.
@@ -335,11 +344,20 @@ def redact_output(subcommand: str | None, lines: list[str]) -> list[str]:
     >>> redact_output("show-environment", ["-EDITOR"])
     ['-EDITOR']
 
+    Terminal and buffer content is dropped rather than redacted — the caller
+    already has it as a return value, and ``tmux_stdout_len`` still reports how
+    much there was:
+
+    >>> redact_output("capture-pane", ["$ whoami", "root"])
+    []
+
     Output from anything else is left alone, so a debug record stays useful:
 
     >>> redact_output("list-sessions", ["mysession: 1 windows"])
     ['mysession: 1 windows']
     """
+    if subcommand in _CONTENT_SUBCOMMANDS:
+        return []
     if subcommand not in _ENV_OUTPUT_SUBCOMMANDS:
         return lines
     return [

--- a/src/libtmux/_internal/log_context.py
+++ b/src/libtmux/_internal/log_context.py
@@ -1,562 +1,85 @@
-"""Structured logging context for :mod:`libtmux`.
-
-Pure helpers that turn a tmux command line, or a tmux object's identity, into
-the ``extra`` mapping libtmux attaches to its log records. Nothing here runs
-tmux or touches a logger, so the record schema is testable without a server.
-"""
+"""Structured logging context for tmux operations."""
 
 from __future__ import annotations
 
 import os
 import shlex
-import typing as t
-
-if t.TYPE_CHECKING:
-    from collections.abc import Sequence
-
-__all__ = (
-    "REDACTED",
-    "CommandContext",
-    "describe_command",
-    "object_extra",
-    "redact_output",
-)
-
-REDACTED = "REDACTED"
-"""Placeholder substituted for environment values in logged command lines.
-
-Chosen to survive quoting untouched, so quoting in a logged command line
-still marks a genuinely quoted argument.
-"""
-
-_COMMAND_CAP = 16384
-"""Practical rendered-character cap derived from tmux's message ceiling.
-
-Quoting and UTF-8 mean this is not an exact model of tmux's transport bytes.
-"""
-
-_CONTROL_CHARS = (
-    frozenset(chr(code) for code in range(0x20))
-    | frozenset(chr(code) for code in range(0x7F, 0xA0))
-    | {"\u2028", "\u2029"}
-)
-
-_CONTROL_ESCAPES = {
-    "\a": r"\a",
-    "\b": r"\b",
-    "\t": r"\t",
-    "\n": r"\n",
-    "\v": r"\v",
-    "\f": r"\f",
-    "\r": r"\r",
-    "\x1b": r"\e",
-}
+from collections.abc import Sequence
 
 _VALUE_FLAGS = frozenset("cfLST")
-"""tmux global flags that consume the argument after them.
-
-Mirrors the ``getopt`` string in tmux's ``tmux.c`` (``2c:CDdf:hlL:NqS:T:uUvV``).
-Every other global flag is a boolean and may be bundled, as in ``-2q``.
-"""
-
-_CANONICAL_SUBCOMMANDS = {
-    "new": "new-session",
-    "neww": "new-window",
-    "newp": "new-pane",
-    "popup": "display-popup",
-    "respawnp": "respawn-pane",
-    "respawnw": "respawn-window",
-    "splitw": "split-window",
-    "split-pane": "split-window",
-    "splitp": "split-window",
-    "setenv": "set-environment",
-    "showenv": "show-environment",
-    "capturep": "capture-pane",
-    "setb": "set-buffer",
-    "saveb": "save-buffer",
-    "showb": "show-buffer",
-    "lsb": "list-buffers",
-    "showmsgs": "show-messages",
-    "server-info": "show-messages",
-    "info": "show-messages",
-    "showphist": "show-prompt-history",
-}
-"""Relevant tmux aliases mapped to the policy command they execute."""
-
-_ENV_SUBCOMMANDS = frozenset(
-    {
-        "new-session",
-        "new-window",
-        "new-pane",
-        "display-popup",
-        "respawn-pane",
-        "respawn-window",
-        "split-window",
-    },
-)
-"""Subcommands whose ``-e`` carries a ``NAME=VALUE`` pair.
-
-``select-pane -e`` and ``copy-mode -e`` are booleans, so a bare ``-e`` is never
-read as an environment pair.
-"""
-
-_ENV_BOOLEAN_FLAGS = {
-    "new-session": frozenset("AdDEPX"),
-    "new-window": frozenset("abdkPS"),
-    "new-pane": frozenset("bdEfhIkLPvZ"),
-    "display-popup": frozenset("BCEkN"),
-    "respawn-pane": frozenset("k"),
-    "respawn-window": frozenset("k"),
-    "split-window": frozenset("bdEfhIkPvZ"),
-}
-"""Boolean flags that tmux permits before bundled value-taking ``-e``."""
-
-_SETENV_SUBCOMMANDS = frozenset({"set-environment"})
-"""Subcommands shaped ``[-Fhgru] [-t target] variable [value]``."""
-
-_ENV_OUTPUT_SUBCOMMANDS = frozenset({"show-environment"})
-"""Subcommands whose stdout reports ``NAME=VALUE`` for environment variables."""
-
-_BUFFER_INPUT_SUBCOMMANDS = frozenset({"set-buffer"})
-"""Subcommands whose positional data is caller-provided buffer content."""
-
-_CONTENT_SUBCOMMANDS = frozenset(
-    {
-        "capture-pane",
-        "list-buffers",
-        "save-buffer",
-        "show-buffer",
-        "show-messages",
-        "show-prompt-history",
-    },
-)
-"""Subcommands whose stdout is terminal or buffer content rather than control data.
-
-Their output is whatever happened to be on a screen or in a paste buffer, and it
-already reaches the caller as a return value, so a record reports how much came
-back instead of what it was."""
-
-_ENVIRONMENT_POLICY = "environment"
-_SETENV_POLICY = "set-environment"
-_BUFFER_INPUT_POLICY = "set-buffer"
-_SENSITIVE_OUTPUT_POLICY = "sensitive-output"
-
-_POLICY_BY_COMMAND = {
-    **dict.fromkeys(_ENV_SUBCOMMANDS, _ENVIRONMENT_POLICY),
-    **dict.fromkeys(_SETENV_SUBCOMMANDS, _SETENV_POLICY),
-    **dict.fromkeys(_BUFFER_INPUT_SUBCOMMANDS, _BUFFER_INPUT_POLICY),
-    **dict.fromkeys(_ENV_OUTPUT_SUBCOMMANDS, _SENSITIVE_OUTPUT_POLICY),
-    **dict.fromkeys(_CONTENT_SUBCOMMANDS, _SENSITIVE_OUTPUT_POLICY),
-}
-"""Canonical commands grouped by the log-safety policy they share."""
+"""tmux global flags that consume a value."""
 
 
-def _quote(token: str) -> str:
-    r"""Quote one argument for a log record, keeping control characters out.
-
-    A caller controls much of what reaches a tmux command line — the keys
-    :meth:`Pane.send_keys` sends, a start directory, a window command. A
-    newline among them would end the log line early and let the remainder pose
-    as a record of its own, so a token carrying control characters is rendered
-    with shell ANSI-C quoting. The result remains pasteable for ordinary tmux
-    arguments, but the log itself stays on one line.
-
-    Examples
-    --------
-    >>> _quote("plain")
-    'plain'
-
-    >>> _quote("has space")
-    "'has space'"
-
-    A newline cannot break out of the record:
-
-    >>> _quote("echo hi\nCRITICAL forged")
-    "$'echo hi\\nCRITICAL forged'"
-
-    Neither can an escape sequence reach the terminal reading the log:
-
-    >>> _quote("\x1b[31mred")
-    "$'\\e[31mred'"
-    """
-    if not _CONTROL_CHARS.intersection(token):
-        return shlex.quote(token)
-
-    escaped = []
-    for char in token:
-        if char in {"\\", "'"}:
-            escaped.append("\\" + char)
-        elif char in _CONTROL_ESCAPES:
-            escaped.append(_CONTROL_ESCAPES[char])
-        elif char in _CONTROL_CHARS:
-            codepoint = ord(char)
-            if codepoint <= 0x7F:
-                escaped.append(f"\\x{codepoint:02x}")
-            elif codepoint <= 0xFFFF:
-                escaped.append(f"\\u{codepoint:04x}")
-            else:
-                escaped.append(f"\\U{codepoint:08x}")
-        else:
-            escaped.append(char)
-    return "$'" + "".join(escaped) + "'"
+def _safe_scalar(value: str) -> str:
+    """Keep printable identities readable and escape control characters."""
+    return value if value.isprintable() else ascii(value)
 
 
-def _canonical_subcommand(subcommand: str | None) -> str | None:
-    """Return the command name used for logging policy decisions.
-
-    Examples
-    --------
-    >>> _canonical_subcommand("new")
-    'new-session'
-
-    >>> _canonical_subcommand("list-sessions")
-    'list-sessions'
-    """
-    if subcommand is None:
-        return None
-    return _CANONICAL_SUBCOMMANDS.get(subcommand, subcommand)
+def _quote(value: str) -> str:
+    """Quote a printable operation token or escape it as an ASCII literal."""
+    return shlex.quote(value) if value.isprintable() else ascii(value)
 
 
-def _policy_for_subcommand(subcommand: str | None) -> str | None:
-    """Return the safety policy for an exact command or tmux abbreviation.
+def command_extra(argv: Sequence[str]) -> dict[str, str]:
+    """Describe a tmux operation without logging its operands.
 
-    A prefix is safe to classify when every protected command it matches uses
-    the same policy. Prefixes spanning incompatible argument grammars remain
-    unclassified.
-
-    Examples
-    --------
-    >>> _policy_for_subcommand("new-")
-    'environment'
-
-    >>> _policy_for_subcommand("set-") is None
-    True
-    """
-    canonical_subcommand = _canonical_subcommand(subcommand)
-    if canonical_subcommand is None:
-        return None
-    exact_policy = _POLICY_BY_COMMAND.get(canonical_subcommand)
-    if exact_policy is not None:
-        return exact_policy
-
-    policies = {
-        policy
-        for command, policy in _POLICY_BY_COMMAND.items()
-        if command.startswith(canonical_subcommand)
-    }
-    return policies.pop() if len(policies) == 1 else None
-
-
-def _safe_scalar(value: str | None) -> str | None:
-    r"""Quote control characters while preserving ordinary field values.
-
-    Examples
-    --------
-    >>> _safe_scalar("server")
-    'server'
-
-    >>> _safe_scalar("safe\nERROR forged")
-    "$'safe\\nERROR forged'"
-    """
-    if value is None or not _CONTROL_CHARS.intersection(value):
-        return value
-    return _quote(value)
-
-
-class CommandContext(t.NamedTuple):
-    """Logging context derived from a tmux command line.
-
-    Attributes
-    ----------
-    subcommand : str | None
-        tmux subcommand, e.g. ``"new-session"``. ``None`` when the command line
-        carries only global flags, as ``tmux -V`` does.
-    socket : str | None
-        Socket name (``-L``) or path (``-S``) identifying which tmux server the
-        command addressed. ``None`` when tmux would use its default socket.
-    command : str
-        Shell-quoted command line with environment values replaced by
-        :data:`REDACTED`. A line longer than :data:`_COMMAND_CAP` is shortened
-        and ends in an ellipsis.
-    """
-
-    subcommand: str | None
-    socket: str | None
-    command: str
-
-
-def describe_command(argv: Sequence[str]) -> CommandContext:
-    """Derive logging context from a tmux command line.
-
-    Parameters
-    ----------
-    argv : Sequence[str]
-        Full argument vector, beginning with the tmux binary.
-
-    Returns
-    -------
-    CommandContext
-        Subcommand, socket, and a redacted command string.
-
-    Examples
-    --------
-    Global flags are skipped to reach the subcommand:
-
-    >>> describe_command(["tmux", "-Lmysock", "new-session", "-d"]).subcommand
-    'new-session'
-
-    >>> describe_command(["tmux", "-Lmysock", "new-session", "-d"]).socket
-    'mysock'
-
-    Flags that take a value are understood in both joined and separated form,
-    so the value is never mistaken for the subcommand:
-
-    >>> describe_command(["tmux", "-L", "mysock", "kill-server"]).subcommand
-    'kill-server'
-
-    A command line with no subcommand reports ``None``:
-
-    >>> describe_command(["tmux", "-V"]).subcommand is None
-    True
-
-    Environment values are redacted, and their names kept:
-
-    >>> describe_command(
-    ...     ["tmux", "new-session", "-eAPI_TOKEN=hunter2"]
-    ... ).command
-    'tmux new-session -eAPI_TOKEN=REDACTED'
+    The rendered compatibility field contains only the executable, effective
+    socket selection, and subcommand. A marker reports how many arguments after
+    the subcommand were omitted. This operation/parameter split makes unknown
+    tmux commands safe without knowing their argument grammar.
     """
     tokens = [str(arg) for arg in argv]
+    executable = tokens[0] if tokens else "tmux"
     subcommand: str | None = None
+    subcommand_index = len(tokens)
     socket_label: str | None = None
     socket_path: str | None = None
-    subcommand_index = len(tokens)
 
     index = 1
     while index < len(tokens):
         token = tokens[index]
-        body = token[1:]
-        if not token.startswith("-") or not body:
+        if token == "--":
+            index += 1
+            if index < len(tokens):
+                subcommand = tokens[index]
+                subcommand_index = index
+            break
+        if not token.startswith("-") or token == "-":
             subcommand = token
             subcommand_index = index
             break
-        # Booleans bundle, so a value flag can sit anywhere in the token and
-        # takes the remainder of it — or the next token when it ends there.
-        takes_next_token = False
-        for position, flag in enumerate(body):
+
+        takes_next = False
+        for position, flag in enumerate(token[1:]):
             if flag not in _VALUE_FLAGS:
                 continue
-            joined_value = body[position + 1 :]
-            value = joined_value or (
-                tokens[index + 1] if index + 1 < len(tokens) else None
-            )
+            attached = token[position + 2 :]
+            value = attached or (tokens[index + 1] if index + 1 < len(tokens) else None)
             if flag == "L":
                 socket_label = value
             elif flag == "S":
                 socket_path = value
-            takes_next_token = not joined_value
+            takes_next = not attached
             break
-        index += 2 if takes_next_token else 1
+        index += 2 if takes_next else 1
 
-    command = " ".join(
-        _quote(token) for token in _redact(tokens, subcommand, subcommand_index)
-    )
-    return CommandContext(
-        subcommand=subcommand,
-        socket=_safe_scalar(socket_path if socket_path is not None else socket_label),
-        command=(
-            command
-            if len(command) <= _COMMAND_CAP
-            else command[: _COMMAND_CAP - 1] + "\N{HORIZONTAL ELLIPSIS}"
-        ),
-    )
+    socket_flag = "S" if socket_path is not None else "L"
+    socket = socket_path if socket_path is not None else socket_label
+    operation = [_quote(executable)]
+    if socket is not None:
+        operation.extend((f"-{socket_flag}", _quote(socket)))
+    if subcommand is not None:
+        operation.append(_quote(subcommand))
+        omitted = len(tokens) - subcommand_index - 1
+        if omitted:
+            operation.append(f"<{omitted} arguments omitted>")
 
-
-def _redact(
-    tokens: list[str],
-    subcommand: str | None,
-    subcommand_index: int,
-) -> list[str]:
-    """Return ``tokens`` with environment values replaced.
-
-    Examples
-    --------
-    >>> _redact(["tmux", "new-session", "-eK=v"], "new-session", 1)
-    ['tmux', 'new-session', '-eK=REDACTED']
-
-    A boolean ``-e`` keeps the argument that follows it:
-
-    >>> _redact(["tmux", "select-pane", "-e", "-t%1"], "select-pane", 1)
-    ['tmux', 'select-pane', '-e', '-t%1']
-    """
-    policy = _policy_for_subcommand(subcommand)
-    if policy == _SETENV_POLICY:
-        return _redact_set_environment(tokens, subcommand_index)
-    if policy == _BUFFER_INPUT_POLICY:
-        return _redact_set_buffer(tokens, subcommand_index)
-
-    redacted = list(tokens)
-    separated_pairs = policy == _ENVIRONMENT_POLICY
-    canonical_subcommand = _canonical_subcommand(subcommand)
-    matching_flags = [
-        flags
-        for command, flags in _ENV_BOOLEAN_FLAGS.items()
-        if canonical_subcommand is not None
-        and (
-            command == canonical_subcommand or command.startswith(canonical_subcommand)
-        )
-    ]
-    boolean_flags = frozenset().union(*matching_flags)
-    index = subcommand_index + 1
-    while index < len(redacted):
-        token = redacted[index]
-        if separated_pairs and token.startswith("-"):
-            options = token[1:]
-            for position, flag in enumerate(options):
-                if flag == "e":
-                    attached = options[position + 1 :]
-                    if "=" in attached:
-                        name = attached.split("=", 1)[0]
-                        redacted[index] = f"-{options[: position + 1]}{name}={REDACTED}"
-                    elif not attached and index + 1 < len(redacted):
-                        following = redacted[index + 1]
-                        if "=" in following:
-                            redacted[index + 1] = (
-                                f"{following.split('=', 1)[0]}={REDACTED}"
-                            )
-                        index += 1
-                    break
-                if flag not in boolean_flags:
-                    break
-        index += 1
-    return redacted
-
-
-def _redact_set_environment(tokens: list[str], subcommand_index: int) -> list[str]:
-    """Return ``tokens`` with a ``set-environment`` value replaced.
-
-    tmux reads ``set-environment [-Fhgru] [-t target-session] variable [value]``,
-    so only a trailing second positional is a value worth hiding.
-
-    Examples
-    --------
-    >>> _redact_set_environment(["tmux", "set-environment", "K", "v"], 1)
-    ['tmux', 'set-environment', 'K', 'REDACTED']
-
-    Unsetting passes a name and no value, which stays visible:
-
-    >>> _redact_set_environment(["tmux", "set-environment", "-u", "K"], 1)
-    ['tmux', 'set-environment', '-u', 'K']
-    """
-    redacted = list(tokens)
-    index = subcommand_index + 1
-    while index < len(redacted):
-        token = redacted[index]
-        if token == "--":
-            index += 1
-            break
-        if token.startswith("-") and len(token) > 1:
-            takes_next = False
-            valid_option = True
-            for position, flag in enumerate(token[1:]):
-                if flag == "t":
-                    takes_next = position == len(token) - 2
-                    break
-                if flag not in "Fhgru":
-                    valid_option = False
-                    break
-            if valid_option:
-                index += 2 if takes_next else 1
-                continue
-        break
-
-    if index + 1 < len(redacted):
-        redacted[index + 1] = REDACTED
-    return redacted
-
-
-def _redact_set_buffer(tokens: list[str], subcommand_index: int) -> list[str]:
-    """Return ``tokens`` with ``set-buffer`` data replaced.
-
-    Examples
-    --------
-    >>> _redact_set_buffer(["tmux", "set-buffer", "-b", "name", "data"], 1)
-    ['tmux', 'set-buffer', '-b', 'name', 'REDACTED']
-
-    A command that only selects a buffer has no data to redact:
-
-    >>> _redact_set_buffer(["tmux", "set-buffer", "-b", "name"], 1)
-    ['tmux', 'set-buffer', '-b', 'name']
-    """
-    redacted = list(tokens)
-    index = subcommand_index + 1
-    while index < len(redacted):
-        token = redacted[index]
-        if token == "--":
-            index += 1
-            break
-        if token.startswith("-") and len(token) > 1:
-            takes_next = False
-            valid_option = True
-            for position, flag in enumerate(token[1:]):
-                if flag in "bnt":
-                    takes_next = position == len(token) - 2
-                    break
-                if flag not in "aw":
-                    valid_option = False
-                    break
-            if valid_option:
-                index += 2 if takes_next else 1
-                continue
-        break
-
-    if index < len(redacted):
-        redacted[index] = REDACTED
-    return redacted
-
-
-def redact_output(subcommand: str | None, lines: list[str]) -> list[str]:
-    """Hide values in output that reports environment variables.
-
-    Redacting what libtmux sends is only half of it: ``show-environment`` hands
-    the same values straight back on stdout, so
-    :meth:`~libtmux.common.EnvironmentMixin.getenv` would log a secret that
-    :meth:`~libtmux.common.EnvironmentMixin.set_environment` was careful not to.
-
-    Parameters
-    ----------
-    subcommand : str | None
-        tmux subcommand that produced ``lines``.
-    lines : list[str]
-        Output lines as tmux wrote them.
-
-    Returns
-    -------
-    list[str]
-        Safe lines for a log record. Sensitive command output is withheld.
-
-    Examples
-    --------
-    >>> redact_output("show-environment", ["EDITOR=vim", "continued value"])
-    []
-
-    Terminal and buffer content is dropped rather than redacted — the caller
-    already has it as a return value, and ``tmux_stdout_len`` still reports how
-    much there was:
-
-    >>> redact_output("capture-pane", ["$ whoami", "root"])
-    []
-
-    Output from anything else is left alone, so a debug record stays useful:
-
-    >>> redact_output("list-sessions", ["mysession: 1 windows"])
-    ['mysession: 1 windows']
-    """
-    # Dropping beats redacting: a subcommand in both sets returns content, and
-    # content is withheld whole rather than pattern-matched.
-    if _policy_for_subcommand(subcommand) == _SENSITIVE_OUTPUT_POLICY:
-        return []
-    return lines
+    extra = {"tmux_cmd": " ".join(operation)}
+    if subcommand is not None:
+        extra["tmux_subcommand"] = _safe_scalar(subcommand)
+    if socket is not None:
+        extra["tmux_socket"] = _safe_scalar(socket)
+    return extra
 
 
 def object_extra(
@@ -568,49 +91,10 @@ def object_extra(
     pane: str | None = None,
     target: str | int | None = None,
 ) -> dict[str, str]:
-    """Build the ``extra`` mapping for a tmux object lifecycle record.
-
-    Keeps the schema's two invariants in one place: every value is a ``str``,
-    and a key absent from tmux is absent from the record rather than ``None``.
-
-    Parameters
-    ----------
-    subcommand : str
-        tmux subcommand the operation ran, e.g. ``"kill-pane"``.
-    socket : str | os.PathLike[str], optional
-        Socket name or path identifying the tmux server.
-    session : str, optional
-        Session name.
-    window : str, optional
-        Window name or index.
-    pane : str, optional
-        Pane identifier.
-    target : str | int, optional
-        tmux target specifier the operation addressed.
-
-    Returns
-    -------
-    dict[str, str]
-        Mapping suitable for a logger's ``extra`` argument.
-
-    Examples
-    --------
-    >>> object_extra("kill-pane", pane="%1", target="%1")
-    {'tmux_subcommand': 'kill-pane', 'tmux_pane': '%1', 'tmux_target': '%1'}
-
-    Omitted context stays out of the record:
-
-    >>> object_extra("kill-server")
-    {'tmux_subcommand': 'kill-server'}
-
-    Non-string targets are coerced, so a formatter never sees an ``int``:
-
-    >>> object_extra("kill-window", target=3)["tmux_target"]
-    '3'
-    """
+    """Build structured context for a tmux object lifecycle record."""
     extra = {"tmux_subcommand": subcommand}
     if socket is not None:
-        extra["tmux_socket"] = t.cast(str, _safe_scalar(str(socket)))
+        extra["tmux_socket"] = _safe_scalar(str(socket))
     for key, value in (
         ("tmux_session", session),
         ("tmux_window", window),

--- a/src/libtmux/_internal/log_context.py
+++ b/src/libtmux/_internal/log_context.py
@@ -77,6 +77,8 @@ _CANONICAL_SUBCOMMANDS = {
     "showb": "show-buffer",
     "lsb": "list-buffers",
     "showmsgs": "show-messages",
+    "server-info": "show-messages",
+    "info": "show-messages",
     "showphist": "show-prompt-history",
 }
 """Relevant tmux aliases mapped to the policy command they execute."""
@@ -97,6 +99,17 @@ _ENV_SUBCOMMANDS = frozenset(
 ``select-pane -e`` and ``copy-mode -e`` are booleans, so a bare ``-e`` is never
 read as an environment pair.
 """
+
+_ENV_BOOLEAN_FLAGS = {
+    "new-session": frozenset("AdDEPX"),
+    "new-window": frozenset("abdkPS"),
+    "new-pane": frozenset("bdEfhIkLPvZ"),
+    "display-popup": frozenset("BCEkN"),
+    "respawn-pane": frozenset("k"),
+    "respawn-window": frozenset("k"),
+    "split-window": frozenset("bdEfhIkPvZ"),
+}
+"""Boolean flags that tmux permits before bundled value-taking ``-e``."""
 
 _SETENV_SUBCOMMANDS = frozenset({"set-environment"})
 """Subcommands shaped ``[-Fhgru] [-t target] variable [value]``."""
@@ -384,21 +397,37 @@ def _redact(
 
     redacted = list(tokens)
     separated_pairs = policy == _ENVIRONMENT_POLICY
+    canonical_subcommand = _canonical_subcommand(subcommand)
+    matching_flags = [
+        flags
+        for command, flags in _ENV_BOOLEAN_FLAGS.items()
+        if canonical_subcommand is not None
+        and (
+            command == canonical_subcommand or command.startswith(canonical_subcommand)
+        )
+    ]
+    boolean_flags = frozenset().union(*matching_flags)
     index = subcommand_index + 1
     while index < len(redacted):
         token = redacted[index]
-        if (
-            policy == _ENVIRONMENT_POLICY
-            and token.startswith("-e")
-            and "=" in token[2:]
-        ):
-            name = token[2:].split("=", 1)[0]
-            redacted[index] = f"-e{name}={REDACTED}"
-        elif separated_pairs and token == "-e" and index + 1 < len(redacted):
-            following = redacted[index + 1]
-            if "=" in following:
-                redacted[index + 1] = f"{following.split('=', 1)[0]}={REDACTED}"
-            index += 1
+        if separated_pairs and token.startswith("-"):
+            options = token[1:]
+            for position, flag in enumerate(options):
+                if flag == "e":
+                    attached = options[position + 1 :]
+                    if "=" in attached:
+                        name = attached.split("=", 1)[0]
+                        redacted[index] = f"-{options[: position + 1]}{name}={REDACTED}"
+                    elif not attached and index + 1 < len(redacted):
+                        following = redacted[index + 1]
+                        if "=" in following:
+                            redacted[index + 1] = (
+                                f"{following.split('=', 1)[0]}={REDACTED}"
+                            )
+                        index += 1
+                    break
+                if flag not in boolean_flags:
+                    break
         index += 1
     return redacted
 

--- a/src/libtmux/_internal/query_list.py
+++ b/src/libtmux/_internal/query_list.py
@@ -102,11 +102,7 @@ def keygetter(
                 dct = getattr(dct, sub_field)
 
     except Exception:
-        logger.debug(
-            "key lookup failed for path: %s",
-            path,
-            exc_info=True,
-        )
+        logger.debug("key lookup failed for path: %s", path)
         return None
 
     return dct
@@ -146,11 +142,7 @@ def parse_lookup(
             if field_name is not None:
                 return keygetter(obj, field_name)
     except Exception:
-        logger.debug(
-            "lookup parsing failed for path: %s",
-            path,
-            exc_info=True,
-        )
+        logger.debug("lookup parsing failed for path: %s", path)
     return None
 
 

--- a/src/libtmux/_internal/query_list.py
+++ b/src/libtmux/_internal/query_list.py
@@ -102,7 +102,7 @@ def keygetter(
                 dct = getattr(dct, sub_field)
 
     except Exception:
-        logger.debug("key lookup failed for path: %s", path)
+        logger.debug("key lookup failed for path: %r", path)
         return None
 
     return dct
@@ -142,7 +142,7 @@ def parse_lookup(
             if field_name is not None:
                 return keygetter(obj, field_name)
     except Exception:
-        logger.debug("lookup parsing failed for path: %s", path)
+        logger.debug("lookup parsing failed for path: %r", path)
     return None
 
 

--- a/src/libtmux/client.py
+++ b/src/libtmux/client.py
@@ -8,7 +8,6 @@ libtmux.client
 from __future__ import annotations
 
 import dataclasses
-import logging
 import typing as t
 
 from libtmux import exc
@@ -19,9 +18,6 @@ if t.TYPE_CHECKING:
     from libtmux.server import Server
     from libtmux.session import Session
     from libtmux.window import Window
-
-
-logger = logging.getLogger(__name__)
 
 
 @dataclasses.dataclass()

--- a/src/libtmux/common.py
+++ b/src/libtmux/common.py
@@ -25,6 +25,8 @@ if t.TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+_UNUSABLE_TMUX_ERRNOS = frozenset({errno.EACCES, errno.ENOENT, errno.ENOEXEC})
+
 #: Minimum version of tmux required to run libtmux
 TMUX_MIN_VERSION = "3.2a"
 
@@ -35,6 +37,12 @@ SessionDict = dict[str, t.Any]
 WindowDict = dict[str, t.Any]
 WindowOptionDict = dict[str, t.Any]
 PaneDict = dict[str, t.Any]
+
+
+def _raise_if_unusable_tmux(error: OSError) -> None:
+    """Translate an unavailable executable while preserving its OS diagnostic."""
+    if error.errno in _UNUSABLE_TMUX_ERRNOS:
+        raise exc.TmuxCommandNotFound(str(error)) from error
 
 
 class CmdProtocol(t.Protocol):
@@ -303,7 +311,8 @@ class tmux_cmd:
         self.cmd = cmd
 
         if not resolved:
-            raise exc.TmuxCommandNotFound
+            msg = "tmux executable not found on PATH"
+            raise exc.TmuxCommandNotFound(msg)
 
         log_extra = command_extra(cmd) if logger.isEnabledFor(logging.DEBUG) else None
         if log_extra is not None:
@@ -319,8 +328,7 @@ class tmux_cmd:
                 errors="backslashreplace",
             )
         except OSError as error:
-            if error.errno in {errno.EACCES, errno.ENOENT, errno.ENOEXEC}:
-                raise exc.TmuxCommandNotFound from None
+            _raise_if_unusable_tmux(error)
             raise exc.LibTmuxException(str(error)) from error
 
         stdout, stderr = self.process.communicate()

--- a/src/libtmux/common.py
+++ b/src/libtmux/common.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import functools
 import logging
 import re
-import shlex
 import shutil
 import subprocess
 import sys
@@ -18,12 +17,16 @@ import typing as t
 
 from . import exc
 from ._compat import LooseVersion
+from ._internal.log_context import describe_command
 
 if t.TYPE_CHECKING:
     from collections.abc import Callable
 
 logger = logging.getLogger(__name__)
 
+
+#: Maximum stdout/stderr lines attached to a debug record
+_LOG_LINE_CAP = 100
 
 #: Minimum version of tmux required to run libtmux
 TMUX_MIN_VERSION = "3.2a"
@@ -250,6 +253,12 @@ def raise_if_stderr(proc: tmux_cmd, subcommand: str) -> None:
     originating tmux subcommand so downstream consumers (e.g. libtmux-mcp's
     ``handle_tool_errors``) keep the "which tmux command failed" context.
 
+    Logs one ``ERROR`` record before raising. The record carries the exit code,
+    socket, and command line, which the exception message does not, so an
+    accessor that swallows the exception — :attr:`Server.sessions` and the
+    other lenient list accessors — still leaves a trace of why it came back
+    empty.
+
     Parameters
     ----------
     proc : :class:`tmux_cmd`
@@ -273,11 +282,23 @@ def raise_if_stderr(proc: tmux_cmd, subcommand: str) -> None:
 
     .. versionadded:: 0.57
     """
-    if proc.stderr:
-        raise exc.LibTmuxException(
-            "\n".join(proc.stderr),
-            subcommand=subcommand,
-        )
+    if not proc.stderr:
+        return
+
+    logger.error(
+        "tmux command failed",
+        extra={
+            **proc._log_extra,
+            "tmux_subcommand": subcommand,
+            "tmux_exit_code": proc.returncode,
+            "tmux_stderr": proc.stderr[:_LOG_LINE_CAP],
+            "tmux_stderr_len": len(proc.stderr),
+        },
+    )
+    raise exc.LibTmuxException(
+        "\n".join(proc.stderr),
+        subcommand=subcommand,
+    )
 
 
 class tmux_cmd:
@@ -321,11 +342,7 @@ class tmux_cmd:
         self.cmd = cmd
 
         if logger.isEnabledFor(logging.DEBUG):
-            cmd_str = shlex.join(cmd)
-            logger.debug(
-                "tmux command dispatched",
-                extra={"tmux_cmd": cmd_str},
-            )
+            logger.debug("tmux command dispatched", extra=self._log_extra)
 
         try:
             self.process = subprocess.Popen(
@@ -343,9 +360,7 @@ class tmux_cmd:
         except Exception:
             logger.error(  # noqa: TRY400
                 "tmux subprocess failed",
-                extra={
-                    "tmux_cmd": shlex.join(cmd),
-                },
+                extra=self._log_extra,
             )
             raise
 
@@ -368,14 +383,30 @@ class tmux_cmd:
             logger.debug(
                 "tmux command completed",
                 extra={
-                    "tmux_cmd": shlex.join(cmd),
+                    **self._log_extra,
                     "tmux_exit_code": self.returncode,
-                    "tmux_stdout": self.stdout[:100],
-                    "tmux_stderr": self.stderr[:100],
+                    "tmux_stdout": self.stdout[:_LOG_LINE_CAP],
+                    "tmux_stderr": self.stderr[:_LOG_LINE_CAP],
                     "tmux_stdout_len": len(self.stdout),
                     "tmux_stderr_len": len(self.stderr),
                 },
             )
+
+    @functools.cached_property
+    def _log_extra(self) -> dict[str, t.Any]:
+        """Logging context every record for this command shares.
+
+        Derived once from :attr:`cmd`, so the command line a record reports is
+        the same string whichever layer emitted it, with environment values
+        already redacted.
+        """
+        context = describe_command(self.cmd)
+        extra: dict[str, t.Any] = {"tmux_cmd": context.command}
+        if context.subcommand is not None:
+            extra["tmux_subcommand"] = context.subcommand
+        if context.socket is not None:
+            extra["tmux_socket"] = context.socket
+        return extra
 
 
 class _TmuxVersionUnavailable(Exception):

--- a/src/libtmux/common.py
+++ b/src/libtmux/common.py
@@ -7,6 +7,7 @@ libtmux.common
 
 from __future__ import annotations
 
+import errno
 import functools
 import logging
 import re
@@ -317,8 +318,10 @@ class tmux_cmd:
                 encoding="utf-8",
                 errors="backslashreplace",
             )
-        except OSError:
-            raise exc.TmuxCommandNotFound from None
+        except OSError as error:
+            if error.errno in {errno.EACCES, errno.ENOENT, errno.ENOEXEC}:
+                raise exc.TmuxCommandNotFound from None
+            raise exc.LibTmuxException(str(error)) from error
 
         stdout, stderr = self.process.communicate()
         returncode = self.process.returncode

--- a/src/libtmux/common.py
+++ b/src/libtmux/common.py
@@ -18,7 +18,7 @@ import typing as t
 
 from . import exc
 from ._compat import LooseVersion
-from ._internal.log_context import command_extra
+from ._internal.log_context import LOG_OUTPUT_LINE_LIMIT, command_extra
 
 if t.TYPE_CHECKING:
     from collections.abc import Callable
@@ -347,6 +347,8 @@ class tmux_cmd:
                 extra={
                     **log_extra,
                     "tmux_exit_code": self.returncode,
+                    "tmux_stdout": self.stdout[:LOG_OUTPUT_LINE_LIMIT],
+                    "tmux_stderr": self.stderr[:LOG_OUTPUT_LINE_LIMIT],
                     "tmux_stdout_len": len(self.stdout),
                     "tmux_stderr_len": len(self.stderr),
                 },

--- a/src/libtmux/common.py
+++ b/src/libtmux/common.py
@@ -7,7 +7,6 @@ libtmux.common
 
 from __future__ import annotations
 
-import contextvars
 import functools
 import logging
 import re
@@ -24,12 +23,6 @@ if t.TYPE_CHECKING:
     from collections.abc import Callable
 
 logger = logging.getLogger(__name__)
-
-_log_subprocess_errors = contextvars.ContextVar(
-    "libtmux_log_subprocess_errors",
-    default=True,
-)
-
 
 #: Maximum stdout/stderr lines attached to a debug record
 _LOG_LINE_CAP = 100
@@ -115,7 +108,6 @@ class EnvironmentMixin:
         cmd = self.cmd(*args)
 
         if cmd.stderr:
-            _log_if_stderr(cmd, "set-environment")
             msg = f"tmux set-environment stderr: {cmd.stderr}"
             raise ValueError(msg)
 
@@ -140,7 +132,6 @@ class EnvironmentMixin:
         cmd = self.cmd(*args)
 
         if cmd.stderr:
-            _log_if_stderr(cmd, "set-environment")
             msg = f"tmux set-environment stderr: {cmd.stderr}"
             raise ValueError(msg)
 
@@ -165,7 +156,6 @@ class EnvironmentMixin:
         cmd = self.cmd(*args)
 
         if cmd.stderr:
-            _log_if_stderr(cmd, "set-environment")
             msg = f"tmux set-environment stderr: {cmd.stderr}"
             raise ValueError(msg)
 
@@ -239,53 +229,6 @@ class EnvironmentMixin:
         return opts_dict.get(name)
 
 
-def _log_if_stderr(
-    proc: tmux_cmd,
-    subcommand: str | None,
-    *,
-    stacklevel: int = 2,
-) -> bool:
-    """Log one standard failure record when ``proc`` carries stderr.
-
-    Parameters
-    ----------
-    proc : :class:`tmux_cmd`
-        Result of a tmux command.
-    subcommand : str | None
-        tmux subcommand, when the command line contains one.
-    stacklevel : int, optional
-        Logging call depth needed to identify the operation wrapper.
-
-    Returns
-    -------
-    bool
-        Whether stderr was present and a record was emitted.
-
-    Examples
-    --------
-    >>> proc = session.cmd("display-message", "-p", "#{session_id}")
-    >>> _log_if_stderr(proc, "display-message")
-    False
-    """
-    if not proc.stderr:
-        return False
-
-    extra: dict[str, t.Any] = {
-        **proc._log_extra,
-        "tmux_exit_code": proc.returncode,
-        "tmux_stderr": proc.stderr[:_LOG_LINE_CAP],
-        "tmux_stderr_len": len(proc.stderr),
-    }
-    if subcommand is not None:
-        extra["tmux_subcommand"] = subcommand
-    logger.error(
-        "tmux command failed",
-        extra=extra,
-        stacklevel=stacklevel,
-    )
-    return True
-
-
 def raise_if_stderr(proc: tmux_cmd, subcommand: str) -> None:
     """Raise :exc:`LibTmuxException` tagged with the tmux subcommand on stderr.
 
@@ -293,12 +236,6 @@ def raise_if_stderr(proc: tmux_cmd, subcommand: str) -> None:
     pattern scattered across the wrappers. Tags the exception with the
     originating tmux subcommand so downstream consumers (e.g. libtmux-mcp's
     ``handle_tool_errors``) keep the "which tmux command failed" context.
-
-    Logs one ``ERROR`` record before raising. The record carries the exit code,
-    socket, and command line, which the exception message does not, so an
-    accessor that swallows the exception — :attr:`Server.sessions` and the
-    other lenient list accessors — still leaves a trace of why it came back
-    empty.
 
     Parameters
     ----------
@@ -323,13 +260,11 @@ def raise_if_stderr(proc: tmux_cmd, subcommand: str) -> None:
 
     .. versionadded:: 0.57
     """
-    if not _log_if_stderr(proc, subcommand, stacklevel=3):
-        return
-
-    raise exc.LibTmuxException(
-        "\n".join(proc.stderr),
-        subcommand=subcommand,
-    )
+    if proc.stderr:
+        raise exc.LibTmuxException(
+            "\n".join(proc.stderr),
+            subcommand=subcommand,
+        )
 
 
 class tmux_cmd:
@@ -370,8 +305,6 @@ class tmux_cmd:
         self.cmd = cmd
 
         if not resolved:
-            if _log_subprocess_errors.get():
-                logger.error("tmux subprocess failed", extra=self._log_extra)
             raise exc.TmuxCommandNotFound
 
         if logger.isEnabledFor(logging.DEBUG):
@@ -389,11 +322,6 @@ class tmux_cmd:
             stdout, stderr = self.process.communicate()
             returncode = self.process.returncode
         except Exception as error:
-            if _log_subprocess_errors.get():
-                logger.error(  # noqa: TRY400
-                    "tmux subprocess failed",
-                    extra=self._log_extra,
-                )
             if isinstance(error, FileNotFoundError):
                 raise exc.TmuxCommandNotFound from None
             raise
@@ -494,7 +422,6 @@ def _query_version(tmux_bin: str | None = None) -> str:
     if proc.stderr:
         if proc.stderr[0] == "tmux: unknown option -- V":
             raise _TmuxVersionUnavailable
-        _log_if_stderr(proc, None)
         raise exc.VersionTooLow(proc.stderr)
 
     return proc.stdout[0].split("tmux ")[1]

--- a/src/libtmux/common.py
+++ b/src/libtmux/common.py
@@ -294,6 +294,10 @@ def raise_if_stderr(proc: tmux_cmd, subcommand: str) -> None:
             "tmux_stderr": proc.stderr[:_LOG_LINE_CAP],
             "tmux_stderr_len": len(proc.stderr),
         },
+        # Attribute the record to the wrapper that ran the command, not to this
+        # helper. Every one of its call sites would otherwise report the same
+        # file and line.
+        stacklevel=2,
     )
     raise exc.LibTmuxException(
         "\n".join(proc.stderr),

--- a/src/libtmux/common.py
+++ b/src/libtmux/common.py
@@ -109,11 +109,7 @@ class EnvironmentMixin:
         cmd = self.cmd(*args)
 
         if cmd.stderr:
-            (
-                cmd.stderr[0]
-                if isinstance(cmd.stderr, list) and len(cmd.stderr) == 1
-                else cmd.stderr
-            )
+            _log_if_stderr(cmd, "set-environment")
             msg = f"tmux set-environment stderr: {cmd.stderr}"
             raise ValueError(msg)
 
@@ -138,11 +134,7 @@ class EnvironmentMixin:
         cmd = self.cmd(*args)
 
         if cmd.stderr:
-            (
-                cmd.stderr[0]
-                if isinstance(cmd.stderr, list) and len(cmd.stderr) == 1
-                else cmd.stderr
-            )
+            _log_if_stderr(cmd, "set-environment")
             msg = f"tmux set-environment stderr: {cmd.stderr}"
             raise ValueError(msg)
 
@@ -167,11 +159,7 @@ class EnvironmentMixin:
         cmd = self.cmd(*args)
 
         if cmd.stderr:
-            (
-                cmd.stderr[0]
-                if isinstance(cmd.stderr, list) and len(cmd.stderr) == 1
-                else cmd.stderr
-            )
+            _log_if_stderr(cmd, "set-environment")
             msg = f"tmux set-environment stderr: {cmd.stderr}"
             raise ValueError(msg)
 
@@ -245,6 +233,53 @@ class EnvironmentMixin:
         return opts_dict.get(name)
 
 
+def _log_if_stderr(
+    proc: tmux_cmd,
+    subcommand: str | None,
+    *,
+    stacklevel: int = 2,
+) -> bool:
+    """Log one standard failure record when ``proc`` carries stderr.
+
+    Parameters
+    ----------
+    proc : :class:`tmux_cmd`
+        Result of a tmux command.
+    subcommand : str | None
+        tmux subcommand, when the command line contains one.
+    stacklevel : int, optional
+        Logging call depth needed to identify the operation wrapper.
+
+    Returns
+    -------
+    bool
+        Whether stderr was present and a record was emitted.
+
+    Examples
+    --------
+    >>> proc = session.cmd("display-message", "-p", "#{session_id}")
+    >>> _log_if_stderr(proc, "display-message")
+    False
+    """
+    if not proc.stderr:
+        return False
+
+    extra: dict[str, t.Any] = {
+        **proc._log_extra,
+        "tmux_exit_code": proc.returncode,
+        "tmux_stderr": proc.stderr[:_LOG_LINE_CAP],
+        "tmux_stderr_len": len(proc.stderr),
+    }
+    if subcommand is not None:
+        extra["tmux_subcommand"] = subcommand
+    logger.error(
+        "tmux command failed",
+        extra=extra,
+        stacklevel=stacklevel,
+    )
+    return True
+
+
 def raise_if_stderr(proc: tmux_cmd, subcommand: str) -> None:
     """Raise :exc:`LibTmuxException` tagged with the tmux subcommand on stderr.
 
@@ -282,23 +317,9 @@ def raise_if_stderr(proc: tmux_cmd, subcommand: str) -> None:
 
     .. versionadded:: 0.57
     """
-    if not proc.stderr:
+    if not _log_if_stderr(proc, subcommand, stacklevel=3):
         return
 
-    logger.error(
-        "tmux command failed",
-        extra={
-            **proc._log_extra,
-            "tmux_subcommand": subcommand,
-            "tmux_exit_code": proc.returncode,
-            "tmux_stderr": proc.stderr[:_LOG_LINE_CAP],
-            "tmux_stderr_len": len(proc.stderr),
-        },
-        # Attribute the record to the wrapper that ran the command, not to this
-        # helper. Every one of its call sites would otherwise report the same
-        # file and line.
-        stacklevel=2,
-    )
     raise exc.LibTmuxException(
         "\n".join(proc.stderr),
         subcommand=subcommand,
@@ -336,14 +357,15 @@ class tmux_cmd:
 
     def __init__(self, *args: t.Any, tmux_bin: str | None = None) -> None:
         resolved = tmux_bin or shutil.which("tmux")
-        if not resolved:
-            raise exc.TmuxCommandNotFound
-
-        cmd = [resolved]
+        cmd = [resolved or "tmux"]
         cmd += args  # add the command arguments to cmd
         cmd = [str(c) for c in cmd]
 
         self.cmd = cmd
+
+        if not resolved:
+            logger.error("tmux subprocess failed", extra=self._log_extra)
+            raise exc.TmuxCommandNotFound
 
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug("tmux command dispatched", extra=self._log_extra)
@@ -359,13 +381,13 @@ class tmux_cmd:
             )
             stdout, stderr = self.process.communicate()
             returncode = self.process.returncode
-        except FileNotFoundError:
-            raise exc.TmuxCommandNotFound from None
-        except Exception:
+        except Exception as error:
             logger.error(  # noqa: TRY400
                 "tmux subprocess failed",
                 extra=self._log_extra,
             )
+            if isinstance(error, FileNotFoundError):
+                raise exc.TmuxCommandNotFound from None
             raise
 
         self.returncode = returncode
@@ -464,6 +486,7 @@ def _query_version(tmux_bin: str | None = None) -> str:
     if proc.stderr:
         if proc.stderr[0] == "tmux: unknown option -- V":
             raise _TmuxVersionUnavailable
+        _log_if_stderr(proc, None)
         raise exc.VersionTooLow(proc.stderr)
 
     return proc.stdout[0].split("tmux ")[1]

--- a/src/libtmux/common.py
+++ b/src/libtmux/common.py
@@ -296,6 +296,13 @@ class tmux_cmd:
 
         $ tmux new-session -s my session
 
+    Raises
+    ------
+    :exc:`~libtmux.exc.TmuxCommandNotFound`
+        When the tmux binary cannot be found or executed.
+    :class:`OSError`
+        When the operating system rejects the launch for another reason.
+
     Notes
     -----
     .. versionchanged:: 0.8
@@ -329,7 +336,7 @@ class tmux_cmd:
             )
         except OSError as error:
             _raise_if_unusable_tmux(error)
-            raise exc.LibTmuxException(str(error)) from error
+            raise
 
         stdout, stderr = self.process.communicate()
         returncode = self.process.returncode

--- a/src/libtmux/common.py
+++ b/src/libtmux/common.py
@@ -7,6 +7,7 @@ libtmux.common
 
 from __future__ import annotations
 
+import contextvars
 import functools
 import logging
 import re
@@ -23,6 +24,11 @@ if t.TYPE_CHECKING:
     from collections.abc import Callable
 
 logger = logging.getLogger(__name__)
+
+_log_subprocess_errors = contextvars.ContextVar(
+    "libtmux_log_subprocess_errors",
+    default=True,
+)
 
 
 #: Maximum stdout/stderr lines attached to a debug record
@@ -364,7 +370,8 @@ class tmux_cmd:
         self.cmd = cmd
 
         if not resolved:
-            logger.error("tmux subprocess failed", extra=self._log_extra)
+            if _log_subprocess_errors.get():
+                logger.error("tmux subprocess failed", extra=self._log_extra)
             raise exc.TmuxCommandNotFound
 
         if logger.isEnabledFor(logging.DEBUG):
@@ -382,10 +389,11 @@ class tmux_cmd:
             stdout, stderr = self.process.communicate()
             returncode = self.process.returncode
         except Exception as error:
-            logger.error(  # noqa: TRY400
-                "tmux subprocess failed",
-                extra=self._log_extra,
-            )
+            if _log_subprocess_errors.get():
+                logger.error(  # noqa: TRY400
+                    "tmux subprocess failed",
+                    extra=self._log_extra,
+                )
             if isinstance(error, FileNotFoundError):
                 raise exc.TmuxCommandNotFound from None
             raise

--- a/src/libtmux/common.py
+++ b/src/libtmux/common.py
@@ -17,7 +17,7 @@ import typing as t
 
 from . import exc
 from ._compat import LooseVersion
-from ._internal.log_context import describe_command
+from ._internal.log_context import describe_command, redact_output
 
 if t.TYPE_CHECKING:
     from collections.abc import Callable
@@ -389,7 +389,10 @@ class tmux_cmd:
                 extra={
                     **self._log_extra,
                     "tmux_exit_code": self.returncode,
-                    "tmux_stdout": self.stdout[:_LOG_LINE_CAP],
+                    "tmux_stdout": redact_output(
+                        self._log_extra.get("tmux_subcommand"),
+                        self.stdout[:_LOG_LINE_CAP],
+                    ),
                     "tmux_stderr": self.stderr[:_LOG_LINE_CAP],
                     "tmux_stdout_len": len(self.stdout),
                     "tmux_stderr_len": len(self.stderr),

--- a/src/libtmux/common.py
+++ b/src/libtmux/common.py
@@ -408,10 +408,7 @@ class tmux_cmd:
         already redacted.
         """
         context = describe_command(self.cmd)
-        extra: dict[str, t.Any] = {
-            "tmux_cmd": context.command,
-            "tmux_cmd_len": context.length,
-        }
+        extra: dict[str, t.Any] = {"tmux_cmd": context.command}
         if context.subcommand is not None:
             extra["tmux_subcommand"] = context.subcommand
         if context.socket is not None:

--- a/src/libtmux/common.py
+++ b/src/libtmux/common.py
@@ -405,7 +405,10 @@ class tmux_cmd:
         already redacted.
         """
         context = describe_command(self.cmd)
-        extra: dict[str, t.Any] = {"tmux_cmd": context.command}
+        extra: dict[str, t.Any] = {
+            "tmux_cmd": context.command,
+            "tmux_cmd_len": context.length,
+        }
         if context.subcommand is not None:
             extra["tmux_subcommand"] = context.subcommand
         if context.socket is not None:

--- a/src/libtmux/common.py
+++ b/src/libtmux/common.py
@@ -17,15 +17,12 @@ import typing as t
 
 from . import exc
 from ._compat import LooseVersion
-from ._internal.log_context import describe_command, redact_output
+from ._internal.log_context import command_extra
 
 if t.TYPE_CHECKING:
     from collections.abc import Callable
 
 logger = logging.getLogger(__name__)
-
-#: Maximum stdout/stderr lines attached to a debug record
-_LOG_LINE_CAP = 100
 
 #: Minimum version of tmux required to run libtmux
 TMUX_MIN_VERSION = "3.2a"
@@ -307,8 +304,9 @@ class tmux_cmd:
         if not resolved:
             raise exc.TmuxCommandNotFound
 
-        if logger.isEnabledFor(logging.DEBUG):
-            logger.debug("tmux command dispatched", extra=self._log_extra)
+        log_extra = command_extra(cmd) if logger.isEnabledFor(logging.DEBUG) else None
+        if log_extra is not None:
+            logger.debug("tmux command dispatched", extra=log_extra)
 
         try:
             self.process = subprocess.Popen(
@@ -341,37 +339,16 @@ class tmux_cmd:
         else:
             self.stdout = stdout_split
 
-        if logger.isEnabledFor(logging.DEBUG):
+        if log_extra is not None:
             logger.debug(
                 "tmux command completed",
                 extra={
-                    **self._log_extra,
+                    **log_extra,
                     "tmux_exit_code": self.returncode,
-                    "tmux_stdout": redact_output(
-                        self._log_extra.get("tmux_subcommand"),
-                        self.stdout[:_LOG_LINE_CAP],
-                    ),
-                    "tmux_stderr": self.stderr[:_LOG_LINE_CAP],
                     "tmux_stdout_len": len(self.stdout),
                     "tmux_stderr_len": len(self.stderr),
                 },
             )
-
-    @functools.cached_property
-    def _log_extra(self) -> dict[str, t.Any]:
-        """Logging context every record for this command shares.
-
-        Derived once from :attr:`cmd`, so the command line a record reports is
-        the same string whichever layer emitted it, with environment values
-        already redacted.
-        """
-        context = describe_command(self.cmd)
-        extra: dict[str, t.Any] = {"tmux_cmd": context.command}
-        if context.subcommand is not None:
-            extra["tmux_subcommand"] = context.subcommand
-        if context.socket is not None:
-            extra["tmux_socket"] = context.socket
-        return extra
 
 
 class _TmuxVersionUnavailable(Exception):

--- a/src/libtmux/common.py
+++ b/src/libtmux/common.py
@@ -317,12 +317,11 @@ class tmux_cmd:
                 encoding="utf-8",
                 errors="backslashreplace",
             )
-            stdout, stderr = self.process.communicate()
-            returncode = self.process.returncode
-        except Exception as error:
-            if isinstance(error, FileNotFoundError):
-                raise exc.TmuxCommandNotFound from None
-            raise
+        except OSError:
+            raise exc.TmuxCommandNotFound from None
+
+        stdout, stderr = self.process.communicate()
+        returncode = self.process.returncode
 
         self.returncode = returncode
 

--- a/src/libtmux/exc.py
+++ b/src/libtmux/exc.py
@@ -96,7 +96,7 @@ class TmuxSessionExists(LibTmuxException):
 
 
 class TmuxCommandNotFound(LibTmuxException):
-    """Application binary for tmux not found."""
+    """Application binary for tmux not found or not executable."""
 
 
 class NotInsideTmux(LibTmuxException):

--- a/src/libtmux/hooks.py
+++ b/src/libtmux/hooks.py
@@ -312,7 +312,10 @@ class HooksMixin(CmdMixin):
             elif len(parts) == 1:
                 key, val = parts[0], None
             else:
-                logger.warning("failed to extract hook: %s", item)
+                logger.warning(
+                    "hook parse failed",
+                    extra={"tmux_subcommand": "show-hooks"},
+                )
                 continue
 
             if isinstance(val, str) and val.isdigit():

--- a/src/libtmux/hooks.py
+++ b/src/libtmux/hooks.py
@@ -38,7 +38,7 @@ from libtmux._internal.constants import (
     Hooks,
 )
 from libtmux._internal.sparse_array import SparseArray
-from libtmux.common import CmdMixin, has_lt_version
+from libtmux.common import CmdMixin, _log_if_stderr, has_lt_version
 from libtmux.constants import (
     DEFAULT_OPTION_SCOPE,
     HOOK_SCOPE_FLAG_MAP,
@@ -111,6 +111,7 @@ class HooksMixin(CmdMixin):
         )
 
         if isinstance(cmd.stderr, list) and len(cmd.stderr):
+            _log_if_stderr(cmd, "set-hook")
             handle_option_error(cmd.stderr[0])
 
         return self
@@ -191,6 +192,7 @@ class HooksMixin(CmdMixin):
         )
 
         if isinstance(cmd.stderr, list) and len(cmd.stderr):
+            _log_if_stderr(cmd, "set-hook")
             handle_option_error(cmd.stderr[0])
 
         return self
@@ -243,6 +245,7 @@ class HooksMixin(CmdMixin):
         )
 
         if isinstance(cmd.stderr, list) and len(cmd.stderr):
+            _log_if_stderr(cmd, "set-hook")
             handle_option_error(cmd.stderr[0])
 
         return self
@@ -367,6 +370,7 @@ class HooksMixin(CmdMixin):
         cmd = self.cmd("show-hooks", *flags)
 
         if len(cmd.stderr):
+            _log_if_stderr(cmd, "show-hooks")
             handle_option_error(cmd.stderr[0])
 
         return cmd.stdout

--- a/src/libtmux/hooks.py
+++ b/src/libtmux/hooks.py
@@ -38,7 +38,7 @@ from libtmux._internal.constants import (
     Hooks,
 )
 from libtmux._internal.sparse_array import SparseArray
-from libtmux.common import CmdMixin, _log_if_stderr, has_lt_version
+from libtmux.common import CmdMixin, has_lt_version
 from libtmux.constants import (
     DEFAULT_OPTION_SCOPE,
     HOOK_SCOPE_FLAG_MAP,
@@ -111,7 +111,6 @@ class HooksMixin(CmdMixin):
         )
 
         if isinstance(cmd.stderr, list) and len(cmd.stderr):
-            _log_if_stderr(cmd, "set-hook")
             handle_option_error(cmd.stderr[0])
 
         return self
@@ -192,7 +191,6 @@ class HooksMixin(CmdMixin):
         )
 
         if isinstance(cmd.stderr, list) and len(cmd.stderr):
-            _log_if_stderr(cmd, "set-hook")
             handle_option_error(cmd.stderr[0])
 
         return self
@@ -245,7 +243,6 @@ class HooksMixin(CmdMixin):
         )
 
         if isinstance(cmd.stderr, list) and len(cmd.stderr):
-            _log_if_stderr(cmd, "set-hook")
             handle_option_error(cmd.stderr[0])
 
         return self
@@ -370,7 +367,6 @@ class HooksMixin(CmdMixin):
         cmd = self.cmd("show-hooks", *flags)
 
         if len(cmd.stderr):
-            _log_if_stderr(cmd, "show-hooks")
             handle_option_error(cmd.stderr[0])
 
         return cmd.stdout

--- a/src/libtmux/neo.py
+++ b/src/libtmux/neo.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 import dataclasses
 import functools
-import logging
-import shlex
 import typing as t
 from collections.abc import Iterable
 
@@ -19,9 +17,6 @@ if t.TYPE_CHECKING:
     ListExtraArgs = Iterable[str] | None
 
     from libtmux.server import Server
-
-logger = logging.getLogger(__name__)
-
 
 OutputRaw = dict[str, t.Any]
 OutputsRaw = list[OutputRaw]
@@ -1118,18 +1113,6 @@ def fetch_objs(
 
     tmux_cmds.append(f"-F{format_string}")
 
-    cmd_str: str | None = None
-
-    if logger.isEnabledFor(logging.DEBUG):
-        cmd_str = shlex.join([str(x) for x in tmux_cmds])
-        logger.debug(
-            "tmux list queried",
-            extra={
-                "tmux_subcommand": list_cmd,
-                "tmux_cmd": cmd_str,
-            },
-        )
-
     proc = tmux_cmd(
         *tmux_cmds,
         tmux_bin=server.tmux_bin,
@@ -1137,21 +1120,7 @@ def fetch_objs(
 
     raise_if_stderr(proc, list_cmd)
 
-    outputs = [parse_output(line, list_cmd, tmux_version) for line in proc.stdout]
-
-    if logger.isEnabledFor(logging.DEBUG):
-        if cmd_str is None:
-            cmd_str = shlex.join([str(x) for x in tmux_cmds])
-        logger.debug(
-            "tmux list parsed",
-            extra={
-                "tmux_subcommand": list_cmd,
-                "tmux_cmd": cmd_str,
-                "tmux_stdout_len": len(proc.stdout),
-            },
-        )
-
-    return outputs
+    return [parse_output(line, list_cmd, tmux_version) for line in proc.stdout]
 
 
 def _is_target_not_found_error(stderr_text: str) -> bool:

--- a/src/libtmux/neo.py
+++ b/src/libtmux/neo.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import dataclasses
 import functools
-import logging
 import typing as t
 from collections.abc import Iterable
 
@@ -18,8 +17,6 @@ if t.TYPE_CHECKING:
     ListExtraArgs = Iterable[str] | None
 
     from libtmux.server import Server
-
-logger = logging.getLogger(__name__)
 
 OutputRaw = dict[str, t.Any]
 OutputsRaw = list[OutputRaw]
@@ -1029,17 +1026,6 @@ def parse_output(
     # Remove the trailing empty string from the split
     if values and values[-1] == "":
         values = values[:-1]
-
-    if len(values) != len(formats):
-        # Preserve field counts before zip(strict=True) loses tmux context.
-        logger.error(
-            "tmux output parse failed",
-            extra={
-                "tmux_subcommand": list_cmd,
-                "tmux_fields_expected": len(formats),
-                "tmux_fields_received": len(values),
-            },
-        )
 
     formatter = dict(zip(formats, values, strict=True))
     return {k: v for k, v in formatter.items() if v}

--- a/src/libtmux/neo.py
+++ b/src/libtmux/neo.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import dataclasses
 import functools
+import logging
 import typing as t
 from collections.abc import Iterable
 
@@ -17,6 +18,8 @@ if t.TYPE_CHECKING:
     ListExtraArgs = Iterable[str] | None
 
     from libtmux.server import Server
+
+logger = logging.getLogger(__name__)
 
 OutputRaw = dict[str, t.Any]
 OutputsRaw = list[OutputRaw]
@@ -1026,6 +1029,19 @@ def parse_output(
     # Remove the trailing empty string from the split
     if values and values[-1] == "":
         values = values[:-1]
+
+    if len(values) != len(formats):
+        # zip(strict=True) is about to raise, and its message names zip rather
+        # than tmux. A field holding FORMAT_SEPARATOR splits in two and shows up
+        # here as a surplus field.
+        logger.error(
+            "tmux output parse failed",
+            extra={
+                "tmux_subcommand": list_cmd,
+                "tmux_fields_expected": len(formats),
+                "tmux_fields_received": len(values),
+            },
+        )
 
     formatter = dict(zip(formats, values, strict=True))
     return {k: v for k, v in formatter.items() if v}

--- a/src/libtmux/neo.py
+++ b/src/libtmux/neo.py
@@ -1031,9 +1031,7 @@ def parse_output(
         values = values[:-1]
 
     if len(values) != len(formats):
-        # zip(strict=True) is about to raise, and its message names zip rather
-        # than tmux. A field holding FORMAT_SEPARATOR splits in two and shows up
-        # here as a surplus field.
+        # Preserve field counts before zip(strict=True) loses tmux context.
         logger.error(
             "tmux output parse failed",
             extra={
@@ -1333,10 +1331,7 @@ def fetch_obj(
             list_extra_args=list_extra_args,
         )
     except exc.LibTmuxException as e:
-        # A ``-t``-scoped listing pushes the "does it exist?" question down
-        # into tmux, which answers on stderr rather than with an empty listing.
-        # Re-raise those as the same TmuxObjectDoesNotExist an unscoped listing
-        # would have produced; anything else (a dead server) keeps propagating.
+        # Scoped missing targets arrive on stderr; keep lookup semantics aligned.
         if not _is_target_not_found_error(str(e)):
             raise
         raise exc.TmuxObjectDoesNotExist(

--- a/src/libtmux/options.py
+++ b/src/libtmux/options.py
@@ -75,7 +75,7 @@ import typing as t
 import warnings
 
 from libtmux._internal.sparse_array import SparseArray
-from libtmux.common import CmdMixin, _log_if_stderr
+from libtmux.common import CmdMixin
 from libtmux.constants import (
     DEFAULT_OPTION_SCOPE,
     OPTION_SCOPE_FLAG_MAP,
@@ -715,7 +715,6 @@ class OptionsMixin(CmdMixin):
         )
 
         if isinstance(cmd.stderr, list) and len(cmd.stderr):
-            _log_if_stderr(cmd, "set-option")
             handle_option_error(cmd.stderr[0])
 
         return self
@@ -803,7 +802,6 @@ class OptionsMixin(CmdMixin):
         )
 
         if isinstance(cmd.stderr, list) and len(cmd.stderr):
-            _log_if_stderr(cmd, "set-option")
             handle_option_error(cmd.stderr[0])
 
         return self
@@ -1200,7 +1198,6 @@ class OptionsMixin(CmdMixin):
         )
 
         if cmd.stderr is not None and len(cmd.stderr):
-            _log_if_stderr(cmd, "show-options")
             handle_option_error(cmd.stderr[0])
 
         options_output = cmd.stdout

--- a/src/libtmux/options.py
+++ b/src/libtmux/options.py
@@ -436,6 +436,15 @@ def explode_arrays(
     return options
 
 
+def _warn_skipped(key: str, skipped: int) -> None:
+    """Report unparseable entries for one option, once rather than per entry."""
+    if skipped:
+        logger.warning(
+            "tmux options parse failed",
+            extra={"tmux_option_key": key, "tmux_option_skipped": skipped},
+        )
+
+
 def explode_complex(
     _dict: ExplodedUntypedOptionsDict,
 ) -> ExplodedComplexUntypedOptionsDict:
@@ -510,20 +519,20 @@ def explode_complex(
         try:
             if isinstance(val, SparseArray) and key == "terminal-features":
                 new_val: TerminalFeatures = {}
+                skipped = 0
 
                 for item in val.iter_values():
                     try:
                         term, features = item.split(":", maxsplit=1)
                         new_val[term] = features.split(":")
                     except Exception:  # NOQA: PERF203
-                        logger.warning(
-                            "tmux options parse failed",
-                            extra={"tmux_option_key": key},
-                        )
+                        skipped += 1
+                _warn_skipped(key, skipped)
                 options[key] = new_val
                 continue
             if isinstance(val, SparseArray) and key == "terminal-overrides":
                 new_overrides: TerminalOverrides = {}
+                skipped = 0
 
                 for item in val.iter_values():
                     try:
@@ -543,14 +552,13 @@ def explode_complex(
                             elif feature:
                                 new_overrides[term][feature] = None
                     except Exception:  # NOQA: PERF203
-                        logger.warning(
-                            "tmux options parse failed",
-                            extra={"tmux_option_key": key},
-                        )
+                        skipped += 1
+                _warn_skipped(key, skipped)
                 options[key] = new_overrides
                 continue
             if isinstance(val, SparseArray) and key == "command-alias":
                 new_aliases: CommandAliases = {}
+                skipped = 0
 
                 for item in val.iter_values():
                     try:
@@ -562,10 +570,8 @@ def explode_complex(
                             options[key] = {}
                         new_aliases[alias] = command
                     except Exception:  # NOQA: PERF203
-                        logger.warning(
-                            "tmux options parse failed",
-                            extra={"tmux_option_key": key},
-                        )
+                        skipped += 1
+                _warn_skipped(key, skipped)
                 options[key] = new_aliases
                 continue
             options[key] = val

--- a/src/libtmux/options.py
+++ b/src/libtmux/options.py
@@ -75,7 +75,7 @@ import typing as t
 import warnings
 
 from libtmux._internal.sparse_array import SparseArray
-from libtmux.common import CmdMixin
+from libtmux.common import CmdMixin, _log_if_stderr
 from libtmux.constants import (
     DEFAULT_OPTION_SCOPE,
     OPTION_SCOPE_FLAG_MAP,
@@ -715,6 +715,7 @@ class OptionsMixin(CmdMixin):
         )
 
         if isinstance(cmd.stderr, list) and len(cmd.stderr):
+            _log_if_stderr(cmd, "set-option")
             handle_option_error(cmd.stderr[0])
 
         return self
@@ -802,6 +803,7 @@ class OptionsMixin(CmdMixin):
         )
 
         if isinstance(cmd.stderr, list) and len(cmd.stderr):
+            _log_if_stderr(cmd, "set-option")
             handle_option_error(cmd.stderr[0])
 
         return self
@@ -1198,6 +1200,7 @@ class OptionsMixin(CmdMixin):
         )
 
         if cmd.stderr is not None and len(cmd.stderr):
+            _log_if_stderr(cmd, "show-options")
             handle_option_error(cmd.stderr[0])
 
         options_output = cmd.stdout

--- a/src/libtmux/pane.py
+++ b/src/libtmux/pane.py
@@ -16,7 +16,13 @@ import warnings
 from libtmux import exc
 from libtmux._internal.env import pane_id_from_env
 from libtmux._internal.log_context import object_extra
-from libtmux.common import get_version_str, has_gte_version, raise_if_stderr, tmux_cmd
+from libtmux.common import (
+    _log_if_stderr,
+    get_version_str,
+    has_gte_version,
+    raise_if_stderr,
+    tmux_cmd,
+)
 from libtmux.constants import (
     PANE_DIRECTION_FLAG_MAP,
     RESIZE_ADJUSTMENT_DIRECTION_FLAG_MAP,
@@ -1075,6 +1081,7 @@ class Pane(
             "other panes killed" if all_except else "pane killed",
             extra=object_extra(
                 "kill-pane",
+                socket=self.server.socket_path or self.server.socket_name,
                 pane=self.pane_id,
                 target=self.pane_id,
             ),
@@ -1399,6 +1406,7 @@ class Pane(
         pane_cmd = self.cmd("split-window", *tmux_args, target=target)
 
         if pane_cmd.stderr:
+            _log_if_stderr(pane_cmd, "split-window")
             if "pane too small" in pane_cmd.stderr:
                 raise exc.LibTmuxException(pane_cmd.stderr)
 
@@ -1420,6 +1428,7 @@ class Pane(
             "pane created",
             extra=object_extra(
                 "split-window",
+                socket=self.server.socket_path or self.server.socket_name,
                 session=self.session.session_name,
                 window=self.window.window_name,
                 pane=pane.pane_id,
@@ -1578,6 +1587,7 @@ class Pane(
             "floating pane created",
             extra=object_extra(
                 "new-pane",
+                socket=self.server.socket_path or self.server.socket_name,
                 session=self.session.session_name,
                 window=self.window.window_name,
                 pane=pane.pane_id,

--- a/src/libtmux/pane.py
+++ b/src/libtmux/pane.py
@@ -15,6 +15,7 @@ import warnings
 
 from libtmux import exc
 from libtmux._internal.env import pane_id_from_env
+from libtmux._internal.log_context import object_extra
 from libtmux.common import get_version_str, has_gte_version, raise_if_stderr, tmux_cmd
 from libtmux.constants import (
     PANE_DIRECTION_FLAG_MAP,
@@ -1070,14 +1071,14 @@ class Pane(
 
         raise_if_stderr(proc, "kill-pane")
 
-        extra: dict[str, str] = {
-            "tmux_subcommand": "kill-pane",
-        }
-        if self.pane_id is not None:
-            extra["tmux_pane"] = str(self.pane_id)
-            extra["tmux_target"] = str(self.pane_id)
-        msg = "other panes killed" if all_except else "pane killed"
-        logger.info(msg, extra=extra)
+        logger.info(
+            "other panes killed" if all_except else "pane killed",
+            extra=object_extra(
+                "kill-pane",
+                pane=self.pane_id,
+                target=self.pane_id,
+            ),
+        )
 
     """
     Commands ("climber"-helpers)
@@ -1415,18 +1416,16 @@ class Pane(
 
         pane = self.from_pane_id(server=self.server, pane_id=pane_formatters["pane_id"])
 
-        extra: dict[str, str] = {
-            "tmux_subcommand": "split-window",
-            "tmux_pane": str(pane.pane_id),
-        }
-        if self.session.session_name is not None:
-            extra["tmux_session"] = str(self.session.session_name)
-        if self.window.window_name is not None:
-            extra["tmux_window"] = str(self.window.window_name)
-        if target is not None:
-            extra["tmux_target"] = str(target)
-
-        logger.info("pane created", extra=extra)
+        logger.info(
+            "pane created",
+            extra=object_extra(
+                "split-window",
+                session=self.session.session_name,
+                window=self.window.window_name,
+                pane=pane.pane_id,
+                target=target,
+            ),
+        )
 
         return pane
 
@@ -1575,18 +1574,16 @@ class Pane(
 
         pane = self.from_pane_id(server=self.server, pane_id=pane_formatters["pane_id"])
 
-        extra: dict[str, str] = {
-            "tmux_subcommand": "new-pane",
-            "tmux_pane": str(pane.pane_id),
-        }
-        if self.session.session_name is not None:
-            extra["tmux_session"] = str(self.session.session_name)
-        if self.window.window_name is not None:
-            extra["tmux_window"] = str(self.window.window_name)
-        if target is not None:
-            extra["tmux_target"] = str(target)
-
-        logger.info("floating pane created", extra=extra)
+        logger.info(
+            "floating pane created",
+            extra=object_extra(
+                "new-pane",
+                session=self.session.session_name,
+                window=self.window.window_name,
+                pane=pane.pane_id,
+                target=target,
+            ),
+        )
 
         return pane
 

--- a/src/libtmux/pane.py
+++ b/src/libtmux/pane.py
@@ -17,7 +17,6 @@ from libtmux import exc
 from libtmux._internal.env import pane_id_from_env
 from libtmux._internal.log_context import object_extra
 from libtmux.common import (
-    _log_if_stderr,
     get_version_str,
     has_gte_version,
     raise_if_stderr,
@@ -1406,7 +1405,6 @@ class Pane(
         pane_cmd = self.cmd("split-window", *tmux_args, target=target)
 
         if pane_cmd.stderr:
-            _log_if_stderr(pane_cmd, "split-window")
             if "pane too small" in pane_cmd.stderr:
                 raise exc.LibTmuxException(pane_cmd.stderr)
 

--- a/src/libtmux/pytest_plugin.py
+++ b/src/libtmux/pytest_plugin.py
@@ -14,6 +14,7 @@ import pytest
 
 from libtmux import exc
 from libtmux._internal.control_mode import ControlMode
+from libtmux._internal.log_context import object_extra
 from libtmux.server import Server
 from libtmux.test.constants import TEST_SESSION_PREFIX
 from libtmux.test.random import get_test_session_name, namer
@@ -286,10 +287,7 @@ def session(
         server.kill_session(old_test_session)
         logger.debug(
             "old test session killed",
-            extra={
-                "tmux_session": old_test_session,
-                "tmux_subcommand": "kill-session",
-            },
+            extra=object_extra("kill-session", session=old_test_session),
         )
     assert session.session_name == TEST_SESSION_NAME
     assert TEST_SESSION_NAME != "tmuxp"

--- a/src/libtmux/pytest_plugin.py
+++ b/src/libtmux/pytest_plugin.py
@@ -280,10 +280,8 @@ def session(
     session_id = session.session_id
     assert session_id is not None
 
-    # Avoid an ERROR record that pytest would replay as fixture noise.
-    if server.clients:
-        with contextlib.suppress(exc.LibTmuxException):
-            server.switch_client(target_session=session_id)
+    with contextlib.suppress(exc.LibTmuxException):
+        server.switch_client(target_session=session_id)
 
     for old_test_session in old_test_sessions:
         server.kill_session(old_test_session)

--- a/src/libtmux/pytest_plugin.py
+++ b/src/libtmux/pytest_plugin.py
@@ -280,10 +280,7 @@ def session(
     session_id = session.session_id
     assert session_id is not None
 
-    # Only worth attempting when a client is attached. Asking tmux to switch a
-    # client that does not exist is a command failure, which libtmux logs at
-    # ERROR — and pytest replays that into the captured log of every failing
-    # test, where it reads as the cause rather than fixture noise.
+    # Avoid an ERROR record that pytest would replay as fixture noise.
     if server.clients:
         with contextlib.suppress(exc.LibTmuxException):
             server.switch_client(target_session=session_id)
@@ -292,7 +289,11 @@ def session(
         server.kill_session(old_test_session)
         logger.debug(
             "old test session killed",
-            extra=object_extra("kill-session", session=old_test_session),
+            extra=object_extra(
+                "kill-session",
+                socket=server.socket_path or server.socket_name,
+                session=old_test_session,
+            ),
         )
     assert session.session_name == TEST_SESSION_NAME
     assert TEST_SESSION_NAME != "tmuxp"

--- a/src/libtmux/pytest_plugin.py
+++ b/src/libtmux/pytest_plugin.py
@@ -280,8 +280,13 @@ def session(
     session_id = session.session_id
     assert session_id is not None
 
-    with contextlib.suppress(exc.LibTmuxException):
-        server.switch_client(target_session=session_id)
+    # Only worth attempting when a client is attached. Asking tmux to switch a
+    # client that does not exist is a command failure, which libtmux logs at
+    # ERROR — and pytest replays that into the captured log of every failing
+    # test, where it reads as the cause rather than fixture noise.
+    if server.clients:
+        with contextlib.suppress(exc.LibTmuxException):
+            server.switch_client(target_session=session_id)
 
     for old_test_session in old_test_sessions:
         server.kill_session(old_test_session)

--- a/src/libtmux/server.py
+++ b/src/libtmux/server.py
@@ -92,7 +92,7 @@ def _fetch_or_empty(
 def _log_swallowed_list_error(
     server: Server,
     list_cmd: str,
-    error: exc.LibTmuxException,
+    error: Exception,
 ) -> None:
     """Record a list failure at the boundary that converts it to empty."""
     stderr = str(error).splitlines()
@@ -339,6 +339,8 @@ class Server(
         :class:`subprocess.CalledProcessError`
             When the tmux server is not running (non-zero exit from
             ``list-sessions``).
+        :class:`OSError`
+            When the operating system rejects the launch for another reason.
 
         >>> tmux = Server(socket_name="no_exist")
         >>> try:
@@ -2473,7 +2475,7 @@ class Server(
                 Session(server=self, **obj)
                 for obj in fetch_objs(server=self, list_cmd="list-sessions")
             ]
-        except exc.LibTmuxException as error:
+        except (exc.LibTmuxException, OSError) as error:
             _log_swallowed_list_error(self, "list-sessions", error)
             return QueryList([])
         return QueryList(sessions)
@@ -2547,7 +2549,7 @@ class Server(
                 Client(server=self, **obj)
                 for obj in fetch_objs(server=self, list_cmd="list-clients")
             ]
-        except exc.LibTmuxException as error:
+        except (exc.LibTmuxException, OSError) as error:
             _log_swallowed_list_error(self, "list-clients", error)
             return QueryList([])
         return QueryList(clients)

--- a/src/libtmux/server.py
+++ b/src/libtmux/server.py
@@ -94,7 +94,6 @@ def _log_swallowed_list_error(
     error: exc.LibTmuxException,
 ) -> None:
     """Record a list failure at the boundary that converts it to empty."""
-    stderr = str(error).splitlines()
     logger.error(
         "tmux command failed",
         extra={
@@ -102,8 +101,7 @@ def _log_swallowed_list_error(
                 list_cmd,
                 socket=server.socket_path or server.socket_name,
             ),
-            "tmux_stderr": stderr[:100],
-            "tmux_stderr_len": len(stderr),
+            "tmux_stderr_len": len(str(error).splitlines()),
         },
         stacklevel=2,
     )

--- a/src/libtmux/server.py
+++ b/src/libtmux/server.py
@@ -502,6 +502,11 @@ class Server(
 
         raise_if_stderr(proc, "kill-session")
 
+        logger.info(
+            "session killed",
+            extra=object_extra("kill-session", target=target_session),
+        )
+
         return self
 
     def run_shell(

--- a/src/libtmux/server.py
+++ b/src/libtmux/server.py
@@ -17,6 +17,7 @@ import warnings
 
 from libtmux import exc
 from libtmux._internal.env import socket_path_from_env
+from libtmux._internal.log_context import object_extra
 from libtmux._internal.query_list import QueryList
 from libtmux.client import Client
 from libtmux.common import get_version, has_gte_version, raise_if_stderr, tmux_cmd
@@ -478,7 +479,7 @@ class Server(
             if _is_daemon_not_up_error(stderr_text):
                 return
             raise exc.LibTmuxException(proc.stderr)
-        logger.info("server killed", extra={"tmux_subcommand": "kill-server"})
+        logger.info("server killed", extra=object_extra("kill-server"))
 
     def kill_session(self, target_session: str | int) -> Server:
         """Kill tmux session.
@@ -2306,10 +2307,7 @@ class Server(
                     raise_if_stderr(proc, "kill-session")
                     logger.info(
                         "existing session killed",
-                        extra={
-                            "tmux_session": session_name,
-                            "tmux_subcommand": "kill-session",
-                        },
+                        extra=object_extra("kill-session", session=session_name),
                     )
                 else:
                     msg = f"Session named {session_name} exists"
@@ -2317,12 +2315,10 @@ class Server(
                         msg,
                     )
 
-        extra: dict[str, str] = {
-            "tmux_subcommand": "new-session",
-        }
-        if session_name is not None:
-            extra["tmux_session"] = str(session_name)
-        logger.debug("creating session", extra=extra)
+        logger.debug(
+            "creating session",
+            extra=object_extra("new-session", session=session_name),
+        )
 
         env = os.environ.get("TMUX")
 
@@ -2387,12 +2383,14 @@ class Server(
 
         session = Session(server=self, **session_data)
 
-        info_extra: dict[str, str] = {
-            "tmux_subcommand": "new-session",
-        }
-        if session.session_name is not None:
-            info_extra["tmux_session"] = str(session.session_name)
-        logger.info("session created", extra=info_extra)
+        logger.info(
+            "session created",
+            extra=object_extra(
+                "new-session",
+                session=session.session_name,
+                target=session.session_id,
+            ),
+        )
 
         return session
 
@@ -2411,7 +2409,9 @@ class Server(
         tmux's ``list-sessions`` fails for any reason — no running daemon, a
         missing socket, a permission error, or a subprocess failure. To
         distinguish "no sessions" from "tmux unreachable", call
-        :meth:`Server.is_alive` or :meth:`Server.raise_if_dead`.
+        :meth:`Server.is_alive` or :meth:`Server.raise_if_dead`. The swallowed
+        failure is also logged once at ``ERROR`` on ``libtmux.common``; see
+        :ref:`logging`.
         """
         try:
             sessions: list[Session] = [

--- a/src/libtmux/server.py
+++ b/src/libtmux/server.py
@@ -22,6 +22,7 @@ from libtmux._internal.query_list import QueryList
 from libtmux.client import Client
 from libtmux.common import (
     _log_if_stderr,
+    _log_subprocess_errors,
     get_version,
     has_gte_version,
     raise_if_stderr,
@@ -300,10 +301,13 @@ class Server(
         >>> tmux = Server(socket_name="no_exist")
         >>> assert not tmux.is_alive()
         """
+        token = _log_subprocess_errors.set(False)
         try:
             res = self.cmd("list-sessions")
         except Exception:
             return False
+        finally:
+            _log_subprocess_errors.reset(token)
         return res.returncode == 0
 
     def raise_if_dead(self) -> None:

--- a/src/libtmux/server.py
+++ b/src/libtmux/server.py
@@ -21,6 +21,7 @@ from libtmux._internal.log_context import LOG_OUTPUT_LINE_LIMIT, object_extra
 from libtmux._internal.query_list import QueryList
 from libtmux.client import Client
 from libtmux.common import (
+    _raise_if_unusable_tmux,
     get_version,
     has_gte_version,
     raise_if_stderr,
@@ -333,6 +334,8 @@ class Server(
         ------
         :exc:`exc.TmuxCommandNotFound`
             When the tmux binary cannot be found or executed.
+            When the operating system attempted the launch, its diagnostic is
+            available as the exception message and cause.
         :class:`subprocess.CalledProcessError`
             When the tmux server is not running (non-zero exit from
             ``list-sessions``).
@@ -346,7 +349,8 @@ class Server(
         """
         resolved = self.tmux_bin or shutil.which("tmux")
         if resolved is None:
-            raise exc.TmuxCommandNotFound
+            msg = "tmux executable not found on PATH"
+            raise exc.TmuxCommandNotFound(msg)
 
         cmd_args: list[str] = ["list-sessions"]
         if self.socket_name:
@@ -358,8 +362,9 @@ class Server(
 
         try:
             subprocess.check_call([resolved, *cmd_args])
-        except FileNotFoundError:
-            raise exc.TmuxCommandNotFound from None
+        except OSError as error:
+            _raise_if_unusable_tmux(error)
+            raise
 
     #
     # Command

--- a/src/libtmux/server.py
+++ b/src/libtmux/server.py
@@ -21,8 +21,6 @@ from libtmux._internal.log_context import object_extra
 from libtmux._internal.query_list import QueryList
 from libtmux.client import Client
 from libtmux.common import (
-    _log_if_stderr,
-    _log_subprocess_errors,
     get_version,
     has_gte_version,
     raise_if_stderr,
@@ -88,6 +86,27 @@ def _fetch_or_empty(
         if e.args and _is_daemon_not_up_error(str(e.args[0])):
             return []
         raise
+
+
+def _log_swallowed_list_error(
+    server: Server,
+    list_cmd: str,
+    error: exc.LibTmuxException,
+) -> None:
+    """Record a list failure at the boundary that converts it to empty."""
+    stderr = str(error).splitlines()
+    logger.error(
+        "tmux command failed",
+        extra={
+            **object_extra(
+                list_cmd,
+                socket=server.socket_path or server.socket_name,
+            ),
+            "tmux_stderr": stderr[:100],
+            "tmux_stderr_len": len(stderr),
+        },
+        stacklevel=2,
+    )
 
 
 class Server(
@@ -301,13 +320,10 @@ class Server(
         >>> tmux = Server(socket_name="no_exist")
         >>> assert not tmux.is_alive()
         """
-        token = _log_subprocess_errors.set(False)
         try:
             res = self.cmd("list-sessions")
         except Exception:
             return False
-        finally:
-            _log_subprocess_errors.reset(token)
         return res.returncode == 0
 
     def raise_if_dead(self) -> None:
@@ -488,7 +504,6 @@ class Server(
             stderr_text = " ".join(str(line) for line in proc.stderr)
             if _is_daemon_not_up_error(stderr_text):
                 return
-            _log_if_stderr(proc, "kill-server")
             raise exc.LibTmuxException(proc.stderr)
         logger.info(
             "server killed",
@@ -2445,7 +2460,7 @@ class Server(
         missing socket, a permission error, or a subprocess failure. To
         distinguish "no sessions" from "tmux unreachable", call
         :meth:`Server.is_alive` or :meth:`Server.raise_if_dead`. The swallowed
-        failure is also logged once at ``ERROR`` on ``libtmux.common``; see
+        failure is also logged once at ``ERROR`` on ``libtmux.server``; see
         :ref:`logging`.
         """
         try:
@@ -2453,7 +2468,8 @@ class Server(
                 Session(server=self, **obj)
                 for obj in fetch_objs(server=self, list_cmd="list-sessions")
             ]
-        except exc.LibTmuxException:
+        except exc.LibTmuxException as error:
+            _log_swallowed_list_error(self, "list-sessions", error)
             return QueryList([])
         return QueryList(sessions)
 
@@ -2507,7 +2523,8 @@ class Server(
         tmux's ``list-clients`` fails for any reason — no running daemon, a
         missing socket, a permission error, or a subprocess failure. To
         distinguish "no clients attached" from "tmux unreachable", call
-        :meth:`Server.is_alive` or :meth:`Server.raise_if_dead`.
+        :meth:`Server.is_alive` or :meth:`Server.raise_if_dead`. The swallowed
+        failure is logged once at ``ERROR`` on ``libtmux.server``.
 
         Returns
         -------
@@ -2525,7 +2542,8 @@ class Server(
                 Client(server=self, **obj)
                 for obj in fetch_objs(server=self, list_cmd="list-clients")
             ]
-        except exc.LibTmuxException:
+        except exc.LibTmuxException as error:
+            _log_swallowed_list_error(self, "list-clients", error)
             return QueryList([])
         return QueryList(clients)
 

--- a/src/libtmux/server.py
+++ b/src/libtmux/server.py
@@ -17,7 +17,7 @@ import warnings
 
 from libtmux import exc
 from libtmux._internal.env import socket_path_from_env
-from libtmux._internal.log_context import object_extra
+from libtmux._internal.log_context import LOG_OUTPUT_LINE_LIMIT, object_extra
 from libtmux._internal.query_list import QueryList
 from libtmux.client import Client
 from libtmux.common import (
@@ -94,6 +94,7 @@ def _log_swallowed_list_error(
     error: exc.LibTmuxException,
 ) -> None:
     """Record a list failure at the boundary that converts it to empty."""
+    stderr = str(error).splitlines()
     logger.error(
         "tmux command failed",
         extra={
@@ -101,7 +102,8 @@ def _log_swallowed_list_error(
                 list_cmd,
                 socket=server.socket_path or server.socket_name,
             ),
-            "tmux_stderr_len": len(str(error).splitlines()),
+            "tmux_stderr": stderr[:LOG_OUTPUT_LINE_LIMIT],
+            "tmux_stderr_len": len(stderr),
         },
         stacklevel=2,
     )

--- a/src/libtmux/server.py
+++ b/src/libtmux/server.py
@@ -20,7 +20,13 @@ from libtmux._internal.env import socket_path_from_env
 from libtmux._internal.log_context import object_extra
 from libtmux._internal.query_list import QueryList
 from libtmux.client import Client
-from libtmux.common import get_version, has_gte_version, raise_if_stderr, tmux_cmd
+from libtmux.common import (
+    _log_if_stderr,
+    get_version,
+    has_gte_version,
+    raise_if_stderr,
+    tmux_cmd,
+)
 from libtmux.constants import OptionScope
 from libtmux.hooks import HooksMixin
 from libtmux.neo import fetch_objs, get_output_format, parse_output
@@ -478,8 +484,15 @@ class Server(
             stderr_text = " ".join(str(line) for line in proc.stderr)
             if _is_daemon_not_up_error(stderr_text):
                 return
+            _log_if_stderr(proc, "kill-server")
             raise exc.LibTmuxException(proc.stderr)
-        logger.info("server killed", extra=object_extra("kill-server"))
+        logger.info(
+            "server killed",
+            extra=object_extra(
+                "kill-server",
+                socket=self.socket_path or self.socket_name,
+            ),
+        )
 
     def kill_session(self, target_session: str | int) -> Server:
         """Kill tmux session.
@@ -504,7 +517,11 @@ class Server(
 
         logger.info(
             "session killed",
-            extra=object_extra("kill-session", target=target_session),
+            extra=object_extra(
+                "kill-session",
+                socket=self.socket_path or self.socket_name,
+                target=target_session,
+            ),
         )
 
         return self
@@ -2312,7 +2329,11 @@ class Server(
                     raise_if_stderr(proc, "kill-session")
                     logger.info(
                         "existing session killed",
-                        extra=object_extra("kill-session", session=session_name),
+                        extra=object_extra(
+                            "kill-session",
+                            socket=self.socket_path or self.socket_name,
+                            session=session_name,
+                        ),
                     )
                 else:
                     msg = f"Session named {session_name} exists"
@@ -2322,7 +2343,11 @@ class Server(
 
         logger.debug(
             "creating session",
-            extra=object_extra("new-session", session=session_name),
+            extra=object_extra(
+                "new-session",
+                socket=self.socket_path or self.socket_name,
+                session=session_name,
+            ),
         )
 
         env = os.environ.get("TMUX")
@@ -2392,6 +2417,7 @@ class Server(
             "session created",
             extra=object_extra(
                 "new-session",
+                socket=self.socket_path or self.socket_name,
                 session=session.session_name,
                 target=session.session_id,
             ),

--- a/src/libtmux/session.py
+++ b/src/libtmux/session.py
@@ -13,6 +13,7 @@ import pathlib
 import typing as t
 import warnings
 
+from libtmux._internal.log_context import object_extra
 from libtmux._internal.query_list import QueryList
 from libtmux.common import has_gte_version, raise_if_stderr, tmux_cmd
 from libtmux.constants import WINDOW_DIRECTION_FLAG_MAP, OptionScope, WindowDirection
@@ -738,15 +739,14 @@ class Session(
 
         raise_if_stderr(proc, "kill-session")
 
-        msg = "other sessions killed" if all_except else "session killed"
-        extra: dict[str, str] = {
-            "tmux_subcommand": "kill-session",
-        }
-        if self.session_name is not None:
-            extra["tmux_session"] = str(self.session_name)
-        if self.session_id is not None:
-            extra["tmux_target"] = str(self.session_id)
-        logger.info(msg, extra=extra)
+        logger.info(
+            "other sessions killed" if all_except else "session killed",
+            extra=object_extra(
+                "kill-session",
+                session=self.session_name,
+                target=self.session_id,
+            ),
+        )
 
     def switch_client(self) -> Session:
         """Switch client to session.
@@ -781,13 +781,14 @@ class Session(
 
         self.refresh()
 
-        extra: dict[str, str] = {
-            "tmux_subcommand": "rename-session",
-            "tmux_session": new_name,
-        }
-        if self.session_id is not None:
-            extra["tmux_target"] = str(self.session_id)
-        logger.info("session renamed", extra=extra)
+        logger.info(
+            "session renamed",
+            extra=object_extra(
+                "rename-session",
+                session=new_name,
+                target=self.session_id,
+            ),
+        )
 
         return self
 
@@ -942,17 +943,15 @@ class Session(
             window_id=window_formatters["window_id"],
         )
 
-        extra: dict[str, str] = {
-            "tmux_subcommand": "new-window",
-        }
-        if self.session_name is not None:
-            extra["tmux_session"] = str(self.session_name)
-        if window.window_name is not None:
-            extra["tmux_window"] = str(window.window_name)
-        if target is not None:
-            extra["tmux_target"] = str(target)
-
-        logger.info("window created", extra=extra)
+        logger.info(
+            "window created",
+            extra=object_extra(
+                "new-window",
+                session=self.session_name,
+                window=window.window_name,
+                target=target,
+            ),
+        )
 
         return window
 
@@ -983,14 +982,14 @@ class Session(
 
         raise_if_stderr(proc, "kill-window")
 
-        extra: dict[str, str] = {
-            "tmux_subcommand": "kill-window",
-        }
-        if self.session_name is not None:
-            extra["tmux_session"] = str(self.session_name)
-        if target is not None:
-            extra["tmux_target"] = str(target)
-        logger.info("window killed", extra=extra)
+        logger.info(
+            "window killed",
+            extra=object_extra(
+                "kill-window",
+                session=self.session_name,
+                target=target,
+            ),
+        )
 
     #
     # Dunder

--- a/src/libtmux/session.py
+++ b/src/libtmux/session.py
@@ -743,6 +743,7 @@ class Session(
             "other sessions killed" if all_except else "session killed",
             extra=object_extra(
                 "kill-session",
+                socket=self.server.socket_path or self.server.socket_name,
                 session=self.session_name,
                 target=self.session_id,
             ),
@@ -785,6 +786,7 @@ class Session(
             "session renamed",
             extra=object_extra(
                 "rename-session",
+                socket=self.server.socket_path or self.server.socket_name,
                 session=new_name,
                 target=self.session_id,
             ),
@@ -947,6 +949,7 @@ class Session(
             "window created",
             extra=object_extra(
                 "new-window",
+                socket=self.server.socket_path or self.server.socket_name,
                 session=self.session_name,
                 window=window.window_name,
                 target=target,
@@ -986,6 +989,7 @@ class Session(
             "window killed",
             extra=object_extra(
                 "kill-window",
+                socket=self.server.socket_path or self.server.socket_name,
                 session=self.session_name,
                 target=target,
             ),

--- a/src/libtmux/window.py
+++ b/src/libtmux/window.py
@@ -14,6 +14,7 @@ import shlex
 import typing as t
 import warnings
 
+from libtmux._internal.log_context import object_extra
 from libtmux._internal.query_list import QueryList
 from libtmux.common import has_gte_version, raise_if_stderr, tmux_cmd
 from libtmux.constants import (
@@ -1385,14 +1386,14 @@ class Window(
         self.window_name = new_name
         self.refresh()
 
-        extra: dict[str, str] = {
-            "tmux_subcommand": "rename-window",
-        }
-        if self.window_name is not None:
-            extra["tmux_window"] = str(self.window_name)
-        if self.window_id is not None:
-            extra["tmux_target"] = str(self.window_id)
-        logger.info("window renamed", extra=extra)
+        logger.info(
+            "window renamed",
+            extra=object_extra(
+                "rename-window",
+                window=self.window_name,
+                target=self.window_id,
+            ),
+        )
 
         return self
 
@@ -1448,15 +1449,14 @@ class Window(
 
         raise_if_stderr(proc, "kill-window")
 
-        msg = "other windows killed" if all_except else "window killed"
-        extra: dict[str, str] = {
-            "tmux_subcommand": "kill-window",
-        }
-        if self.window_name is not None:
-            extra["tmux_window"] = str(self.window_name)
-        if self.window_id is not None:
-            extra["tmux_target"] = str(self.window_id)
-        logger.info(msg, extra=extra)
+        logger.info(
+            "other windows killed" if all_except else "window killed",
+            extra=object_extra(
+                "kill-window",
+                window=self.window_name,
+                target=self.window_id,
+            ),
+        )
 
     def move_window(
         self,

--- a/src/libtmux/window.py
+++ b/src/libtmux/window.py
@@ -1390,6 +1390,7 @@ class Window(
             "window renamed",
             extra=object_extra(
                 "rename-window",
+                socket=self.server.socket_path or self.server.socket_name,
                 window=self.window_name,
                 target=self.window_id,
             ),
@@ -1453,6 +1454,7 @@ class Window(
             "other windows killed" if all_except else "window killed",
             extra=object_extra(
                 "kill-window",
+                socket=self.server.socket_path or self.server.socket_name,
                 window=self.window_name,
                 target=self.window_id,
             ),

--- a/tests/test_control_mode.py
+++ b/tests/test_control_mode.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import locale
 import os
-import select
+import queue
 import sys
+import threading
+import time
 import typing as t
 
 import pytest
@@ -14,7 +16,63 @@ from libtmux._internal.control_mode import ControlMode
 from libtmux.formats import FORMAT_SEPARATOR
 
 if t.TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from libtmux.server import Server
+
+
+def _read_lines(
+    stream: t.IO[str],
+    *,
+    limit: int,
+    timeout: float,
+) -> Iterator[str]:
+    """Yield up to *limit* lines from *stream*, giving up after *timeout*.
+
+    A reader thread owns the stream and the caller polls a queue, so the wait
+    is bounded without anything having to ask the file descriptor whether a
+    line is available.
+
+    That question has no useful answer here. ``ControlMode`` builds its
+    subprocess with ``text=True``, so ``stream`` is a ``TextIOWrapper`` over a
+    ``BufferedReader``: ``select`` would report readiness on the raw
+    descriptor while ``readline`` serves from the userspace buffer above it.
+    tmux writes a whole ``%begin``/``%end`` block in one burst, so the first
+    ``readline`` routinely drains every remaining line off the descriptor --
+    leaving ``select`` with nothing to report and the answer already in hand.
+    """
+    lines: queue.Queue[str | BaseException | None] = queue.Queue()
+
+    def pump() -> None:
+        try:
+            for line in stream:
+                lines.put(line)
+        except BaseException as e:  # noqa: BLE001
+            # Carry it across the thread boundary. Collapsing it into the
+            # ``None`` sentinel would report the reader as having reached EOF,
+            # naming the wrong cause for a decode error this test exists to
+            # catch.
+            lines.put(e)
+        finally:
+            lines.put(None)
+
+    reader = threading.Thread(target=pump, daemon=True)
+    reader.start()
+
+    deadline = time.monotonic() + timeout
+    for _ in range(limit):
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            pytest.fail("timed out waiting for control-mode output")
+        try:
+            line = lines.get(timeout=remaining)
+        except queue.Empty:
+            pytest.fail("timed out waiting for control-mode output")
+        if isinstance(line, BaseException):
+            raise line
+        if line is None:
+            pytest.fail("control-mode stream closed before the expected output")
+        yield line
 
 
 def test_control_mode_creates_client(
@@ -86,11 +144,7 @@ def test_control_mode_stdout_preserves_non_ascii_output(
                 f"display-message -p '{FORMAT_SEPARATOR}'\n".encode(),
             )
 
-            for _ in range(20):
-                ready, _, _ = select.select([ctl.stdout], [], [], 1)
-                assert ready, "timed out waiting for control-mode output"
-
-                line = ctl.stdout.readline()
+            for line in _read_lines(ctl.stdout, limit=20, timeout=5):
                 if FORMAT_SEPARATOR in line:
                     break
             else:

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -410,3 +410,29 @@ def test_command_records_carry_socket_identity(
     rec = t.cast(t.Any, records[0])
     assert rec.tmux_socket == server.socket_name
     assert rec.tmux_subcommand == "list-sessions"
+
+
+def test_server_kill_session_info_logging(
+    server: Server,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Server.kill_session() logs the same lifecycle event Session.kill() does."""
+    from libtmux.test.random import namer
+
+    name = f"log_kill_{next(namer)}"
+    server.new_session(session_name=name)
+
+    with caplog.at_level(logging.INFO, logger="libtmux.server"):
+        server.kill_session(name)
+
+    records = [
+        r
+        for r in caplog.records
+        if getattr(r, "tmux_subcommand", None) == "kill-session"
+        and r.levelno == logging.INFO
+    ]
+    assert len(records) >= 1, "expected INFO record for Server.kill_session()"
+
+    rec = t.cast(t.Any, records[0])
+    assert rec.getMessage() == "session killed"
+    assert rec.tmux_target == name

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -436,3 +436,18 @@ def test_server_kill_session_info_logging(
     rec = t.cast(t.Any, records[0])
     assert rec.getMessage() == "session killed"
     assert rec.tmux_target == name
+
+
+def test_session_fixture_setup_logs_no_errors(
+    session: Session,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The bundled fixtures must not leave ERROR records in a test's report.
+
+    pytest replays captured records into the report of every failing test, so a
+    fixture that provokes a tmux failure reads as the cause of that failure.
+    """
+    assert session.session_name is not None
+
+    errors = [r for r in caplog.get_records("setup") if r.levelno >= logging.ERROR]
+    assert errors == [], f"fixture setup logged: {[r.getMessage() for r in errors]}"

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,284 +1,259 @@
-"""Tests for libtmux logging standards compliance."""
+"""Tests for libtmux logging contracts."""
 
 from __future__ import annotations
 
-import concurrent.futures
 import logging
 import pathlib
 import typing as t
+from collections.abc import Callable
 
 import pytest
-
-from libtmux.test.retry import retry_until
 
 if t.TYPE_CHECKING:
     from libtmux.server import Server
     from libtmux.session import Session
 
 
-def test_tmux_cmd_debug_logging_schema(
-    server: Server,
+def _capture_info(
     caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Test that tmux_cmd produces structured log records per AGENTS.md."""
-    with caplog.at_level(logging.DEBUG, logger="libtmux.common"):
-        server.cmd("list-sessions")
-    records = [r for r in caplog.records if hasattr(r, "tmux_exit_code")]
-    assert len(records) >= 1
-    record = t.cast(t.Any, records[0])
-    assert isinstance(record.tmux_cmd, str)
-    assert isinstance(record.tmux_exit_code, int)
-    assert isinstance(record.tmux_stdout_len, int)
-    assert isinstance(record.tmux_stderr_len, int)
-    assert not hasattr(record, "tmux_stdout")
-    assert not hasattr(record, "tmux_stderr")
+    logger_name: str,
+    message: str,
+    action: Callable[[], object],
+) -> tuple[t.Any, t.Any]:
+    """Run one action and return its single matching lifecycle record."""
+    caplog.clear()
+    with caplog.at_level(logging.INFO, logger=logger_name):
+        result = action()
+
+    records = [
+        record
+        for record in caplog.records
+        if record.levelno == logging.INFO and record.getMessage() == message
+    ]
+    assert len(records) == 1
+    return result, t.cast(t.Any, records[0])
 
 
-def test_lifecycle_info_logging_schema(
+def test_tmux_cmd_debug_logging_schema(
     session: Session,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test that lifecycle operations produce INFO records with str-typed extra."""
-    with caplog.at_level(logging.INFO, logger="libtmux.session"):
-        window = session.new_window(window_name="log_test")
+    """Command records expose bounded metadata, never operands or output bodies."""
+    server = session.server
+    marker = "caller-secret"
 
+    with caplog.at_level(logging.DEBUG, logger="libtmux.common"):
+        proc = server.cmd("list-sessions", "-F", marker)
+
+    assert marker in proc.stdout
     records = [
-        r
-        for r in caplog.records
-        if hasattr(r, "tmux_subcommand") and r.levelno == logging.INFO
+        record
+        for record in caplog.records
+        if record.getMessage().startswith("tmux command")
     ]
-    assert len(records) >= 1, "expected at least one INFO lifecycle record"
-
+    assert [record.getMessage() for record in records] == [
+        "tmux command dispatched",
+        "tmux command completed",
+    ]
     for record in records:
         rec = t.cast(t.Any, record)
-        assert rec.tmux_socket == session.server.socket_name
+        assert rec.tmux_subcommand == "list-sessions"
+        assert rec.tmux_socket == server.socket_name
+        assert rec.tmux_cmd.endswith("list-sessions <2 arguments omitted>")
+        assert marker not in rec.tmux_cmd
+        assert not hasattr(rec, "tmux_stdout")
+        assert not hasattr(rec, "tmux_stderr")
+
+    completed = t.cast(t.Any, records[-1])
+    assert isinstance(completed.tmux_exit_code, int)
+    assert completed.tmux_stdout_len == len(proc.stdout)
+    assert completed.tmux_stderr_len == 0
+
+
+def test_lifecycle_info_logging(
+    server: Server,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Lifecycle call sites emit the shared string-valued context schema."""
+    from libtmux.test.random import namer
+
+    session_name = f"log_session_{next(namer)}"
+    renamed_session = f"log_session_{next(namer)}"
+    window_name = f"log_window_{next(namer)}"
+    renamed_window = f"log_window_{next(namer)}"
+
+    session, session_created = _capture_info(
+        caplog,
+        "libtmux.server",
+        "session created",
+        lambda: server.new_session(session_name=session_name),
+    )
+    _, session_renamed = _capture_info(
+        caplog,
+        "libtmux.session",
+        "session renamed",
+        lambda: session.rename_session(renamed_session),
+    )
+    window, window_created = _capture_info(
+        caplog,
+        "libtmux.session",
+        "window created",
+        lambda: session.new_window(window_name=window_name),
+    )
+    _, window_renamed = _capture_info(
+        caplog,
+        "libtmux.window",
+        "window renamed",
+        lambda: window.rename_window(renamed_window),
+    )
+    pane = window.active_pane
+    assert pane is not None
+    split_pane, pane_created = _capture_info(
+        caplog,
+        "libtmux.pane",
+        "pane created",
+        pane.split,
+    )
+    _, pane_killed = _capture_info(
+        caplog,
+        "libtmux.pane",
+        "pane killed",
+        split_pane.kill,
+    )
+    _, window_killed = _capture_info(
+        caplog,
+        "libtmux.session",
+        "window killed",
+        lambda: session.kill_window(window.window_id),
+    )
+    doomed_name = f"log_session_{next(namer)}"
+    doomed, _ = _capture_info(
+        caplog,
+        "libtmux.server",
+        "session created",
+        lambda: server.new_session(session_name=doomed_name),
+    )
+    _, session_killed = _capture_info(
+        caplog,
+        "libtmux.server",
+        "session killed",
+        lambda: server.kill_session(doomed_name),
+    )
+
+    records = [
+        session_created,
+        session_renamed,
+        window_created,
+        window_renamed,
+        pane_created,
+        pane_killed,
+        window_killed,
+        session_killed,
+    ]
+    assert [
+        (record.name, record.getMessage(), record.tmux_subcommand) for record in records
+    ] == [
+        ("libtmux.server", "session created", "new-session"),
+        ("libtmux.session", "session renamed", "rename-session"),
+        ("libtmux.session", "window created", "new-window"),
+        ("libtmux.window", "window renamed", "rename-window"),
+        ("libtmux.pane", "pane created", "split-window"),
+        ("libtmux.pane", "pane killed", "kill-pane"),
+        ("libtmux.session", "window killed", "kill-window"),
+        ("libtmux.server", "session killed", "kill-session"),
+    ]
+    for record in records:
+        assert record.tmux_socket == server.socket_name
         for key in (
             "tmux_subcommand",
             "tmux_socket",
             "tmux_session",
             "tmux_window",
+            "tmux_pane",
             "tmux_target",
         ):
-            val = getattr(rec, key, None)
-            if val is not None:
-                assert isinstance(val, str), (
-                    f"extra key {key!r} should be str, got {type(val).__name__}"
-                )
+            value = getattr(record, key, None)
+            assert value is None or isinstance(value, str)
 
-    window.kill()
+    assert session_created.tmux_session == session_name
+    assert session_renamed.tmux_session == renamed_session
+    assert window_created.tmux_window == window_name
+    assert window_renamed.tmux_window == renamed_window
+    assert pane_created.tmux_pane == split_pane.pane_id
+    assert pane_killed.tmux_pane == split_pane.pane_id
+    assert window_killed.tmux_target == window.window_id
+    assert session_killed.tmux_target == doomed.session_name
 
 
-def test_server_new_session_info_logging(
+def test_all_except_lifecycle_logging(
     server: Server,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test that server.new_session() produces INFO record with str-typed extra."""
-    with caplog.at_level(logging.INFO, logger="libtmux.server"):
-        new_session = server.new_session(session_name="log_test_session")
+    """The three all-except branches identify the object they preserve."""
+    from libtmux.test.random import namer
 
-    records = [
-        r
-        for r in caplog.records
-        if hasattr(r, "tmux_subcommand")
-        and r.levelno == logging.INFO
-        and getattr(r, "tmux_subcommand", None) == "new-session"
-    ]
-    assert len(records) >= 1, "expected INFO record for session creation"
+    workspace = server.new_session(session_name=f"log_workspace_{next(namer)}")
+    window = workspace.new_window(window_name=f"log_window_{next(namer)}")
+    workspace.new_window(window_name=f"log_other_{next(namer)}")
+    _, windows_killed = _capture_info(
+        caplog,
+        "libtmux.window",
+        "other windows killed",
+        lambda: window.kill(all_except=True),
+    )
 
-    rec = t.cast(t.Any, records[0])
-    assert isinstance(rec.tmux_subcommand, str)
-    assert isinstance(rec.tmux_session, str)
+    window.resize(height=100, width=100)
+    pane = window.split()
+    window.split()
+    _, panes_killed = _capture_info(
+        caplog,
+        "libtmux.pane",
+        "other panes killed",
+        lambda: pane.kill(all_except=True),
+    )
 
-    new_session.kill()
+    survivor = server.new_session(session_name=f"log_survivor_{next(namer)}")
+    server.new_session(session_name=f"log_other_{next(namer)}")
+    _, sessions_killed = _capture_info(
+        caplog,
+        "libtmux.session",
+        "other sessions killed",
+        lambda: survivor.kill(all_except=True),
+    )
+
+    assert (
+        windows_killed.tmux_subcommand,
+        windows_killed.tmux_window,
+        windows_killed.tmux_target,
+    ) == ("kill-window", window.window_name, window.window_id)
+    assert (
+        panes_killed.tmux_subcommand,
+        panes_killed.tmux_pane,
+        panes_killed.tmux_target,
+    ) == ("kill-pane", pane.pane_id, pane.pane_id)
+    assert (
+        sessions_killed.tmux_subcommand,
+        sessions_killed.tmux_session,
+        sessions_killed.tmux_target,
+    ) == ("kill-session", survivor.session_name, survivor.session_id)
 
 
-def test_server_kill_info_logging(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Test that server.kill() emits a lifecycle INFO record."""
+def test_server_kill_info_logging(caplog: pytest.LogCaptureFixture) -> None:
+    """Killing a server emits its lifecycle record."""
     from libtmux.server import Server
     from libtmux.test.random import namer
 
-    with Server(socket_name=f"libtmux_log_{next(namer)}") as temp_server:
-        temp_server.new_session(session_name=f"log_session_{next(namer)}")
-        caplog.clear()
+    with Server(socket_name=f"libtmux_log_{next(namer)}") as server:
+        server.new_session(session_name=f"log_session_{next(namer)}")
+        _, record = _capture_info(
+            caplog,
+            "libtmux.server",
+            "server killed",
+            server.kill,
+        )
 
-        with caplog.at_level(logging.INFO, logger="libtmux.server"):
-            temp_server.kill()
-
-    records = [
-        r
-        for r in caplog.records
-        if getattr(r, "tmux_subcommand", None) == "kill-server"
-        and r.levelno == logging.INFO
-    ]
-    assert len(records) >= 1, "expected INFO record for server kill"
-
-    rec = t.cast(t.Any, records[0])
-    assert rec.getMessage() == "server killed"
-    assert isinstance(rec.tmux_subcommand, str)
-
-
-def test_window_rename_info_logging(
-    session: Session,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Test that window.rename_window() produces INFO record with str-typed extra."""
-    window = session.active_window
-    assert window is not None
-    with caplog.at_level(logging.INFO, logger="libtmux.window"):
-        window.rename_window("log_renamed")
-
-    records = [
-        r
-        for r in caplog.records
-        if hasattr(r, "tmux_subcommand")
-        and r.levelno == logging.INFO
-        and getattr(r, "tmux_subcommand", None) == "rename-window"
-    ]
-    assert len(records) >= 1, "expected INFO record for window rename"
-
-    rec = t.cast(t.Any, records[0])
-    assert isinstance(rec.tmux_subcommand, str)
-    for key in ("tmux_window", "tmux_target"):
-        val = getattr(rec, key, None)
-        if val is not None:
-            assert isinstance(val, str), (
-                f"extra key {key!r} should be str, got {type(val).__name__}"
-            )
-
-
-def test_window_kill_all_except_logging(
-    session: Session,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Test that window.kill(all_except=True) identifies the surviving window."""
-    from libtmux.test.random import namer
-
-    survivor = session.new_window(window_name=f"log_survivor_{next(namer)}")
-    other_windows = [
-        session.new_window(window_name=f"log_other_{next(namer)}"),
-        session.new_window(window_name=f"log_other_{next(namer)}"),
-    ]
-
-    with caplog.at_level(logging.INFO, logger="libtmux.window"):
-        survivor.kill(all_except=True)
-
-    records = [
-        r
-        for r in caplog.records
-        if getattr(r, "tmux_subcommand", None) == "kill-window"
-        and r.levelno == logging.INFO
-    ]
-    assert len(records) >= 1, "expected INFO record for all-except window kill"
-
-    rec = t.cast(t.Any, records[0])
-    assert rec.getMessage() == "other windows killed"
-    assert rec.tmux_window == survivor.window_name
-    assert rec.tmux_target == survivor.window_id
-    remaining_window_ids = {window.window_id for window in session.windows}
-    assert survivor.window_id in remaining_window_ids
-    assert all(window.window_id not in remaining_window_ids for window in other_windows)
-
-
-def test_pane_split_info_logging(
-    session: Session,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Test that pane.split() produces INFO record with str-typed extra."""
-    window = session.active_window
-    assert window is not None
-    pane = window.active_pane
-    assert pane is not None
-    with caplog.at_level(logging.INFO, logger="libtmux.pane"):
-        new_pane = pane.split()
-
-    records = [
-        r
-        for r in caplog.records
-        if hasattr(r, "tmux_subcommand")
-        and r.levelno == logging.INFO
-        and getattr(r, "tmux_subcommand", None) == "split-window"
-    ]
-    assert len(records) >= 1, "expected INFO record for pane split"
-
-    rec = t.cast(t.Any, records[0])
-    assert isinstance(rec.tmux_subcommand, str)
-    assert isinstance(rec.tmux_pane, str)
-    for key in ("tmux_session", "tmux_window"):
-        val = getattr(rec, key, None)
-        if val is not None:
-            assert isinstance(val, str), (
-                f"extra key {key!r} should be str, got {type(val).__name__}"
-            )
-
-    new_pane.kill()
-
-
-def test_pane_kill_all_except_logging(
-    session: Session,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Test that pane.kill(all_except=True) identifies the surviving pane."""
-    window = session.active_window
-    assert window is not None
-    window.resize(height=100, width=100)
-    survivor = window.split()
-    other_panes = [window.split(), window.split()]
-
-    with caplog.at_level(logging.INFO, logger="libtmux.pane"):
-        survivor.kill(all_except=True)
-
-    records = [
-        r
-        for r in caplog.records
-        if getattr(r, "tmux_subcommand", None) == "kill-pane"
-        and r.levelno == logging.INFO
-    ]
-    assert len(records) >= 1, "expected INFO record for all-except pane kill"
-
-    rec = t.cast(t.Any, records[0])
-    assert rec.getMessage() == "other panes killed"
-    assert rec.tmux_pane == survivor.pane_id
-    assert rec.tmux_target == survivor.pane_id
-    remaining_pane_ids = {p.pane_id for p in window.panes}
-    assert survivor.pane_id in remaining_pane_ids
-    assert all(p.pane_id not in remaining_pane_ids for p in other_panes)
-
-
-def test_session_kill_all_except_logging(
-    server: Server,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Test that session.kill(all_except=True) identifies the surviving session."""
-    from libtmux.test.random import namer
-
-    survivor = server.new_session(session_name=f"log_survivor_{next(namer)}")
-    other_sessions = [
-        server.new_session(session_name=f"log_other_{next(namer)}"),
-        server.new_session(session_name=f"log_other_{next(namer)}"),
-    ]
-
-    with caplog.at_level(logging.INFO, logger="libtmux.session"):
-        survivor.kill(all_except=True)
-
-    records = [
-        r
-        for r in caplog.records
-        if getattr(r, "tmux_subcommand", None) == "kill-session"
-        and r.levelno == logging.INFO
-    ]
-    assert len(records) >= 1, "expected INFO record for all-except session kill"
-
-    rec = t.cast(t.Any, records[0])
-    assert rec.getMessage() == "other sessions killed"
-    assert rec.tmux_session == survivor.session_name
-    assert rec.tmux_target == survivor.session_id
-    remaining_session_ids = {session.session_id for session in server.sessions}
-    assert survivor.session_id in remaining_session_ids
-    assert all(
-        session.session_id not in remaining_session_ids for session in other_sessions
-    )
+    assert record.tmux_subcommand == "kill-server"
+    assert record.tmux_socket == server.socket_name
 
 
 def test_server_new_session_propagates_without_logging(
@@ -297,7 +272,9 @@ def test_server_new_session_propagates_without_logging(
     ):
         server.new_session(session_name="no_such_session", kill_session=True)
 
-    assert [r for r in caplog.records if r.levelno == logging.ERROR] == []
+    assert [
+        record for record in caplog.records if record.levelno == logging.ERROR
+    ] == []
 
 
 def test_environment_failure_propagates_without_logging(
@@ -314,7 +291,9 @@ def test_environment_failure_propagates_without_logging(
     ):
         dead.set_environment("KEY", "value")
 
-    assert [r for r in caplog.records if r.levelno == logging.ERROR] == []
+    assert [
+        record for record in caplog.records if record.levelno == logging.ERROR
+    ] == []
 
 
 @pytest.mark.parametrize("configured", [True, False], ids=["configured", "default"])
@@ -337,7 +316,9 @@ def test_missing_tmux_binary_propagates_without_logging(
     ):
         tmux_cmd("list-sessions", tmux_bin=tmux_bin)
 
-    assert [r for r in caplog.records if r.levelno == logging.ERROR] == []
+    assert [
+        record for record in caplog.records if record.levelno == logging.ERROR
+    ] == []
 
 
 @pytest.mark.parametrize(
@@ -350,7 +331,7 @@ def test_is_alive_unusable_binary_stays_quiet(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """A health check converts an unusable executable to a quiet ``False``."""
+    """A health check converts an unusable executable to a quiet false result."""
     from libtmux.server import Server
 
     tmux_bin: str | None = str(tmp_path / "missing-tmux")
@@ -375,11 +356,10 @@ def test_is_alive_unusable_binary_stays_quiet(
 def test_options_warning_logging_schema(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test that options parse warnings produce records with tmux_option_key."""
+    """Malformed values produce one aggregate warning without traceback data."""
     from libtmux._internal.sparse_array import SparseArray
     from libtmux.options import explode_complex
 
-    # ints rather than "term:feature" strings, so every .split() fails
     bad_features: SparseArray[str | int | bool | None] = SparseArray()
     for index in range(25):
         bad_features[index] = index
@@ -388,18 +368,14 @@ def test_options_warning_logging_schema(
         explode_complex({"terminal-features": bad_features})  # type: ignore[dict-item]
 
     records = [
-        r
-        for r in caplog.records
-        if hasattr(r, "tmux_option_key") and r.levelno == logging.WARNING
+        record
+        for record in caplog.records
+        if getattr(record, "tmux_option_key", None) == "terminal-features"
     ]
-    assert len(records) == 1, (
-        f"one option should warn once, not once per entry; got {len(records)}"
-    )
-
-    rec = t.cast(t.Any, records[0])
-    assert isinstance(rec.tmux_option_key, str)
-    assert rec.tmux_option_skipped == 25
-    assert rec.exc_info is None
+    assert len(records) == 1
+    record = t.cast(t.Any, records[0])
+    assert record.tmux_option_skipped == 25
+    assert record.exc_info is None
 
 
 @pytest.mark.parametrize(
@@ -459,94 +435,23 @@ def test_command_extra_separates_operation_from_parameters(
     assert command_extra(argv) == expected
 
 
-def test_command_records_carry_socket_identity(
-    server: Server,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Records name which tmux server they came from."""
-    with caplog.at_level(logging.DEBUG, logger="libtmux.common"):
-        server.cmd("list-sessions")
-
-    records = [r for r in caplog.records if hasattr(r, "tmux_socket")]
-    assert len(records) >= 1, "expected records tagged with the socket"
-
-    rec = t.cast(t.Any, records[0])
-    assert rec.tmux_socket == server.socket_name
-    assert rec.tmux_subcommand == "list-sessions"
-
-
-def test_server_kill_session_info_logging(
-    server: Server,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Server.kill_session() logs the same lifecycle event Session.kill() does."""
-    from libtmux.test.random import namer
-
-    name = f"log_kill_{next(namer)}"
-    server.new_session(session_name=name)
-
-    with caplog.at_level(logging.INFO, logger="libtmux.server"):
-        server.kill_session(name)
-
-    records = [
-        r
-        for r in caplog.records
-        if getattr(r, "tmux_subcommand", None) == "kill-session"
-        and r.levelno == logging.INFO
-    ]
-    assert len(records) >= 1, "expected INFO record for Server.kill_session()"
-
-    rec = t.cast(t.Any, records[0])
-    assert rec.getMessage() == "session killed"
-    assert rec.tmux_target == name
-
-
 def test_session_fixture_setup_logs_no_errors(
     session: Session,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """The bundled fixtures must not leave ERROR records in a test's report.
-
-    pytest replays captured records into the report of every failing test, so a
-    fixture that provokes a tmux failure reads as the cause of that failure.
-    """
+    """The bundled fixture does not inject ERROR records into test reports."""
     assert session.session_name is not None
-
-    errors = [r for r in caplog.get_records("setup") if r.levelno >= logging.ERROR]
-    assert errors == [], f"fixture setup logged: {[r.getMessage() for r in errors]}"
-
-
-def test_command_content_cannot_forge_a_log_line(
-    session: Session,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """A newline a caller sends must not end the record and start a new one.
-
-    ``send_keys`` carries whatever the caller types, so a multi-line payload
-    would otherwise split one record across several lines of a line-oriented
-    log, where the remainder reads as a record of its own.
-    """
-    pane = session.active_window.active_pane
-    assert pane is not None
-
-    with caplog.at_level(logging.DEBUG, logger="libtmux.common"):
-        pane.send_keys("echo hi\nCRITICAL libtmux.server forged", enter=False)
-
-    dispatched = [
-        r for r in caplog.records if r.getMessage() == "tmux command dispatched"
-    ]
-    assert len(dispatched) >= 1
-
-    rec = t.cast(t.Any, dispatched[-1])
-    assert "\n" not in rec.tmux_cmd
-    assert "CRITICAL libtmux.server forged" not in rec.tmux_cmd
-    assert rec.tmux_cmd.endswith("send-keys <3 arguments omitted>")
+    assert [
+        record
+        for record in caplog.get_records("setup")
+        if record.levelno >= logging.ERROR
+    ] == []
 
 
 def test_lookup_path_cannot_forge_a_log_line(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """A failed caller-provided lookup stays on one diagnostic line."""
+    """A caller-provided lookup path remains one diagnostic line."""
     from libtmux._internal.query_list import keygetter
 
     with caplog.at_level(logging.DEBUG, logger="libtmux._internal.query_list"):
@@ -555,36 +460,6 @@ def test_lookup_path_cannot_forge_a_log_line(
     record = caplog.records[-1]
     assert "\n" not in record.getMessage()
     assert "\\nERROR libtmux forged" in record.getMessage()
-
-
-def test_pane_content_is_not_written_to_records(
-    session: Session,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Terminal content reaches the caller as a return value, not as a record.
-
-    A pane holds whatever was typed into it, so its contents are the tmux
-    equivalent of an HTTP response body: the record reports how much came back.
-    """
-    pane = session.active_window.active_pane
-    assert pane is not None
-    marker = "hunter2-typed-into-the-pane"
-    pane.send_keys(f"# {marker}", enter=True)
-    retry_until(lambda: any(marker in line for line in pane.capture_pane()), 2)
-
-    with caplog.at_level(logging.DEBUG, logger="libtmux.common"):
-        captured = pane.capture_pane()
-
-    assert any(marker in line for line in captured), "caller still gets the content"
-
-    records = [r for r in caplog.records if r.getMessage() == "tmux command completed"]
-    assert records, "expected a completion record"
-    for record in records:
-        rec = t.cast(t.Any, record)
-        assert not hasattr(rec, "tmux_stdout")
-        assert not hasattr(rec, "tmux_stderr")
-        if rec.tmux_subcommand == "capture-pane":
-            assert rec.tmux_stdout_len > 0, "the count still reports what came back"
 
 
 def test_parse_failure_propagates_without_logging(
@@ -602,41 +477,6 @@ def test_parse_failure_propagates_without_logging(
     ):
         parse_output(row, "list-panes", "3.7")
 
-    assert [r for r in caplog.records if r.levelno == logging.ERROR] == []
-
-
-def test_concurrent_records_keep_operation_context(
-    session: Session,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Concurrent commands keep their fields isolated.
-
-    Handler locks make :mod:`logging` itself thread-safe, so the only way
-    libtmux could introduce a race is by handing the same list or dict to more
-    than one record.
-    """
-    server = session.server
-    markers = [f"concurrent-{index}" for index in range(8)]
-    with (
-        caplog.at_level(logging.DEBUG, logger="libtmux.common"),
-        concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor,
-    ):
-        futures = [
-            executor.submit(server.cmd, "display-message", "-p", marker)
-            for marker in markers
-        ]
-        results = [future.result() for future in futures]
-
-    assert [result.stdout for result in results] == [[marker] for marker in markers]
-    completed = [
-        record
-        for record in caplog.records
-        if record.getMessage() == "tmux command completed"
-        and getattr(record, "tmux_subcommand", None) == "display-message"
-    ]
-    assert len(completed) == len(markers)
-    assert all(
-        t.cast(t.Any, record).tmux_socket == server.socket_name for record in completed
-    )
-    assert all(t.cast(t.Any, record).tmux_stdout_len == 1 for record in completed)
-    assert all(not hasattr(record, "tmux_stdout") for record in completed)
+    assert [
+        record for record in caplog.records if record.levelno == logging.ERROR
+    ] == []

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -278,17 +278,12 @@ def test_session_kill_all_except_logging(
     )
 
 
-def test_server_new_session_surfaces_kill_session_stderr(
+def test_server_new_session_propagates_without_logging(
     server: Server,
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test kill-session stderr propagation, and the ERROR record it emits.
-
-    ``has_session`` is monkeypatched so ``new_session`` attempts to kill a
-    session that does not exist; tmux then fails the ``kill-session`` for real,
-    which is the condition under test.
-    """
+    """A propagated tmux failure remains exception data, not a log record."""
     from libtmux import exc
 
     monkeypatch.setattr(server, "has_session", lambda session_name: True)
@@ -299,22 +294,16 @@ def test_server_new_session_surfaces_kill_session_stderr(
     ):
         server.new_session(session_name="no_such_session", kill_session=True)
 
-    records = [r for r in caplog.records if r.levelno == logging.ERROR]
-    assert len(records) >= 1, "expected ERROR record for the failed kill-session"
-
-    rec = t.cast(t.Any, records[0])
-    assert rec.getMessage() == "tmux command failed"
-    assert rec.tmux_subcommand == "kill-session"
-    assert isinstance(rec.tmux_exit_code, int)
-    assert rec.tmux_exit_code != 0
-    assert rec.tmux_stderr_len >= 1
+    assert [
+        record for record in caplog.records if record.levelno == logging.ERROR
+    ] == []
 
 
-def test_environment_failure_logs_before_value_error(
+def test_environment_failure_propagates_without_logging(
     server: Server,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Environment errors keep their public exception and log the failure."""
+    """Translated environment errors remain exception data."""
     dead = server.new_session(session_name="logging_dead_environment")
     dead.kill()
 
@@ -324,67 +313,19 @@ def test_environment_failure_logs_before_value_error(
     ):
         dead.set_environment("KEY", "value")
 
-    records = [r for r in caplog.records if r.levelno == logging.ERROR]
-    assert len(records) == 1
-    rec = t.cast(t.Any, records[0])
-    assert rec.getMessage() == "tmux command failed"
-    assert rec.tmux_subcommand == "set-environment"
-    assert rec.funcName == "set_environment"
-
-
-def test_pane_split_failure_logs_before_specialized_exception(
-    session: Session,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Pane creation errors log once without changing their exception."""
-    from libtmux import exc
-
-    pane = session.active_window.active_pane
-    assert pane is not None
-    pane.split()
-    pane.kill()
-
-    with (
-        caplog.at_level(logging.ERROR, logger="libtmux.common"),
-        pytest.raises(exc.LibTmuxException),
-    ):
-        pane.split()
-
-    records = [r for r in caplog.records if r.levelno == logging.ERROR]
-    assert len(records) == 1
-    rec = t.cast(t.Any, records[0])
-    assert rec.tmux_subcommand == "split-window"
-    assert rec.funcName == "split"
-
-
-def test_option_failure_logs_before_option_error(
-    session: Session,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Option errors keep their public exception after transport logging."""
-    from libtmux import exc
-
-    with (
-        caplog.at_level(logging.ERROR, logger="libtmux.common"),
-        pytest.raises(exc.OptionError),
-    ):
-        session.set_option("not-a-libtmux-option", "value")
-
-    records = [r for r in caplog.records if r.levelno == logging.ERROR]
-    assert len(records) == 1
-    rec = t.cast(t.Any, records[0])
-    assert rec.tmux_subcommand == "set-option"
-    assert rec.funcName == "set_option"
+    assert [
+        record for record in caplog.records if record.levelno == logging.ERROR
+    ] == []
 
 
 @pytest.mark.parametrize("configured", [True, False], ids=["configured", "default"])
-def test_missing_tmux_binary_logs_before_public_exception(
+def test_missing_tmux_binary_propagates_without_logging(
     configured: bool,
     tmp_path: pathlib.Path,
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """A missing executable still leaves one failure record."""
+    """A missing executable remains exception data, not a log record."""
     from libtmux import exc
     from libtmux.common import tmux_cmd
 
@@ -397,12 +338,9 @@ def test_missing_tmux_binary_logs_before_public_exception(
     ):
         tmux_cmd("list-sessions", tmux_bin=tmux_bin)
 
-    records = [record for record in caplog.records if record.levelno == logging.ERROR]
-    assert len(records) == 1
-    record = t.cast(t.Any, records[0])
-    assert record.getMessage() == "tmux subprocess failed"
-    assert record.tmux_subcommand == "list-sessions"
-    assert not hasattr(record, "tmux_exit_code")
+    assert [
+        record for record in caplog.records if record.levelno == logging.ERROR
+    ] == []
 
 
 @pytest.mark.parametrize(
@@ -760,32 +698,6 @@ def test_session_fixture_setup_logs_no_errors(
     assert errors == [], f"fixture setup logged: {[r.getMessage() for r in errors]}"
 
 
-def test_failure_record_names_the_caller(
-    session: Session,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """The ERROR record locates the tmux operation, not the shared helper.
-
-    ``raise_if_stderr()`` has many call sites; without ``stacklevel`` every one
-    of them reports the same file and line, which makes ``%(filename)s`` and
-    OpenTelemetry's ``code.filepath`` useless for finding the failure.
-    """
-    from libtmux import exc
-
-    with (
-        caplog.at_level(logging.ERROR, logger="libtmux.common"),
-        pytest.raises(exc.LibTmuxException),
-    ):
-        session.kill_window(target_window="no_such_window")
-
-    records = [r for r in caplog.records if r.levelno == logging.ERROR]
-    assert len(records) >= 1
-
-    rec = records[0]
-    assert rec.funcName == "kill_window"
-    assert rec.filename == "session.py"
-
-
 def test_command_content_cannot_forge_a_log_line(
     session: Session,
     caplog: pytest.LogCaptureFixture,
@@ -929,13 +841,10 @@ def test_pane_content_is_not_written_to_records(
             assert rec.tmux_stdout_len > 0, "the count still reports what came back"
 
 
-def test_parse_failure_is_logged(caplog: pytest.LogCaptureFixture) -> None:
-    """A row libtmux cannot parse must say so; the exception names only zip().
-
-    A field holding the format separator splits in two, and the field counts are
-    what identify that. Nothing else in the log reports it: tmux succeeded, so
-    the command records show a clean exit.
-    """
+def test_parse_failure_propagates_without_logging(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A parser failure remains exception data."""
     from libtmux.formats import FORMAT_SEPARATOR
     from libtmux.neo import parse_output
 
@@ -947,14 +856,9 @@ def test_parse_failure_is_logged(caplog: pytest.LogCaptureFixture) -> None:
     ):
         parse_output(row, "list-panes", "3.7")
 
-    records = [r for r in caplog.records if r.levelno == logging.ERROR]
-    assert len(records) == 1
-
-    rec = t.cast(t.Any, records[0])
-    assert rec.getMessage() == "tmux output parse failed"
-    assert rec.tmux_subcommand == "list-panes"
-    assert rec.tmux_fields_received == 3
-    assert rec.tmux_fields_expected != rec.tmux_fields_received
+    assert [
+        record for record in caplog.records if record.levelno == logging.ERROR
+    ] == []
 
 
 def test_concurrent_records_share_no_mutable_state(

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -8,6 +8,8 @@ import typing as t
 
 import pytest
 
+from libtmux.test.retry import retry_until
+
 if t.TYPE_CHECKING:
     from libtmux.server import Server
     from libtmux.session import Session
@@ -562,3 +564,33 @@ def test_environment_values_are_hidden_in_both_directions(
         if secret in str(getattr(r, key, ""))
     ]
     assert leaked == [], f"secret reached {len(leaked)} record(s)"
+
+
+def test_pane_content_is_not_written_to_records(
+    session: Session,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Terminal content reaches the caller as a return value, not as a record.
+
+    A pane holds whatever was typed into it, so its contents are the tmux
+    equivalent of an HTTP response body: the record reports how much came back.
+    """
+    pane = session.active_window.active_pane
+    assert pane is not None
+    marker = "hunter2-typed-into-the-pane"
+    pane.send_keys(f"# {marker}", enter=True)
+    retry_until(lambda: any(marker in line for line in pane.capture_pane()), 2)
+
+    with caplog.at_level(logging.DEBUG, logger="libtmux.common"):
+        captured = pane.capture_pane()
+
+    assert any(marker in line for line in captured), "caller still gets the content"
+
+    records = [r for r in caplog.records if hasattr(r, "tmux_stdout")]
+    assert records, "expected a completion record"
+    for record in records:
+        rec = t.cast(t.Any, record)
+        assert not any(marker in line for line in rec.tmux_stdout)
+        if rec.tmux_subcommand == "capture-pane":
+            assert rec.tmux_stdout == []
+            assert rec.tmux_stdout_len > 0, "the count still reports what came back"

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import concurrent.futures
 import contextlib
 import logging
+import pathlib
 import typing as t
 
 import pytest
@@ -46,7 +48,14 @@ def test_lifecycle_info_logging_schema(
 
     for record in records:
         rec = t.cast(t.Any, record)
-        for key in ("tmux_subcommand", "tmux_session", "tmux_window", "tmux_target"):
+        assert rec.tmux_socket == session.server.socket_name
+        for key in (
+            "tmux_subcommand",
+            "tmux_socket",
+            "tmux_session",
+            "tmux_window",
+            "tmux_target",
+        ):
             val = getattr(rec, key, None)
             if val is not None:
                 assert isinstance(val, str), (
@@ -301,6 +310,101 @@ def test_server_new_session_surfaces_kill_session_stderr(
     assert rec.tmux_stderr_len >= 1
 
 
+def test_environment_failure_logs_before_value_error(
+    server: Server,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Environment errors keep their public exception and log the failure."""
+    dead = server.new_session(session_name="logging_dead_environment")
+    dead.kill()
+
+    with (
+        caplog.at_level(logging.ERROR, logger="libtmux.common"),
+        pytest.raises(ValueError),
+    ):
+        dead.set_environment("KEY", "value")
+
+    records = [r for r in caplog.records if r.levelno == logging.ERROR]
+    assert len(records) == 1
+    rec = t.cast(t.Any, records[0])
+    assert rec.getMessage() == "tmux command failed"
+    assert rec.tmux_subcommand == "set-environment"
+    assert rec.funcName == "set_environment"
+
+
+def test_pane_split_failure_logs_before_specialized_exception(
+    session: Session,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Pane creation errors log once without changing their exception."""
+    from libtmux import exc
+
+    pane = session.active_window.active_pane
+    assert pane is not None
+    pane.split()
+    pane.kill()
+
+    with (
+        caplog.at_level(logging.ERROR, logger="libtmux.common"),
+        pytest.raises(exc.LibTmuxException),
+    ):
+        pane.split()
+
+    records = [r for r in caplog.records if r.levelno == logging.ERROR]
+    assert len(records) == 1
+    rec = t.cast(t.Any, records[0])
+    assert rec.tmux_subcommand == "split-window"
+    assert rec.funcName == "split"
+
+
+def test_option_failure_logs_before_option_error(
+    session: Session,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Option errors keep their public exception after transport logging."""
+    from libtmux import exc
+
+    with (
+        caplog.at_level(logging.ERROR, logger="libtmux.common"),
+        pytest.raises(exc.OptionError),
+    ):
+        session.set_option("not-a-libtmux-option", "value")
+
+    records = [r for r in caplog.records if r.levelno == logging.ERROR]
+    assert len(records) == 1
+    rec = t.cast(t.Any, records[0])
+    assert rec.tmux_subcommand == "set-option"
+    assert rec.funcName == "set_option"
+
+
+@pytest.mark.parametrize("configured", [True, False], ids=["configured", "default"])
+def test_missing_tmux_binary_logs_before_public_exception(
+    configured: bool,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A missing executable still leaves one failure record."""
+    from libtmux import exc
+    from libtmux.common import tmux_cmd
+
+    tmux_bin = str(tmp_path / "missing-tmux") if configured else None
+    if not configured:
+        monkeypatch.setattr("libtmux.common.shutil.which", lambda _: None)
+    with (
+        caplog.at_level(logging.ERROR, logger="libtmux.common"),
+        pytest.raises(exc.TmuxCommandNotFound),
+    ):
+        tmux_cmd("list-sessions", tmux_bin=tmux_bin)
+
+    records = [record for record in caplog.records if record.levelno == logging.ERROR]
+    assert len(records) == 1
+    record = t.cast(t.Any, records[0])
+    assert record.getMessage() == "tmux subprocess failed"
+    assert record.tmux_subcommand == "list-sessions"
+    assert not hasattr(record, "tmux_exit_code")
+
+
 def test_options_warning_logging_schema(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -344,6 +448,16 @@ def test_options_warning_logging_schema(
         (["tmux", "-qu", "-S", "/tmp/x", "kill-server"], "kill-server", "/tmp/x"),
         (["tmux", "-c", "echo hi", "run-shell"], "run-shell", None),
         (["tmux", "-T", "256", "list-keys"], "list-keys", None),
+        (
+            ["tmux", "-L", "label", "-S", "/tmp/path", "list-sessions"],
+            "list-sessions",
+            "/tmp/path",
+        ),
+        (
+            ["tmux", "-S/path", "-Llabel", "list-sessions"],
+            "list-sessions",
+            "/path",
+        ),
         (["tmux", "-V"], None, None),
     ],
     ids=[
@@ -357,6 +471,8 @@ def test_options_warning_logging_schema(
         "bundled-booleans-then-socket-path",
         "separated-shell-command",
         "separated-features",
+        "path-after-label",
+        "path-before-label",
         "no-subcommand",
     ],
 )
@@ -385,18 +501,36 @@ def test_describe_command_reads_tmux_global_flags(
         (["tmux", "new-session", "-e", "K=v"], "tmux new-session -e K=REDACTED"),
         (["tmux", "split-window", "-eK=a=b"], "tmux split-window -eK=REDACTED"),
         (["tmux", "set-environment", "K", "v"], "tmux set-environment K REDACTED"),
+        (
+            ["tmux", "setenv", "-Ft", "work", "K", "-secret"],
+            "tmux setenv -Ft work K REDACTED",
+        ),
         (["tmux", "set-environment", "-u", "K"], "tmux set-environment -u K"),
         (["tmux", "select-pane", "-e", "-t%1"], "tmux select-pane -e -t%1"),
+        (["tmux", "select-pane", "-eK=v"], "tmux select-pane -eK=v"),
         (["tmux", "copy-mode", "-e"], "tmux copy-mode -e"),
+        (
+            ["tmux", "set-buffer", "-b", "named", "secret data"],
+            "tmux set-buffer -b named REDACTED",
+        ),
+        (["tmux", "setb", "secret data"], "tmux setb REDACTED"),
+        (["tmux", "set-e", "K", "secret"], "tmux set-e K REDACTED"),
+        (["tmux", "set-b", "secret data"], "tmux set-b REDACTED"),
     ],
     ids=[
         "joined-env-pair",
         "separated-env-pair",
         "value-containing-equals",
         "set-environment-value",
+        "setenv-dash-prefixed-value",
         "set-environment-unset-keeps-name",
         "select-pane-boolean-e",
+        "select-pane-joined-boolean-e",
         "copy-mode-boolean-e",
+        "set-buffer-content",
+        "setb-content",
+        "set-environment-prefix",
+        "set-buffer-prefix",
     ],
 )
 def test_describe_command_redacts_only_environment_values(
@@ -406,7 +540,102 @@ def test_describe_command_redacts_only_environment_values(
     """``-e`` is an env pair on some subcommands and a boolean on others."""
     from libtmux._internal.log_context import describe_command
 
-    assert describe_command(argv).command == expected
+    context = describe_command(argv)
+    assert context.subcommand == argv[1]
+    assert context.command == expected
+
+
+def test_describe_command_redacts_every_environment_spelling() -> None:
+    """Every built-in and default alias that accepts ``-e`` hides its value."""
+    from libtmux._internal.log_context import describe_command
+
+    subcommands = (
+        "new-session",
+        "new",
+        "new-window",
+        "neww",
+        "new-pane",
+        "newp",
+        "display-popup",
+        "popup",
+        "respawn-pane",
+        "respawnp",
+        "respawn-window",
+        "respawnw",
+        "split-window",
+        "splitw",
+        "split-pane",
+        "splitp",
+        "new-s",
+        "new-w",
+        "new-p",
+        "display-po",
+        "respawn-p",
+        "respawn-w",
+        "sp",
+    )
+    for subcommand in subcommands:
+        joined = describe_command(["tmux", subcommand, "-eKEY=secret"])
+        separated = describe_command(["tmux", subcommand, "-e", "KEY=secret"])
+        assert joined.command == f"tmux {subcommand} -eKEY=REDACTED"
+        assert separated.command == f"tmux {subcommand} -e KEY=REDACTED"
+
+
+def test_redact_output_suppresses_sensitive_command_spellings() -> None:
+    """Environment, terminal, buffer, and history output stays off records."""
+    from libtmux._internal.log_context import redact_output
+
+    subcommands = (
+        "show-environment",
+        "showenv",
+        "capture-pane",
+        "capturep",
+        "save-buffer",
+        "saveb",
+        "show-buffer",
+        "showb",
+        "list-buffers",
+        "lsb",
+        "show-messages",
+        "showmsgs",
+        "show-prompt-history",
+        "showphist",
+        "show-e",
+        "ca",
+        "sa",
+        "show-b",
+        "list-b",
+        "show-m",
+        "show-p",
+    )
+    for subcommand in subcommands:
+        assert redact_output(subcommand, ["KEY=secret", "continuation"]) == []
+
+
+@pytest.mark.parametrize(
+    ("line_break", "escaped"),
+    (
+        ("\n", r"\n"),
+        ("\x85", r"\u0085"),
+        ("\u2028", r"\u2028"),
+        ("\u2029", r"\u2029"),
+    ),
+)
+def test_socket_identity_cannot_forge_a_log_line(
+    line_break: str,
+    escaped: str,
+) -> None:
+    """Socket identity stays scalar when tmux accepts a control character."""
+    from libtmux._internal.log_context import describe_command
+
+    context = describe_command(
+        ["tmux", "-L", f"safe{line_break}ERROR libtmux forged", "list-sessions"],
+    )
+
+    assert context.socket is not None
+    assert line_break not in context.socket
+    assert escaped in context.socket
+    assert context.socket.splitlines() == [context.socket]
 
 
 def test_command_records_carry_socket_identity(
@@ -518,22 +747,32 @@ def test_command_content_cannot_forge_a_log_line(
     assert "$'echo hi\\nCRITICAL libtmux.server forged'" in rec.tmux_cmd
 
 
+def test_lookup_path_cannot_forge_a_log_line(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A failed caller-provided lookup stays on one diagnostic line."""
+    from libtmux._internal.query_list import keygetter
+
+    with caplog.at_level(logging.DEBUG, logger="libtmux._internal.query_list"):
+        keygetter({}, "missing\nERROR libtmux forged")
+
+    record = caplog.records[-1]
+    assert "\n" not in record.getMessage()
+    assert "\\nERROR libtmux forged" in record.getMessage()
+
+
 def test_oversized_command_is_capped_in_the_record(
     server: Server,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """A command tmux refuses must not put its whole payload in the log.
-
-    tmux caps a command at ``MAX_IMSGSIZE``, so a payload past that never runs;
-    a shortened record ends in an ellipsis to say so.
-    """
+    """An oversized rejected command must not put its whole payload in the log."""
     from libtmux._internal.log_context import _COMMAND_CAP
 
     with (
         caplog.at_level(logging.DEBUG, logger="libtmux.common"),
         contextlib.suppress(Exception),
     ):
-        server.set_buffer("x" * (_COMMAND_CAP * 4))
+        server.cmd("list-sessions", "-F", "x" * (_COMMAND_CAP * 4))
 
     records = [r for r in caplog.records if hasattr(r, "tmux_cmd")]
     assert len(records) >= 1
@@ -564,6 +803,35 @@ def test_environment_values_are_hidden_in_both_directions(
         if secret in str(getattr(r, key, ""))
     ]
     assert leaked == [], f"secret reached {len(leaked)} record(s)"
+
+
+def test_multiline_environment_and_buffer_content_are_withheld(
+    server: Server,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Known multiline and buffer content reaches callers, not records."""
+    continuation = "logging-continuation-secret"
+    buffer_content = "logging-buffer-secret"
+    server.new_session(session_name="logging_sensitive_content")
+    server.set_environment("DEPLOY_KEY", f"first\n{continuation}")
+
+    with caplog.at_level(logging.DEBUG, logger="libtmux.common"):
+        environment = server.cmd("show-environment", "-g", "DEPLOY_KEY")
+        server.set_buffer(buffer_content)
+        buffer = server.cmd("show-buffer")
+
+    assert continuation in environment.stdout
+    assert buffer.stdout == [buffer_content]
+    leaked = [
+        record
+        for record in caplog.records
+        for key in ("tmux_cmd", "tmux_stdout")
+        if any(
+            marker in str(getattr(record, key, ""))
+            for marker in (continuation, buffer_content)
+        )
+    ]
+    assert leaked == []
 
 
 def test_pane_content_is_not_written_to_records(
@@ -624,20 +892,42 @@ def test_parse_failure_is_logged(caplog: pytest.LogCaptureFixture) -> None:
     assert rec.tmux_fields_expected != rec.tmux_fields_received
 
 
-def test_records_share_no_mutable_state(
+def test_concurrent_records_share_no_mutable_state(
     session: Session,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """No two records may point at the same mutable value.
+    """Concurrent commands keep their fields isolated.
 
     Handler locks make :mod:`logging` itself thread-safe, so the only way
     libtmux could introduce a race is by handing the same list or dict to more
-    than one record. Nothing else here needs a lock, and this is what would
-    notice if that changed.
+    than one record.
     """
-    with caplog.at_level(logging.DEBUG, logger="libtmux"):
-        window = session.new_window(window_name="threadsafe")
-        window.kill()
+    server = session.server
+    markers = [f"concurrent-{index}" for index in range(8)]
+    with (
+        caplog.at_level(logging.DEBUG, logger="libtmux.common"),
+        concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor,
+    ):
+        futures = [
+            executor.submit(server.cmd, "display-message", "-p", marker)
+            for marker in markers
+        ]
+        results = [future.result() for future in futures]
+
+    assert [result.stdout for result in results] == [[marker] for marker in markers]
+    completed = [
+        record
+        for record in caplog.records
+        if record.getMessage() == "tmux command completed"
+        and getattr(record, "tmux_subcommand", None) == "display-message"
+    ]
+    assert len(completed) == len(markers)
+    assert {tuple(t.cast(t.Any, record).tmux_stdout) for record in completed} == {
+        (marker,) for marker in markers
+    }
+    assert all(
+        t.cast(t.Any, record).tmux_socket == server.socket_name for record in completed
+    )
 
     containers = [
         (id(value), record.getMessage(), key)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import errno
 import logging
+import os
 import pathlib
 import typing as t
 from collections.abc import Callable
@@ -327,6 +329,21 @@ def test_unusable_tmux_binary_propagates_without_logging(
     assert [
         record for record in caplog.records if record.levelno == logging.ERROR
     ] == []
+
+
+def test_unrelated_tmux_launch_failure_preserves_diagnostics() -> None:
+    """A launch resource failure is not mislabeled as a missing executable."""
+    from libtmux import exc
+    from libtmux.common import tmux_cmd
+
+    with pytest.raises(exc.LibTmuxException) as exc_info:
+        tmux_cmd("set-buffer", "x" * os.sysconf("SC_ARG_MAX"))
+
+    assert not isinstance(exc_info.value, exc.TmuxCommandNotFound)
+    cause = exc_info.value.__cause__
+    assert isinstance(cause, OSError)
+    assert cause.errno == errno.E2BIG
+    assert str(exc_info.value) == str(cause)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -79,6 +79,27 @@ def test_tmux_cmd_debug_logging_schema(
     assert completed.tmux_stderr_len == 0
 
 
+def test_fetch_objs_emits_one_command_record_pair(
+    session: Session,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A query emits one dispatch/completion pair without duplicate records."""
+    from libtmux.neo import fetch_objs
+
+    with caplog.at_level(logging.DEBUG, logger="libtmux"):
+        fetch_objs(server=session.server, list_cmd="list-sessions")
+
+    records = [
+        record
+        for record in caplog.records
+        if getattr(record, "tmux_subcommand", None) == "list-sessions"
+    ]
+    assert [(record.name, record.getMessage()) for record in records] == [
+        ("libtmux.common", "tmux command dispatched"),
+        ("libtmux.common", "tmux command completed"),
+    ]
+
+
 def test_tmux_cmd_debug_logging_bounds_large_output(
     caplog: pytest.LogCaptureFixture,
 ) -> None:

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import typing as t
 
@@ -513,3 +514,28 @@ def test_command_content_cannot_forge_a_log_line(
     rec = t.cast(t.Any, dispatched[-1])
     assert "\n" not in rec.tmux_cmd
     assert "$'echo hi\\nCRITICAL libtmux.server forged'" in rec.tmux_cmd
+
+
+def test_oversized_command_is_capped_in_the_record(
+    server: Server,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A command tmux refuses must not put its whole payload in the log.
+
+    tmux caps a command at ``MAX_IMSGSIZE``, so a payload past that never runs;
+    the record keeps ``tmux_cmd_len`` to report what the caller actually passed.
+    """
+    from libtmux._internal.log_context import _COMMAND_CAP
+
+    with (
+        caplog.at_level(logging.DEBUG, logger="libtmux.common"),
+        contextlib.suppress(Exception),
+    ):
+        server.set_buffer("x" * (_COMMAND_CAP * 4))
+
+    records = [r for r in caplog.records if hasattr(r, "tmux_cmd")]
+    assert len(records) >= 1
+
+    rec = t.cast(t.Any, records[0])
+    assert len(rec.tmux_cmd) <= _COMMAND_CAP
+    assert rec.tmux_cmd_len > _COMMAND_CAP

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -487,3 +487,29 @@ def test_failure_record_names_the_caller(
     rec = records[0]
     assert rec.funcName == "kill_window"
     assert rec.filename == "session.py"
+
+
+def test_command_content_cannot_forge_a_log_line(
+    session: Session,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A newline a caller sends must not end the record and start a new one.
+
+    ``send_keys`` carries whatever the caller types, so a multi-line payload
+    would otherwise split one record across several lines of a line-oriented
+    log, where the remainder reads as a record of its own.
+    """
+    pane = session.active_window.active_pane
+    assert pane is not None
+
+    with caplog.at_level(logging.DEBUG, logger="libtmux.common"):
+        pane.send_keys("echo hi\nCRITICAL libtmux.server forged", enter=False)
+
+    dispatched = [
+        r for r in caplog.records if r.getMessage() == "tmux command dispatched"
+    ]
+    assert len(dispatched) >= 1
+
+    rec = t.cast(t.Any, dispatched[-1])
+    assert "\n" not in rec.tmux_cmd
+    assert "$'echo hi\\nCRITICAL libtmux.server forged'" in rec.tmux_cmd

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -77,6 +77,7 @@ def test_lifecycle_info_logging(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Lifecycle call sites emit the shared string-valued context schema."""
+    from libtmux._internal.log_context import object_extra
     from libtmux.test.random import namer
 
     session_name = f"log_session_{next(namer)}"
@@ -128,8 +129,8 @@ def test_lifecycle_info_logging(
         "window killed",
         lambda: session.kill_window(window.window_id),
     )
-    doomed_name = f"log_session_{next(namer)}\u2028ERROR forged"
-    _capture_info(
+    doomed_name = f"log_session_{next(namer)}"
+    doomed, _ = _capture_info(
         caplog,
         "libtmux.server",
         "session created",
@@ -184,7 +185,11 @@ def test_lifecycle_info_logging(
     assert pane_created.tmux_pane == split_pane.pane_id
     assert pane_killed.tmux_pane == split_pane.pane_id
     assert window_killed.tmux_target == window.window_id
-    assert session_killed.tmux_target == ascii(doomed_name)
+    assert session_killed.tmux_target == doomed.session_name
+    assert (
+        object_extra("kill-session", target="safe\u2028ERROR forged")["tmux_target"]
+        == "'safe\\u2028ERROR forged'"
+    )
 
 
 def test_all_except_lifecycle_logging(

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -126,8 +126,8 @@ def test_lifecycle_info_logging(
         "window killed",
         lambda: session.kill_window(window.window_id),
     )
-    doomed_name = f"log_session_{next(namer)}"
-    doomed, _ = _capture_info(
+    doomed_name = f"log_session_{next(namer)}\u2028ERROR forged"
+    _capture_info(
         caplog,
         "libtmux.server",
         "session created",
@@ -182,7 +182,7 @@ def test_lifecycle_info_logging(
     assert pane_created.tmux_pane == split_pane.pane_id
     assert pane_killed.tmux_pane == split_pane.pane_id
     assert window_killed.tmux_target == window.window_id
-    assert session_killed.tmux_target == doomed.session_name
+    assert session_killed.tmux_target == ascii(doomed_name)
 
 
 def test_all_except_lifecycle_logging(

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -305,9 +305,10 @@ def test_options_warning_logging_schema(
     from libtmux._internal.sparse_array import SparseArray
     from libtmux.options import explode_complex
 
-    # A terminal-features value without ":" triggers a split failure and WARNING
+    # ints rather than "term:feature" strings, so every .split() fails
     bad_features: SparseArray[str | int | bool | None] = SparseArray()
-    bad_features[0] = 42  # int, not str — causes .split() to fail
+    for index in range(25):
+        bad_features[index] = index
 
     with caplog.at_level(logging.WARNING, logger="libtmux.options"):
         explode_complex({"terminal-features": bad_features})  # type: ignore[dict-item]
@@ -317,10 +318,13 @@ def test_options_warning_logging_schema(
         for r in caplog.records
         if hasattr(r, "tmux_option_key") and r.levelno == logging.WARNING
     ]
-    assert len(records) >= 1, "expected WARNING record for option parse failure"
+    assert len(records) == 1, (
+        f"one option should warn once, not once per entry; got {len(records)}"
+    )
 
     rec = t.cast(t.Any, records[0])
     assert isinstance(rec.tmux_option_key, str)
+    assert rec.tmux_option_skipped == 25
     assert rec.exc_info is None
 
 
@@ -332,6 +336,9 @@ def test_options_warning_logging_schema(
         (["tmux", "-S", "/tmp/s", "kill-server"], "kill-server", "/tmp/s"),
         (["tmux", "-f", "/etc/tmux.conf", "kill-server"], "kill-server", None),
         (["tmux", "-2", "-q", "list-panes"], "list-panes", None),
+        (["tmux", "-2Lsock", "new-session"], "new-session", "sock"),
+        (["tmux", "-2L", "sock", "new-session"], "new-session", "sock"),
+        (["tmux", "-qu", "-S", "/tmp/x", "kill-server"], "kill-server", "/tmp/x"),
         (["tmux", "-c", "echo hi", "run-shell"], "run-shell", None),
         (["tmux", "-T", "256", "list-keys"], "list-keys", None),
         (["tmux", "-V"], None, None),
@@ -342,6 +349,9 @@ def test_options_warning_logging_schema(
         "socket-path",
         "separated-config",
         "bundled-booleans",
+        "boolean-bundled-with-socket",
+        "boolean-bundled-socket-takes-next",
+        "bundled-booleans-then-socket-path",
         "separated-shell-command",
         "separated-features",
         "no-subcommand",
@@ -451,3 +461,29 @@ def test_session_fixture_setup_logs_no_errors(
 
     errors = [r for r in caplog.get_records("setup") if r.levelno >= logging.ERROR]
     assert errors == [], f"fixture setup logged: {[r.getMessage() for r in errors]}"
+
+
+def test_failure_record_names_the_caller(
+    session: Session,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The ERROR record locates the tmux operation, not the shared helper.
+
+    ``raise_if_stderr()`` has many call sites; without ``stacklevel`` every one
+    of them reports the same file and line, which makes ``%(filename)s`` and
+    OpenTelemetry's ``code.filepath`` useless for finding the failure.
+    """
+    from libtmux import exc
+
+    with (
+        caplog.at_level(logging.ERROR, logger="libtmux.common"),
+        pytest.raises(exc.LibTmuxException),
+    ):
+        session.kill_window(target_window="no_such_window")
+
+    records = [r for r in caplog.records if r.levelno == logging.ERROR]
+    assert len(records) >= 1
+
+    rec = records[0]
+    assert rec.funcName == "kill_window"
+    assert rec.filename == "session.py"

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -525,7 +525,7 @@ def test_oversized_command_is_capped_in_the_record(
     """A command tmux refuses must not put its whole payload in the log.
 
     tmux caps a command at ``MAX_IMSGSIZE``, so a payload past that never runs;
-    the record keeps ``tmux_cmd_len`` to report what the caller actually passed.
+    a shortened record ends in an ellipsis to say so.
     """
     from libtmux._internal.log_context import _COMMAND_CAP
 
@@ -540,7 +540,7 @@ def test_oversized_command_is_capped_in_the_record(
 
     rec = t.cast(t.Any, records[0])
     assert len(rec.tmux_cmd) <= _COMMAND_CAP
-    assert rec.tmux_cmd_len > _COMMAND_CAP
+    assert rec.tmux_cmd.endswith("\N{HORIZONTAL ELLIPSIS}")
 
 
 def test_environment_values_are_hidden_in_both_directions(
@@ -622,3 +622,32 @@ def test_parse_failure_is_logged(caplog: pytest.LogCaptureFixture) -> None:
     assert rec.tmux_subcommand == "list-panes"
     assert rec.tmux_fields_received == 3
     assert rec.tmux_fields_expected != rec.tmux_fields_received
+
+
+def test_records_share_no_mutable_state(
+    session: Session,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """No two records may point at the same mutable value.
+
+    Handler locks make :mod:`logging` itself thread-safe, so the only way
+    libtmux could introduce a race is by handing the same list or dict to more
+    than one record. Nothing else here needs a lock, and this is what would
+    notice if that changed.
+    """
+    with caplog.at_level(logging.DEBUG, logger="libtmux"):
+        window = session.new_window(window_name="threadsafe")
+        window.kill()
+
+    containers = [
+        (id(value), record.getMessage(), key)
+        for record in caplog.records
+        for key, value in record.__dict__.items()
+        if key.startswith("tmux_") and isinstance(value, (list, dict))
+    ]
+    assert containers, "expected records carrying list-valued fields"
+
+    identities = [identity for identity, _, _ in containers]
+    assert len(identities) == len(set(identities)), (
+        f"records share a mutable value: {containers}"
+    )

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -296,20 +296,28 @@ def test_environment_failure_propagates_without_logging(
     ] == []
 
 
-@pytest.mark.parametrize("configured", [True, False], ids=["configured", "default"])
-def test_missing_tmux_binary_propagates_without_logging(
-    configured: bool,
+@pytest.mark.parametrize(
+    "binary_case",
+    ["configured-missing", "default-missing", "not-executable", "invalid-format"],
+)
+def test_unusable_tmux_binary_propagates_without_logging(
+    binary_case: str,
     tmp_path: pathlib.Path,
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """A missing executable remains exception data, not a log record."""
+    """An unusable executable remains exception data, not a log record."""
     from libtmux import exc
     from libtmux.common import tmux_cmd
 
-    tmux_bin = str(tmp_path / "missing-tmux") if configured else None
-    if not configured:
+    tmux_path = tmp_path / "tmux"
+    tmux_bin: str | None = str(tmux_path)
+    if binary_case == "default-missing":
+        tmux_bin = None
         monkeypatch.setattr("libtmux.common.shutil.which", lambda _: None)
+    elif binary_case in {"not-executable", "invalid-format"}:
+        tmux_path.write_text("not an executable format\n")
+        tmux_path.chmod(0o644 if binary_case == "not-executable" else 0o755)
     with (
         caplog.at_level(logging.ERROR, logger="libtmux.common"),
         pytest.raises(exc.TmuxCommandNotFound),

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -367,37 +367,119 @@ def test_environment_failure_propagates_without_logging(
     ] == []
 
 
-@pytest.mark.parametrize(
-    "binary_case",
-    ["configured-missing", "default-missing", "not-executable", "invalid-format"],
-)
-def test_unusable_tmux_binary_propagates_without_logging(
+_UNUSABLE_TMUX_CASES = [
+    pytest.param("configured-missing", errno.ENOENT, id="configured-missing"),
+    pytest.param("default-missing", None, id="default-missing"),
+    pytest.param("not-executable", errno.EACCES, id="not-executable"),
+    pytest.param("invalid-format", errno.ENOEXEC, id="invalid-format"),
+]
+
+
+def _prepare_unusable_tmux_binary(
     binary_case: str,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[str | None, pathlib.Path]:
+    """Build one unusable executable case and return its configured path."""
+    tmux_path = tmp_path / "tmux"
+    if binary_case == "default-missing":
+        monkeypatch.setenv("PATH", "")
+        return None, tmux_path
+    if binary_case in {"not-executable", "invalid-format"}:
+        tmux_path.write_text("not an executable format\n")
+        tmux_path.chmod(0o644 if binary_case == "not-executable" else 0o755)
+    return str(tmux_path), tmux_path
+
+
+@pytest.mark.parametrize("loud_api", ["tmux-cmd", "raise-if-dead"])
+@pytest.mark.parametrize(("binary_case", "expected_errno"), _UNUSABLE_TMUX_CASES)
+def test_loud_apis_preserve_unusable_tmux_diagnostics_without_logging(
+    loud_api: str,
+    binary_case: str,
+    expected_errno: int | None,
     tmp_path: pathlib.Path,
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """An unusable executable remains exception data, not a log record."""
+    """Loud APIs preserve available launch facts in one domain exception."""
     from libtmux import exc
     from libtmux.common import tmux_cmd
+    from libtmux.server import Server
 
-    tmux_path = tmp_path / "tmux"
-    tmux_bin: str | None = str(tmux_path)
-    if binary_case == "default-missing":
-        tmux_bin = None
-        monkeypatch.setattr("libtmux.common.shutil.which", lambda _: None)
-    elif binary_case in {"not-executable", "invalid-format"}:
-        tmux_path.write_text("not an executable format\n")
-        tmux_path.chmod(0o644 if binary_case == "not-executable" else 0o755)
+    tmux_bin, tmux_path = _prepare_unusable_tmux_binary(
+        binary_case, tmp_path, monkeypatch
+    )
+
+    def run_tmux_cmd() -> object:
+        return tmux_cmd("list-sessions", tmux_bin=tmux_bin)
+
+    action = (
+        run_tmux_cmd
+        if loud_api == "tmux-cmd"
+        else Server(tmux_bin=tmux_bin).raise_if_dead
+    )
+
     with (
         caplog.at_level(logging.ERROR, logger="libtmux.common"),
-        pytest.raises(exc.TmuxCommandNotFound),
+        pytest.raises(exc.TmuxCommandNotFound) as exc_info,
     ):
-        tmux_cmd("list-sessions", tmux_bin=tmux_bin)
+        action()
 
     assert [
         record for record in caplog.records if record.levelno == logging.ERROR
     ] == []
+    if expected_errno is None:
+        assert str(exc_info.value) == "tmux executable not found on PATH"
+        assert exc_info.value.__cause__ is None
+    else:
+        cause = exc_info.value.__cause__
+        assert isinstance(cause, OSError)
+        assert cause.errno == expected_errno
+        assert str(exc_info.value) == str(cause)
+        assert str(tmux_path) in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    ("accessor", "list_cmd"),
+    [
+        ("sessions", "list-sessions"),
+        ("attached_sessions", "list-sessions"),
+        ("clients", "list-clients"),
+    ],
+)
+@pytest.mark.parametrize(("binary_case", "expected_errno"), _UNUSABLE_TMUX_CASES)
+def test_lenient_accessors_log_unusable_tmux_diagnostics(
+    accessor: str,
+    list_cmd: str,
+    binary_case: str,
+    expected_errno: int | None,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A swallowed launch failure keeps its diagnostic in the boundary record."""
+    from libtmux.server import Server
+
+    tmux_bin, tmux_path = _prepare_unusable_tmux_binary(
+        binary_case, tmp_path, monkeypatch
+    )
+    server = Server(tmux_bin=tmux_bin)
+
+    with caplog.at_level(logging.ERROR, logger="libtmux.server"):
+        assert list(getattr(server, accessor)) == []
+
+    records = [record for record in caplog.records if record.levelno == logging.ERROR]
+    assert len(records) == 1
+    record = t.cast(t.Any, records[0])
+    assert record.tmux_subcommand == list_cmd
+    assert record.tmux_stderr_len == 1
+    assert len(record.tmux_stderr) == 1
+    diagnostic = record.tmux_stderr[0]
+    if expected_errno is None:
+        assert diagnostic == "tmux executable not found on PATH"
+    else:
+        assert os.strerror(expected_errno) in diagnostic
+        assert str(tmux_path) in diagnostic
 
 
 def test_unrelated_tmux_launch_failure_preserves_diagnostics() -> None:
@@ -415,9 +497,25 @@ def test_unrelated_tmux_launch_failure_preserves_diagnostics() -> None:
     assert str(exc_info.value) == str(cause)
 
 
+def test_raise_if_dead_unrelated_launch_failure_stays_os_error() -> None:
+    """The loud server probe does not classify resource errors as unavailable."""
+    from libtmux import exc
+    from libtmux.server import Server
+
+    server = Server(
+        tmux_bin=sys.executable,
+        config_file="x" * os.sysconf("SC_ARG_MAX"),
+    )
+    with pytest.raises(OSError) as exc_info:
+        server.raise_if_dead()
+
+    assert not isinstance(exc_info.value, exc.TmuxCommandNotFound)
+    assert exc_info.value.errno == errno.E2BIG
+
+
 @pytest.mark.parametrize(
     "binary_case",
-    ["configured-missing", "default-missing", "invalid-format"],
+    ["configured-missing", "default-missing", "not-executable", "invalid-format"],
 )
 def test_is_alive_unusable_binary_stays_quiet(
     binary_case: str,
@@ -432,10 +530,10 @@ def test_is_alive_unusable_binary_stays_quiet(
     if binary_case == "default-missing":
         tmux_bin = None
         monkeypatch.setenv("PATH", "")
-    elif binary_case == "invalid-format":
+    elif binary_case in {"not-executable", "invalid-format"}:
         invalid_tmux = tmp_path / "invalid-tmux"
         invalid_tmux.write_text("not an executable format\n")
-        invalid_tmux.chmod(0o755)
+        invalid_tmux.chmod(0o644 if binary_case == "not-executable" else 0o755)
         tmux_bin = str(invalid_tmux)
     server = Server(tmux_bin=tmux_bin)
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import types
 import typing as t
 
 import pytest
@@ -268,27 +267,35 @@ def test_session_kill_all_except_logging(
 
 
 def test_server_new_session_surfaces_kill_session_stderr(
+    server: Server,
     monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test kill-session stderr propagation using monkeypatch for the failure path.
+    """Test kill-session stderr propagation, and the ERROR record it emits.
 
-    A real tmux fixture is not used here because this path requires forcing a
-    kill-session command failure before session creation begins.
+    ``has_session`` is monkeypatched so ``new_session`` attempts to kill a
+    session that does not exist; tmux then fails the ``kill-session`` for real,
+    which is the condition under test.
     """
     from libtmux import exc
-    from libtmux.server import Server
-    from libtmux.test.random import namer
 
-    server = Server(socket_name=f"libtmux_log_{next(namer)}")
     monkeypatch.setattr(server, "has_session", lambda session_name: True)
-    monkeypatch.setattr(
-        server,
-        "cmd",
-        lambda *args, **kwargs: types.SimpleNamespace(stderr=["kill failed"]),
-    )
 
-    with pytest.raises(exc.LibTmuxException, match="kill failed"):
-        server.new_session(session_name="existing_session", kill_session=True)
+    with (
+        caplog.at_level(logging.ERROR, logger="libtmux.common"),
+        pytest.raises(exc.LibTmuxException, match="kill-session"),
+    ):
+        server.new_session(session_name="no_such_session", kill_session=True)
+
+    records = [r for r in caplog.records if r.levelno == logging.ERROR]
+    assert len(records) >= 1, "expected ERROR record for the failed kill-session"
+
+    rec = t.cast(t.Any, records[0])
+    assert rec.getMessage() == "tmux command failed"
+    assert rec.tmux_subcommand == "kill-session"
+    assert isinstance(rec.tmux_exit_code, int)
+    assert rec.tmux_exit_code != 0
+    assert rec.tmux_stderr_len >= 1
 
 
 def test_options_warning_logging_schema(
@@ -315,3 +322,91 @@ def test_options_warning_logging_schema(
     rec = t.cast(t.Any, records[0])
     assert isinstance(rec.tmux_option_key, str)
     assert rec.exc_info is None
+
+
+@pytest.mark.parametrize(
+    ("argv", "subcommand", "socket"),
+    [
+        (["tmux", "-Lsock", "new-session"], "new-session", "sock"),
+        (["tmux", "-L", "sock", "new-session"], "new-session", "sock"),
+        (["tmux", "-S", "/tmp/s", "kill-server"], "kill-server", "/tmp/s"),
+        (["tmux", "-f", "/etc/tmux.conf", "kill-server"], "kill-server", None),
+        (["tmux", "-2", "-q", "list-panes"], "list-panes", None),
+        (["tmux", "-c", "echo hi", "run-shell"], "run-shell", None),
+        (["tmux", "-T", "256", "list-keys"], "list-keys", None),
+        (["tmux", "-V"], None, None),
+    ],
+    ids=[
+        "joined-socket",
+        "separated-socket",
+        "socket-path",
+        "separated-config",
+        "bundled-booleans",
+        "separated-shell-command",
+        "separated-features",
+        "no-subcommand",
+    ],
+)
+def test_describe_command_reads_tmux_global_flags(
+    argv: list[str],
+    subcommand: str | None,
+    socket: str | None,
+) -> None:
+    """Global flags that take a value must not be read as the subcommand.
+
+    Mirrors tmux's own ``getopt`` string in ``tmux.c`` (``2c:CDdf:hlL:NqS:T:uUvV``).
+    libtmux always joins its own flags, so only a caller building a command line
+    by hand reaches the separated forms.
+    """
+    from libtmux._internal.log_context import describe_command
+
+    context = describe_command(argv)
+    assert context.subcommand == subcommand
+    assert context.socket == socket
+
+
+@pytest.mark.parametrize(
+    ("argv", "expected"),
+    [
+        (["tmux", "new-session", "-eK=v"], "tmux new-session -eK=REDACTED"),
+        (["tmux", "new-session", "-e", "K=v"], "tmux new-session -e K=REDACTED"),
+        (["tmux", "split-window", "-eK=a=b"], "tmux split-window -eK=REDACTED"),
+        (["tmux", "set-environment", "K", "v"], "tmux set-environment K REDACTED"),
+        (["tmux", "set-environment", "-u", "K"], "tmux set-environment -u K"),
+        (["tmux", "select-pane", "-e", "-t%1"], "tmux select-pane -e -t%1"),
+        (["tmux", "copy-mode", "-e"], "tmux copy-mode -e"),
+    ],
+    ids=[
+        "joined-env-pair",
+        "separated-env-pair",
+        "value-containing-equals",
+        "set-environment-value",
+        "set-environment-unset-keeps-name",
+        "select-pane-boolean-e",
+        "copy-mode-boolean-e",
+    ],
+)
+def test_describe_command_redacts_only_environment_values(
+    argv: list[str],
+    expected: str,
+) -> None:
+    """``-e`` is an env pair on some subcommands and a boolean on others."""
+    from libtmux._internal.log_context import describe_command
+
+    assert describe_command(argv).command == expected
+
+
+def test_command_records_carry_socket_identity(
+    server: Server,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Records name which tmux server they came from."""
+    with caplog.at_level(logging.DEBUG, logger="libtmux.common"):
+        server.cmd("list-sessions")
+
+    records = [r for r in caplog.records if hasattr(r, "tmux_socket")]
+    assert len(records) >= 1, "expected records tagged with the socket"
+
+    rec = t.cast(t.Any, records[0])
+    assert rec.tmux_socket == server.socket_name
+    assert rec.tmux_subcommand == "list-sessions"

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import concurrent.futures
-import contextlib
 import logging
 import pathlib
 import typing as t
@@ -29,6 +28,10 @@ def test_tmux_cmd_debug_logging_schema(
     record = t.cast(t.Any, records[0])
     assert isinstance(record.tmux_cmd, str)
     assert isinstance(record.tmux_exit_code, int)
+    assert isinstance(record.tmux_stdout_len, int)
+    assert isinstance(record.tmux_stderr_len, int)
+    assert not hasattr(record, "tmux_stdout")
+    assert not hasattr(record, "tmux_stderr")
 
 
 def test_lifecycle_info_logging_schema(
@@ -294,16 +297,14 @@ def test_server_new_session_propagates_without_logging(
     ):
         server.new_session(session_name="no_such_session", kill_session=True)
 
-    assert [
-        record for record in caplog.records if record.levelno == logging.ERROR
-    ] == []
+    assert [r for r in caplog.records if r.levelno == logging.ERROR] == []
 
 
 def test_environment_failure_propagates_without_logging(
     server: Server,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Translated environment errors remain exception data."""
+    """A translated environment failure remains exception data only."""
     dead = server.new_session(session_name="logging_dead_environment")
     dead.kill()
 
@@ -313,9 +314,7 @@ def test_environment_failure_propagates_without_logging(
     ):
         dead.set_environment("KEY", "value")
 
-    assert [
-        record for record in caplog.records if record.levelno == logging.ERROR
-    ] == []
+    assert [r for r in caplog.records if r.levelno == logging.ERROR] == []
 
 
 @pytest.mark.parametrize("configured", [True, False], ids=["configured", "default"])
@@ -338,9 +337,7 @@ def test_missing_tmux_binary_propagates_without_logging(
     ):
         tmux_cmd("list-sessions", tmux_bin=tmux_bin)
 
-    assert [
-        record for record in caplog.records if record.levelno == logging.ERROR
-    ] == []
+    assert [r for r in caplog.records if r.levelno == logging.ERROR] == []
 
 
 @pytest.mark.parametrize(
@@ -406,239 +403,60 @@ def test_options_warning_logging_schema(
 
 
 @pytest.mark.parametrize(
-    ("argv", "subcommand", "socket"),
-    [
-        (["tmux", "-Lsock", "new-session"], "new-session", "sock"),
-        (["tmux", "-L", "sock", "new-session"], "new-session", "sock"),
-        (["tmux", "-S", "/tmp/s", "kill-server"], "kill-server", "/tmp/s"),
-        (["tmux", "-f", "/etc/tmux.conf", "kill-server"], "kill-server", None),
-        (["tmux", "-2", "-q", "list-panes"], "list-panes", None),
-        (["tmux", "-2Lsock", "new-session"], "new-session", "sock"),
-        (["tmux", "-2L", "sock", "new-session"], "new-session", "sock"),
-        (["tmux", "-qu", "-S", "/tmp/x", "kill-server"], "kill-server", "/tmp/x"),
-        (["tmux", "-c", "echo hi", "run-shell"], "run-shell", None),
-        (["tmux", "-T", "256", "list-keys"], "list-keys", None),
-        (
-            ["tmux", "-L", "label", "-S", "/tmp/path", "list-sessions"],
-            "list-sessions",
-            "/tmp/path",
-        ),
-        (
-            ["tmux", "-S/path", "-Llabel", "list-sessions"],
-            "list-sessions",
-            "/path",
-        ),
-        (["tmux", "-V"], None, None),
-    ],
-    ids=[
-        "joined-socket",
-        "separated-socket",
-        "socket-path",
-        "separated-config",
-        "bundled-booleans",
-        "boolean-bundled-with-socket",
-        "boolean-bundled-socket-takes-next",
-        "bundled-booleans-then-socket-path",
-        "separated-shell-command",
-        "separated-features",
-        "path-after-label",
-        "path-before-label",
-        "no-subcommand",
-    ],
-)
-def test_describe_command_reads_tmux_global_flags(
-    argv: list[str],
-    subcommand: str | None,
-    socket: str | None,
-) -> None:
-    """Global flags that take a value must not be read as the subcommand.
-
-    Mirrors tmux's own ``getopt`` string in ``tmux.c`` (``2c:CDdf:hlL:NqS:T:uUvV``).
-    libtmux always joins its own flags, so only a caller building a command line
-    by hand reaches the separated forms.
-    """
-    from libtmux._internal.log_context import describe_command
-
-    context = describe_command(argv)
-    assert context.subcommand == subcommand
-    assert context.socket == socket
-
-
-@pytest.mark.parametrize(
     ("argv", "expected"),
     [
-        (["tmux", "new-session", "-eK=v"], "tmux new-session -eK=REDACTED"),
-        (["tmux", "new-session", "-e", "K=v"], "tmux new-session -e K=REDACTED"),
-        (["tmux", "split-window", "-eK=a=b"], "tmux split-window -eK=REDACTED"),
-        (["tmux", "set-environment", "K", "v"], "tmux set-environment K REDACTED"),
         (
-            ["tmux", "setenv", "-Ft", "work", "K", "-secret"],
-            "tmux setenv -Ft work K REDACTED",
-        ),
-        (["tmux", "set-environment", "-u", "K"], "tmux set-environment -u K"),
-        (["tmux", "select-pane", "-e", "-t%1"], "tmux select-pane -e -t%1"),
-        (["tmux", "select-pane", "-eK=v"], "tmux select-pane -eK=v"),
-        (["tmux", "copy-mode", "-e"], "tmux copy-mode -e"),
-        (
-            ["tmux", "new-session", "-c/tmp/secret=path"],
-            "tmux new-session -c/tmp/secret=path",
+            ["tmux", "-Lsock", "new-session", "-eKEY=secret"],
+            {
+                "tmux_cmd": "tmux -L sock new-session <1 arguments omitted>",
+                "tmux_subcommand": "new-session",
+                "tmux_socket": "sock",
+            },
         ),
         (
-            ["tmux", "set-buffer", "-b", "named", "secret data"],
-            "tmux set-buffer -b named REDACTED",
+            ["tmux", "-S", "/tmp/s", "set-buffer", "secret"],
+            {
+                "tmux_cmd": "tmux -S /tmp/s set-buffer <1 arguments omitted>",
+                "tmux_subcommand": "set-buffer",
+                "tmux_socket": "/tmp/s",
+            },
         ),
-        (["tmux", "setb", "secret data"], "tmux setb REDACTED"),
-        (["tmux", "set-e", "K", "secret"], "tmux set-e K REDACTED"),
-        (["tmux", "set-b", "secret data"], "tmux set-b REDACTED"),
-    ],
-    ids=[
-        "joined-env-pair",
-        "separated-env-pair",
-        "value-containing-equals",
-        "set-environment-value",
-        "setenv-dash-prefixed-value",
-        "set-environment-unset-keeps-name",
-        "select-pane-boolean-e",
-        "select-pane-joined-boolean-e",
-        "copy-mode-boolean-e",
-        "other-option-attached-value",
-        "set-buffer-content",
-        "setb-content",
-        "set-environment-prefix",
-        "set-buffer-prefix",
+        (
+            ["tmux", "-f", "secret-conf", "run-shell", "secret"],
+            {
+                "tmux_cmd": "tmux run-shell <1 arguments omitted>",
+                "tmux_subcommand": "run-shell",
+            },
+        ),
+        (
+            ["tmux", "-2L", "sock", "list-panes"],
+            {
+                "tmux_cmd": "tmux -L sock list-panes",
+                "tmux_subcommand": "list-panes",
+                "tmux_socket": "sock",
+            },
+        ),
+        (
+            ["tmux", "-L", "safe\nforged", "future-command", "secret"],
+            {
+                "tmux_cmd": (
+                    "tmux -L 'safe\\nforged' future-command <1 arguments omitted>"
+                ),
+                "tmux_subcommand": "future-command",
+                "tmux_socket": "'safe\\nforged'",
+            },
+        ),
+        (["tmux", "-V"], {"tmux_cmd": "tmux"}),
     ],
 )
-def test_describe_command_redacts_only_environment_values(
+def test_command_extra_separates_operation_from_parameters(
     argv: list[str],
-    expected: str,
+    expected: dict[str, str],
 ) -> None:
-    """``-e`` is an env pair on some subcommands and a boolean on others."""
-    from libtmux._internal.log_context import describe_command
+    """Operation records identify tmux without carrying parameter data."""
+    from libtmux._internal.log_context import command_extra
 
-    context = describe_command(argv)
-    assert context.subcommand == argv[1]
-    assert context.command == expected
-
-
-def test_describe_command_redacts_every_environment_spelling() -> None:
-    """Every built-in and default alias that accepts ``-e`` hides its value."""
-    from libtmux._internal.log_context import describe_command
-
-    subcommands = (
-        "new-session",
-        "new",
-        "new-window",
-        "neww",
-        "new-pane",
-        "newp",
-        "display-popup",
-        "popup",
-        "respawn-pane",
-        "respawnp",
-        "respawn-window",
-        "respawnw",
-        "split-window",
-        "splitw",
-        "split-pane",
-        "splitp",
-        "new-s",
-        "new-w",
-        "new-p",
-        "display-po",
-        "respawn-p",
-        "respawn-w",
-        "sp",
-    )
-    for subcommand in subcommands:
-        joined = describe_command(["tmux", subcommand, "-eKEY=secret"])
-        separated = describe_command(["tmux", subcommand, "-e", "KEY=secret"])
-        assert joined.command == f"tmux {subcommand} -eKEY=REDACTED"
-        assert separated.command == f"tmux {subcommand} -e KEY=REDACTED"
-
-
-@pytest.mark.parametrize(
-    ("subcommand", "boolean_flags"),
-    (
-        ("new-session", "-d"),
-        ("new-window", "-d"),
-        ("new-pane", "-df"),
-        ("display-popup", "-BE"),
-        ("respawn-pane", "-k"),
-        ("respawn-window", "-k"),
-        ("split-window", "-dP"),
-    ),
-)
-def test_describe_command_redacts_bundled_environment_options(
-    subcommand: str,
-    boolean_flags: str,
-) -> None:
-    """Boolean flags before value-taking ``-e`` cannot expose its value."""
-    from libtmux._internal.log_context import describe_command
-
-    option = f"{boolean_flags}eKEY=secret"
-
-    context = describe_command(["tmux", subcommand, option])
-
-    assert context.command == f"tmux {subcommand} {boolean_flags}eKEY=REDACTED"
-
-
-def test_redact_output_suppresses_sensitive_command_spellings() -> None:
-    """Environment, terminal, buffer, and history output stays off records."""
-    from libtmux._internal.log_context import redact_output
-
-    subcommands = (
-        "show-environment",
-        "showenv",
-        "capture-pane",
-        "capturep",
-        "save-buffer",
-        "saveb",
-        "show-buffer",
-        "showb",
-        "list-buffers",
-        "lsb",
-        "show-messages",
-        "showmsgs",
-        "server-info",
-        "info",
-        "show-prompt-history",
-        "showphist",
-        "show-e",
-        "ca",
-        "sa",
-        "show-b",
-        "list-b",
-        "show-m",
-        "show-p",
-    )
-    for subcommand in subcommands:
-        assert redact_output(subcommand, ["KEY=secret", "continuation"]) == []
-
-
-@pytest.mark.parametrize(
-    ("line_break", "escaped"),
-    (
-        ("\n", r"\n"),
-        ("\x85", r"\u0085"),
-        ("\u2028", r"\u2028"),
-        ("\u2029", r"\u2029"),
-    ),
-)
-def test_socket_identity_cannot_forge_a_log_line(
-    line_break: str,
-    escaped: str,
-) -> None:
-    """Socket identity stays scalar when tmux accepts a control character."""
-    from libtmux._internal.log_context import describe_command
-
-    context = describe_command(
-        ["tmux", "-L", f"safe{line_break}ERROR libtmux forged", "list-sessions"],
-    )
-
-    assert context.socket is not None
-    assert line_break not in context.socket
-    assert escaped in context.socket
-    assert context.socket.splitlines() == [context.socket]
+    assert command_extra(argv) == expected
 
 
 def test_command_records_carry_socket_identity(
@@ -721,7 +539,8 @@ def test_command_content_cannot_forge_a_log_line(
 
     rec = t.cast(t.Any, dispatched[-1])
     assert "\n" not in rec.tmux_cmd
-    assert "$'echo hi\\nCRITICAL libtmux.server forged'" in rec.tmux_cmd
+    assert "CRITICAL libtmux.server forged" not in rec.tmux_cmd
+    assert rec.tmux_cmd.endswith("send-keys <3 arguments omitted>")
 
 
 def test_lookup_path_cannot_forge_a_log_line(
@@ -736,79 +555,6 @@ def test_lookup_path_cannot_forge_a_log_line(
     record = caplog.records[-1]
     assert "\n" not in record.getMessage()
     assert "\\nERROR libtmux forged" in record.getMessage()
-
-
-def test_oversized_command_is_capped_in_the_record(
-    server: Server,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """An oversized rejected command must not put its whole payload in the log."""
-    from libtmux._internal.log_context import _COMMAND_CAP
-
-    with (
-        caplog.at_level(logging.DEBUG, logger="libtmux.common"),
-        contextlib.suppress(Exception),
-    ):
-        server.cmd("list-sessions", "-F", "x" * (_COMMAND_CAP * 4))
-
-    records = [r for r in caplog.records if hasattr(r, "tmux_cmd")]
-    assert len(records) >= 1
-
-    rec = t.cast(t.Any, records[0])
-    assert len(rec.tmux_cmd) <= _COMMAND_CAP
-    assert rec.tmux_cmd.endswith("\N{HORIZONTAL ELLIPSIS}")
-
-
-def test_environment_values_are_hidden_in_both_directions(
-    session: Session,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Redacting what libtmux sends is half of it; tmux hands the value back."""
-    secret = "s3cr3t-round-trip"
-    server = session.server
-    server.set_environment("DEPLOY_KEY", secret)
-
-    with caplog.at_level(logging.DEBUG, logger="libtmux.common"):
-        value = server.getenv("DEPLOY_KEY")
-
-    assert value == secret, "redaction must not change what the caller gets"
-
-    leaked = [
-        r
-        for r in caplog.records
-        for key in ("tmux_cmd", "tmux_stdout")
-        if secret in str(getattr(r, key, ""))
-    ]
-    assert leaked == [], f"secret reached {len(leaked)} record(s)"
-
-
-def test_multiline_environment_and_buffer_content_are_withheld(
-    server: Server,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Known multiline and buffer content reaches callers, not records."""
-    continuation = "logging-continuation-secret"
-    buffer_content = "logging-buffer-secret"
-    server.new_session(session_name="logging_sensitive_content")
-    server.set_environment("DEPLOY_KEY", f"first\n{continuation}")
-
-    with caplog.at_level(logging.DEBUG, logger="libtmux.common"):
-        environment = server.cmd("show-environment", "-g", "DEPLOY_KEY")
-        server.set_buffer(buffer_content)
-        buffer = server.cmd("show-buffer")
-
-    assert continuation in environment.stdout
-    assert buffer.stdout == [buffer_content]
-    leaked = [
-        record
-        for record in caplog.records
-        for key in ("tmux_cmd", "tmux_stdout")
-        if any(
-            marker in str(getattr(record, key, ""))
-            for marker in (continuation, buffer_content)
-        )
-    ]
-    assert leaked == []
 
 
 def test_pane_content_is_not_written_to_records(
@@ -831,20 +577,20 @@ def test_pane_content_is_not_written_to_records(
 
     assert any(marker in line for line in captured), "caller still gets the content"
 
-    records = [r for r in caplog.records if hasattr(r, "tmux_stdout")]
+    records = [r for r in caplog.records if r.getMessage() == "tmux command completed"]
     assert records, "expected a completion record"
     for record in records:
         rec = t.cast(t.Any, record)
-        assert not any(marker in line for line in rec.tmux_stdout)
+        assert not hasattr(rec, "tmux_stdout")
+        assert not hasattr(rec, "tmux_stderr")
         if rec.tmux_subcommand == "capture-pane":
-            assert rec.tmux_stdout == []
             assert rec.tmux_stdout_len > 0, "the count still reports what came back"
 
 
 def test_parse_failure_propagates_without_logging(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """A parser failure remains exception data."""
+    """A parser failure remains exception data, not a second error channel."""
     from libtmux.formats import FORMAT_SEPARATOR
     from libtmux.neo import parse_output
 
@@ -856,12 +602,10 @@ def test_parse_failure_propagates_without_logging(
     ):
         parse_output(row, "list-panes", "3.7")
 
-    assert [
-        record for record in caplog.records if record.levelno == logging.ERROR
-    ] == []
+    assert [r for r in caplog.records if r.levelno == logging.ERROR] == []
 
 
-def test_concurrent_records_share_no_mutable_state(
+def test_concurrent_records_keep_operation_context(
     session: Session,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -891,22 +635,8 @@ def test_concurrent_records_share_no_mutable_state(
         and getattr(record, "tmux_subcommand", None) == "display-message"
     ]
     assert len(completed) == len(markers)
-    assert {tuple(t.cast(t.Any, record).tmux_stdout) for record in completed} == {
-        (marker,) for marker in markers
-    }
     assert all(
         t.cast(t.Any, record).tmux_socket == server.socket_name for record in completed
     )
-
-    containers = [
-        (id(value), record.getMessage(), key)
-        for record in caplog.records
-        for key, value in record.__dict__.items()
-        if key.startswith("tmux_") and isinstance(value, (list, dict))
-    ]
-    assert containers, "expected records carrying list-valued fields"
-
-    identities = [identity for identity, _, _ in containers]
-    assert len(identities) == len(set(identities)), (
-        f"records share a mutable value: {containers}"
-    )
+    assert all(t.cast(t.Any, record).tmux_stdout_len == 1 for record in completed)
+    assert all(not hasattr(record, "tmux_stdout") for record in completed)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -594,3 +594,31 @@ def test_pane_content_is_not_written_to_records(
         if rec.tmux_subcommand == "capture-pane":
             assert rec.tmux_stdout == []
             assert rec.tmux_stdout_len > 0, "the count still reports what came back"
+
+
+def test_parse_failure_is_logged(caplog: pytest.LogCaptureFixture) -> None:
+    """A row libtmux cannot parse must say so; the exception names only zip().
+
+    A field holding the format separator splits in two, and the field counts are
+    what identify that. Nothing else in the log reports it: tmux succeeded, so
+    the command records show a clean exit.
+    """
+    from libtmux.formats import FORMAT_SEPARATOR
+    from libtmux.neo import parse_output
+
+    row = FORMAT_SEPARATOR.join(["one", "two", "three"]) + FORMAT_SEPARATOR
+
+    with (
+        caplog.at_level(logging.ERROR, logger="libtmux.neo"),
+        pytest.raises(ValueError, match="zip"),
+    ):
+        parse_output(row, "list-panes", "3.7")
+
+    records = [r for r in caplog.records if r.levelno == logging.ERROR]
+    assert len(records) == 1
+
+    rec = t.cast(t.Any, records[0])
+    assert rec.getMessage() == "tmux output parse failed"
+    assert rec.tmux_subcommand == "list-panes"
+    assert rec.tmux_fields_received == 3
+    assert rec.tmux_fields_expected != rec.tmux_fields_received

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -27,13 +27,15 @@ def _capture_info(
 ) -> tuple[t.Any, t.Any]:
     """Run one action and return its single matching lifecycle record."""
     caplog.clear()
-    with caplog.at_level(logging.INFO, logger=logger_name):
+    with caplog.at_level(logging.DEBUG, logger=logger_name):
         result = action()
 
     records = [
         record
         for record in caplog.records
-        if record.levelno == logging.INFO and record.getMessage() == message
+        if record.name == logger_name
+        and record.levelno == logging.INFO
+        and record.getMessage() == message
     ]
     assert len(records) == 1
     return result, t.cast(t.Any, records[0])
@@ -155,6 +157,15 @@ def test_lifecycle_info_logging(
         "session created",
         lambda: server.new_session(session_name=session_name),
     )
+    session_creating = t.cast(
+        t.Any,
+        next(
+            record
+            for record in caplog.records
+            if record.levelno == logging.DEBUG
+            and record.getMessage() == "creating session"
+        ),
+    )
     _, session_renamed = _capture_info(
         caplog,
         "libtmux.session",
@@ -206,6 +217,13 @@ def test_lifecycle_info_logging(
         "session killed",
         lambda: server.kill_session(doomed_name),
     )
+    replacement, existing_session_killed = _capture_info(
+        caplog,
+        "libtmux.server",
+        "existing session killed",
+        lambda: server.new_session(session_name=renamed_session, kill_session=True),
+    )
+    assert replacement.session_name == renamed_session
 
     records = [
         session_created,
@@ -216,6 +234,7 @@ def test_lifecycle_info_logging(
         pane_killed,
         window_killed,
         session_killed,
+        existing_session_killed,
     ]
     assert [
         (record.name, record.getMessage(), record.tmux_subcommand) for record in records
@@ -228,6 +247,7 @@ def test_lifecycle_info_logging(
         ("libtmux.pane", "pane killed", "kill-pane"),
         ("libtmux.session", "window killed", "kill-window"),
         ("libtmux.server", "session killed", "kill-session"),
+        ("libtmux.server", "existing session killed", "kill-session"),
     ]
     for record in records:
         assert record.tmux_socket == server.socket_name
@@ -243,6 +263,12 @@ def test_lifecycle_info_logging(
             assert value is None or isinstance(value, str)
 
     assert session_created.tmux_session == session_name
+    assert (
+        session_creating.name,
+        session_creating.tmux_subcommand,
+        session_creating.tmux_socket,
+        session_creating.tmux_session,
+    ) == ("libtmux.server", "new-session", server.socket_name, session_name)
     assert session_renamed.tmux_session == renamed_session
     assert window_created.tmux_window == window_name
     assert window_renamed.tmux_window == renamed_window
@@ -250,17 +276,18 @@ def test_lifecycle_info_logging(
     assert pane_killed.tmux_pane == split_pane.pane_id
     assert window_killed.tmux_target == window.window_id
     assert session_killed.tmux_target == doomed.session_name
+    assert existing_session_killed.tmux_session == renamed_session
     assert (
         object_extra("kill-session", target="safe\u2028ERROR forged")["tmux_target"]
         == "'safe\\u2028ERROR forged'"
     )
 
 
-def test_all_except_lifecycle_logging(
+def test_direct_kill_lifecycle_logging(
     server: Server,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """The three all-except branches identify the object they preserve."""
+    """Direct kill branches identify the affected or preserved object."""
     from libtmux.test.random import namer
 
     workspace = server.new_session(session_name=f"log_workspace_{next(namer)}")
@@ -272,7 +299,6 @@ def test_all_except_lifecycle_logging(
         "other windows killed",
         lambda: window.kill(all_except=True),
     )
-
     window.resize(height=100, width=100)
     pane = window.split()
     window.split()
@@ -281,6 +307,13 @@ def test_all_except_lifecycle_logging(
         "libtmux.pane",
         "other panes killed",
         lambda: pane.kill(all_except=True),
+    )
+    workspace.new_window(window_name=f"log_spare_{next(namer)}")
+    _, window_killed = _capture_info(
+        caplog,
+        "libtmux.window",
+        "window killed",
+        window.kill,
     )
 
     survivor = server.new_session(session_name=f"log_survivor_{next(namer)}")
@@ -291,22 +324,31 @@ def test_all_except_lifecycle_logging(
         "other sessions killed",
         lambda: survivor.kill(all_except=True),
     )
+    server.new_session(session_name=f"log_spare_{next(namer)}")
+    _, session_killed = _capture_info(
+        caplog,
+        "libtmux.session",
+        "session killed",
+        survivor.kill,
+    )
 
-    assert (
-        windows_killed.tmux_subcommand,
-        windows_killed.tmux_window,
-        windows_killed.tmux_target,
-    ) == ("kill-window", window.window_name, window.window_id)
+    for record in (windows_killed, window_killed):
+        assert (
+            record.tmux_subcommand,
+            record.tmux_window,
+            record.tmux_target,
+        ) == ("kill-window", window.window_name, window.window_id)
     assert (
         panes_killed.tmux_subcommand,
         panes_killed.tmux_pane,
         panes_killed.tmux_target,
     ) == ("kill-pane", pane.pane_id, pane.pane_id)
-    assert (
-        sessions_killed.tmux_subcommand,
-        sessions_killed.tmux_session,
-        sessions_killed.tmux_target,
-    ) == ("kill-session", survivor.session_name, survivor.session_id)
+    for record in (sessions_killed, session_killed):
+        assert (
+            record.tmux_subcommand,
+            record.tmux_session,
+            record.tmux_target,
+        ) == ("kill-session", survivor.session_name, survivor.session_id)
 
 
 def test_server_kill_info_logging(caplog: pytest.LogCaptureFixture) -> None:
@@ -575,28 +617,37 @@ def test_is_alive_unusable_binary_stays_quiet(
     ] == []
 
 
+@pytest.mark.parametrize(
+    ("option_key", "bad_values"),
+    [
+        ("terminal-features", tuple(range(25))),
+        ("command-alias", ("split-pane", "server-info", "choose-tree")),
+    ],
+)
 def test_options_warning_logging_schema(
     caplog: pytest.LogCaptureFixture,
+    option_key: str,
+    bad_values: tuple[str | int, ...],
 ) -> None:
     """Malformed values produce one aggregate warning without traceback data."""
     from libtmux._internal.sparse_array import SparseArray
     from libtmux.options import explode_complex
 
-    bad_features: SparseArray[str | int | bool | None] = SparseArray()
-    for index in range(25):
-        bad_features[index] = index
+    bad_options: SparseArray[str | int] = SparseArray()
+    for index, bad_value in enumerate(bad_values):
+        bad_options[index] = bad_value
 
     with caplog.at_level(logging.WARNING, logger="libtmux.options"):
-        explode_complex({"terminal-features": bad_features})  # type: ignore[dict-item]
+        explode_complex({option_key: bad_options})  # type: ignore[dict-item]
 
     records = [
         record
         for record in caplog.records
-        if getattr(record, "tmux_option_key", None) == "terminal-features"
+        if getattr(record, "tmux_option_key", None) == option_key
     ]
     assert len(records) == 1
     record = t.cast(t.Any, records[0])
-    assert record.tmux_option_skipped == 25
+    assert record.tmux_option_skipped == len(bad_values)
     assert record.exc_info is None
 
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -405,6 +405,38 @@ def test_missing_tmux_binary_logs_before_public_exception(
     assert not hasattr(record, "tmux_exit_code")
 
 
+@pytest.mark.parametrize(
+    "binary_case",
+    ["configured-missing", "default-missing", "invalid-format"],
+)
+def test_is_alive_unusable_binary_stays_quiet(
+    binary_case: str,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A health check converts an unusable executable to a quiet ``False``."""
+    from libtmux.server import Server
+
+    tmux_bin: str | None = str(tmp_path / "missing-tmux")
+    if binary_case == "default-missing":
+        tmux_bin = None
+        monkeypatch.setenv("PATH", "")
+    elif binary_case == "invalid-format":
+        invalid_tmux = tmp_path / "invalid-tmux"
+        invalid_tmux.write_text("not an executable format\n")
+        invalid_tmux.chmod(0o755)
+        tmux_bin = str(invalid_tmux)
+    server = Server(tmux_bin=tmux_bin)
+
+    with caplog.at_level(logging.ERROR, logger="libtmux.common"):
+        assert not server.is_alive()
+
+    assert [
+        record for record in caplog.records if record.levelno == logging.ERROR
+    ] == []
+
+
 def test_options_warning_logging_schema(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -510,6 +542,10 @@ def test_describe_command_reads_tmux_global_flags(
         (["tmux", "select-pane", "-eK=v"], "tmux select-pane -eK=v"),
         (["tmux", "copy-mode", "-e"], "tmux copy-mode -e"),
         (
+            ["tmux", "new-session", "-c/tmp/secret=path"],
+            "tmux new-session -c/tmp/secret=path",
+        ),
+        (
             ["tmux", "set-buffer", "-b", "named", "secret data"],
             "tmux set-buffer -b named REDACTED",
         ),
@@ -527,6 +563,7 @@ def test_describe_command_reads_tmux_global_flags(
         "select-pane-boolean-e",
         "select-pane-joined-boolean-e",
         "copy-mode-boolean-e",
+        "other-option-attached-value",
         "set-buffer-content",
         "setb-content",
         "set-environment-prefix",
@@ -581,6 +618,32 @@ def test_describe_command_redacts_every_environment_spelling() -> None:
         assert separated.command == f"tmux {subcommand} -e KEY=REDACTED"
 
 
+@pytest.mark.parametrize(
+    ("subcommand", "boolean_flags"),
+    (
+        ("new-session", "-d"),
+        ("new-window", "-d"),
+        ("new-pane", "-df"),
+        ("display-popup", "-BE"),
+        ("respawn-pane", "-k"),
+        ("respawn-window", "-k"),
+        ("split-window", "-dP"),
+    ),
+)
+def test_describe_command_redacts_bundled_environment_options(
+    subcommand: str,
+    boolean_flags: str,
+) -> None:
+    """Boolean flags before value-taking ``-e`` cannot expose its value."""
+    from libtmux._internal.log_context import describe_command
+
+    option = f"{boolean_flags}eKEY=secret"
+
+    context = describe_command(["tmux", subcommand, option])
+
+    assert context.command == f"tmux {subcommand} {boolean_flags}eKEY=REDACTED"
+
+
 def test_redact_output_suppresses_sensitive_command_spellings() -> None:
     """Environment, terminal, buffer, and history output stays off records."""
     from libtmux._internal.log_context import redact_output
@@ -598,6 +661,8 @@ def test_redact_output_suppresses_sensitive_command_spellings() -> None:
         "lsb",
         "show-messages",
         "showmsgs",
+        "server-info",
+        "info",
         "show-prompt-history",
         "showphist",
         "show-e",

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -539,3 +539,26 @@ def test_oversized_command_is_capped_in_the_record(
     rec = t.cast(t.Any, records[0])
     assert len(rec.tmux_cmd) <= _COMMAND_CAP
     assert rec.tmux_cmd_len > _COMMAND_CAP
+
+
+def test_environment_values_are_hidden_in_both_directions(
+    session: Session,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Redacting what libtmux sends is half of it; tmux hands the value back."""
+    secret = "s3cr3t-round-trip"
+    server = session.server
+    server.set_environment("DEPLOY_KEY", secret)
+
+    with caplog.at_level(logging.DEBUG, logger="libtmux.common"):
+        value = server.getenv("DEPLOY_KEY")
+
+    assert value == secret, "redaction must not change what the caller gets"
+
+    leaked = [
+        r
+        for r in caplog.records
+        for key in ("tmux_cmd", "tmux_stdout")
+        if secret in str(getattr(r, key, ""))
+    ]
+    assert leaked == [], f"secret reached {len(leaked)} record(s)"

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -6,12 +6,15 @@ import errno
 import logging
 import os
 import pathlib
+import shlex
+import sys
 import typing as t
 from collections.abc import Callable
 
 import pytest
 
 if t.TYPE_CHECKING:
+    from libtmux._internal.control_mode import ControlMode
     from libtmux.server import Server
     from libtmux.session import Session
 
@@ -40,9 +43,9 @@ def test_tmux_cmd_debug_logging_schema(
     session: Session,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Command records expose bounded metadata, never operands or output bodies."""
+    """Command records expose the command and bounded output snapshots."""
     server = session.server
-    marker = "caller-secret"
+    marker = "caller-payload"
 
     with caplog.at_level(logging.DEBUG, logger="libtmux.common"):
         proc = server.cmd("list-sessions", "-F", marker)
@@ -61,15 +64,76 @@ def test_tmux_cmd_debug_logging_schema(
         rec = t.cast(t.Any, record)
         assert rec.tmux_subcommand == "list-sessions"
         assert rec.tmux_socket == server.socket_name
-        assert rec.tmux_cmd.endswith("list-sessions <2 arguments omitted>")
-        assert marker not in rec.tmux_cmd
-        assert not hasattr(rec, "tmux_stdout")
-        assert not hasattr(rec, "tmux_stderr")
+        assert rec.tmux_cmd.endswith(f"list-sessions -F {marker}")
 
+    dispatched = t.cast(t.Any, records[0])
+    assert not hasattr(dispatched, "tmux_stdout")
+    assert not hasattr(dispatched, "tmux_stderr")
     completed = t.cast(t.Any, records[-1])
     assert isinstance(completed.tmux_exit_code, int)
+    assert completed.tmux_stdout == proc.stdout
+    assert completed.tmux_stderr == proc.stderr
     assert completed.tmux_stdout_len == len(proc.stdout)
     assert completed.tmux_stderr_len == 0
+
+
+def test_tmux_cmd_debug_logging_bounds_large_output(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Completion records retain 100 lines and report the full stream lengths."""
+    from libtmux.common import tmux_cmd
+
+    stdout_lines = [f"stdout-{index}-π-\x1b[31m" for index in range(150)]
+    stderr_lines = [f"stderr-{index}-π-\x1b[31m" for index in range(150)]
+    script = (
+        "import sys\n"
+        "for index in range(150):\n"
+        " print(f'stdout-{index}-π-\\x1b[31m')\n"
+        " print(f'stderr-{index}-π-\\x1b[31m', file=sys.stderr)\n"
+    )
+
+    with caplog.at_level(logging.DEBUG, logger="libtmux.common"):
+        proc = tmux_cmd("-c", script, tmux_bin=sys.executable)
+
+    completed = t.cast(
+        t.Any,
+        next(
+            record
+            for record in caplog.records
+            if record.getMessage() == "tmux command completed"
+        ),
+    )
+    assert proc.stdout == stdout_lines
+    assert proc.stderr == stderr_lines
+    assert completed.tmux_stdout == stdout_lines[:100]
+    assert completed.tmux_stderr == stderr_lines[:100]
+    assert completed.tmux_stdout_len == 150
+    assert completed.tmux_stderr_len == 150
+
+
+def test_control_mode_debug_logging_keeps_command_context(
+    control_mode: Callable[[], ControlMode],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Control mode exposes the spawned command and structured target fields."""
+    with (
+        caplog.at_level(logging.DEBUG, logger="libtmux._internal.control_mode"),
+        control_mode() as client,
+    ):
+        target = str(client.session.session_id)
+
+    record = t.cast(
+        t.Any,
+        next(
+            record
+            for record in caplog.records
+            if record.getMessage() == "control mode client started"
+        ),
+    )
+    assert record.tmux_subcommand == "attach-session"
+    assert record.tmux_target == target
+    assert "-C attach-session -t" in record.tmux_cmd
+    assert shlex.split(record.tmux_cmd)[-1] == target
 
 
 def test_lifecycle_info_logging(
@@ -414,7 +478,7 @@ def test_options_warning_logging_schema(
         (
             ["tmux", "-Lsock", "new-session", "-eKEY=secret"],
             {
-                "tmux_cmd": "tmux -L sock new-session <1 arguments omitted>",
+                "tmux_cmd": "tmux -Lsock new-session -eKEY=secret",
                 "tmux_subcommand": "new-session",
                 "tmux_socket": "sock",
             },
@@ -422,7 +486,7 @@ def test_options_warning_logging_schema(
         (
             ["tmux", "-S", "/tmp/s", "set-buffer", "secret"],
             {
-                "tmux_cmd": "tmux -S /tmp/s set-buffer <1 arguments omitted>",
+                "tmux_cmd": "tmux -S /tmp/s set-buffer secret",
                 "tmux_subcommand": "set-buffer",
                 "tmux_socket": "/tmp/s",
             },
@@ -430,14 +494,14 @@ def test_options_warning_logging_schema(
         (
             ["tmux", "-f", "secret-conf", "run-shell", "secret"],
             {
-                "tmux_cmd": "tmux run-shell <1 arguments omitted>",
+                "tmux_cmd": "tmux -f secret-conf run-shell secret",
                 "tmux_subcommand": "run-shell",
             },
         ),
         (
             ["tmux", "-2L", "sock", "list-panes"],
             {
-                "tmux_cmd": "tmux -L sock list-panes",
+                "tmux_cmd": "tmux -2L sock list-panes",
                 "tmux_subcommand": "list-panes",
                 "tmux_socket": "sock",
             },
@@ -445,24 +509,99 @@ def test_options_warning_logging_schema(
         (
             ["tmux", "-L", "safe\nforged", "future-command", "secret"],
             {
-                "tmux_cmd": (
-                    "tmux -L 'safe\\nforged' future-command <1 arguments omitted>"
-                ),
+                "tmux_cmd": "tmux -L 'safe\\nforged' future-command secret",
                 "tmux_subcommand": "future-command",
                 "tmux_socket": "'safe\\nforged'",
             },
         ),
-        (["tmux", "-V"], {"tmux_cmd": "tmux"}),
+        (
+            ["tmux", "-Z", "operand-secret"],
+            {
+                "tmux_cmd": "tmux -Z operand-secret",
+            },
+        ),
+        (
+            ["tmux", "--future-option=value", "list-sessions", "payload"],
+            {
+                "tmux_cmd": "tmux --future-option=value list-sessions payload",
+            },
+        ),
+        (
+            ["tmux", "--", "future-command", "payload"],
+            {
+                "tmux_cmd": "tmux -- future-command payload",
+                "tmux_subcommand": "future-command",
+            },
+        ),
+        (["tmux", "-V"], {"tmux_cmd": "tmux -V"}),
     ],
 )
-def test_command_extra_separates_operation_from_parameters(
+def test_command_extra_preserves_command_and_extracts_context(
     argv: list[str],
     expected: dict[str, str],
 ) -> None:
-    """Operation records identify tmux without carrying parameter data."""
+    """Command records retain argv while deriving optional structured fields."""
     from libtmux._internal.log_context import command_extra
 
     assert command_extra(argv) == expected
+
+
+@pytest.mark.parametrize("flag", tuple("2CDdhlNquUvV"))
+def test_command_extra_parses_boolean_global_flags(flag: str) -> None:
+    """Known boolean flags leave the following token as the subcommand."""
+    from libtmux._internal.log_context import command_extra
+
+    result = command_extra(["tmux", f"-{flag}", "list-sessions"])
+
+    assert result["tmux_subcommand"] == "list-sessions"
+
+
+@pytest.mark.parametrize("flag", tuple("cfLST"))
+@pytest.mark.parametrize("attached", [False, True])
+def test_command_extra_parses_value_global_flags(
+    flag: str,
+    attached: bool,
+) -> None:
+    """Known value flags accept attached and separate values."""
+    from libtmux._internal.log_context import command_extra
+
+    option = f"-{flag}value" if attached else f"-{flag}"
+    argv = ["tmux", option]
+    if not attached:
+        argv.append("value")
+    argv.append("list-sessions")
+
+    result = command_extra(argv)
+
+    assert result["tmux_subcommand"] == "list-sessions"
+    if flag in "LS":
+        assert result["tmux_socket"] == "value"
+
+
+def test_command_extra_preserves_unicode_and_escapes_controls() -> None:
+    """Printable Unicode remains readable and controls cannot forge log lines."""
+    from libtmux._internal.log_context import command_extra
+
+    payload = "snowman ☃ and Ελληνικά"
+    result = command_extra(
+        ["tmux", "set-buffer", payload, "line\nERROR forged", "nul\0byte"]
+    )
+
+    assert payload in result["tmux_cmd"]
+    assert "\n" not in result["tmux_cmd"]
+    assert "\\nERROR forged" in result["tmux_cmd"]
+    assert "\\x00" in result["tmux_cmd"]
+
+
+def test_command_extra_preserves_large_operand() -> None:
+    """Command logging does not truncate a large argv operand."""
+    from libtmux._internal.log_context import command_extra
+
+    payload = "x" * 1_000_000
+    result = command_extra(["tmux", "set-buffer", payload])
+
+    assert result["tmux_cmd"].endswith(payload)
+    assert len(result["tmux_cmd"]) == len(payload) + len("tmux set-buffer ")
 
 
 def test_session_fixture_setup_logs_no_errors(

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -482,19 +482,49 @@ def test_lenient_accessors_log_unusable_tmux_diagnostics(
         assert str(tmux_path) in diagnostic
 
 
-def test_unrelated_tmux_launch_failure_preserves_diagnostics() -> None:
-    """A launch resource failure is not mislabeled as a missing executable."""
+def test_tmux_cmd_unrelated_launch_failure_stays_os_error() -> None:
+    """A direct launch resource failure retains trunk's native exception."""
     from libtmux import exc
     from libtmux.common import tmux_cmd
 
-    with pytest.raises(exc.LibTmuxException) as exc_info:
+    with pytest.raises(OSError) as exc_info:
         tmux_cmd("set-buffer", "x" * os.sysconf("SC_ARG_MAX"))
 
     assert not isinstance(exc_info.value, exc.TmuxCommandNotFound)
-    cause = exc_info.value.__cause__
-    assert isinstance(cause, OSError)
-    assert cause.errno == errno.E2BIG
-    assert str(exc_info.value) == str(cause)
+    assert exc_info.value.errno == errno.E2BIG
+
+
+@pytest.mark.parametrize(
+    ("accessor", "list_cmd"),
+    [
+        ("sessions", "list-sessions"),
+        ("attached_sessions", "list-sessions"),
+        ("clients", "list-clients"),
+    ],
+)
+def test_lenient_accessors_log_unrelated_launch_failure(
+    accessor: str,
+    list_cmd: str,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Lenient list boundaries still swallow a raw launch resource error."""
+    from libtmux.server import Server
+
+    def raise_e2big(*args: object, **kwargs: object) -> None:
+        raise OSError(errno.E2BIG, os.strerror(errno.E2BIG), "/configured/tmux")
+
+    monkeypatch.setattr("libtmux.common.subprocess.Popen", raise_e2big)
+    server = Server(tmux_bin="/configured/tmux")
+    with caplog.at_level(logging.ERROR, logger="libtmux.server"):
+        assert list(getattr(server, accessor)) == []
+
+    records = [record for record in caplog.records if record.levelno == logging.ERROR]
+    assert len(records) == 1
+    record = t.cast(t.Any, records[0])
+    assert record.tmux_subcommand == list_cmd
+    assert record.tmux_stderr_len == 1
+    assert os.strerror(errno.E2BIG) in record.tmux_stderr[0]
 
 
 def test_raise_if_dead_unrelated_launch_failure_stays_os_error() -> None:

--- a/tests/test_pane.py
+++ b/tests/test_pane.py
@@ -1802,7 +1802,10 @@ _NEW_PANE_EMPTY_VALUE_CASES = (
 )
 
 
-def test_new_pane_floating(session: Session) -> None:
+def test_new_pane_floating(
+    session: Session,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Pane.new_pane() creates a floating pane on tmux 3.7+ (else raises)."""
     window = session.new_window(window_name="floating_pane")
     window.resize(height=50, width=200)
@@ -1810,10 +1813,25 @@ def test_new_pane_floating(session: Session) -> None:
     assert pane is not None
 
     if has_gte_version("3.7"):
-        floating = pane.new_pane(width=80, height=15, x=5, y=3, shell="sleep 30")
+        with caplog.at_level(logging.INFO, logger="libtmux.pane"):
+            floating = pane.new_pane(width=80, height=15, x=5, y=3, shell="sleep 30")
         assert floating.pane_floating_flag == "1"
         assert floating.pane_width == "80"
         assert floating.pane_height == "15"
+        records = [
+            record
+            for record in caplog.records
+            if record.name == "libtmux.pane"
+            and record.getMessage() == "floating pane created"
+        ]
+        assert len(records) == 1
+        record = t.cast(t.Any, records[0])
+        assert record.levelno == logging.INFO
+        assert record.tmux_subcommand == "new-pane"
+        assert record.tmux_socket == session.server.socket_name
+        assert record.tmux_session == session.session_name
+        assert record.tmux_window == window.window_name
+        assert record.tmux_pane == floating.pane_id
     else:
         with pytest.raises(exc.LibTmuxException, match=r"new_pane .*requires tmux 3.7"):
             pane.new_pane(width=40, height=10)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1429,7 +1429,8 @@ def test_lenient_list_accessors_log_and_return_empty(
     record = t.cast(t.Any, records[0])
     assert record.tmux_subcommand == list_cmd
     assert record.tmux_socket == server.socket_name
-    assert record.tmux_stderr == ["simulated list failure"]
+    assert record.tmux_stderr_len == 1
+    assert not hasattr(record, "tmux_stderr")
     assert record.funcName == ("clients" if accessor == "clients" else "sessions")
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1399,24 +1399,38 @@ def test_server_search_panes_filter_by_id(server: Server) -> None:
     assert [p.pane_id for p in matches] == [target.pane_id]
 
 
-def test_server_clients_returns_empty_on_tmux_error(
+@pytest.mark.parametrize(
+    ("accessor", "list_cmd"),
+    [
+        ("sessions", "list-sessions"),
+        ("attached_sessions", "list-sessions"),
+        ("clients", "list-clients"),
+    ],
+)
+def test_lenient_list_accessors_log_and_return_empty(
     server: Server,
     monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    accessor: str,
+    list_cmd: str,
 ) -> None:
-    """``Server.clients`` returns an empty QueryList on tmux failure.
-
-    Lenient-by-default contract: ``list-clients`` failing for any reason
-    yields ``QueryList([])``, matching the historic shape of
-    :attr:`Server.sessions`. Callers needing a connectivity check should
-    use :meth:`Server.is_alive` or :meth:`Server.raise_if_dead`.
-    """
-    sentinel = exc.LibTmuxException("simulated list-clients failure")
+    """Lenient list accessors log once where they swallow a tmux failure."""
+    sentinel = exc.LibTmuxException("simulated list failure")
 
     def _boom(**_: object) -> list[dict[str, str]]:
         raise sentinel
 
     monkeypatch.setattr("libtmux.server.fetch_objs", _boom)
-    assert list(server.clients) == []
+    with caplog.at_level(logging.ERROR, logger="libtmux.server"):
+        assert list(getattr(server, accessor)) == []
+
+    records = [record for record in caplog.records if record.levelno == logging.ERROR]
+    assert len(records) == 1
+    record = t.cast(t.Any, records[0])
+    assert record.tmux_subcommand == list_cmd
+    assert record.tmux_socket == server.socket_name
+    assert record.tmux_stderr == ["simulated list failure"]
+    assert record.funcName == ("clients" if accessor == "clients" else "sessions")
 
 
 def test_server_search_sessions_propagates_errors(
@@ -1437,27 +1451,6 @@ def test_server_search_sessions_propagates_errors(
     monkeypatch.setattr("libtmux.server.fetch_objs", _boom)
     with pytest.raises(exc.LibTmuxException, match="simulated list-sessions failure"):
         server.search_sessions(filter="#{m:keep_*,#{session_name}}")
-
-
-def test_server_sessions_returns_empty_on_tmux_error(
-    server: Server,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """``Server.sessions`` returns an empty QueryList on tmux failure.
-
-    Pins the lenient-by-default contract: a ``list-sessions`` failure —
-    daemon down, missing socket, permission error, subprocess crash —
-    yields ``QueryList([])`` rather than propagating. Callers that need
-    to distinguish "no sessions" from "tmux unreachable" should use
-    :meth:`Server.is_alive` or :meth:`Server.raise_if_dead`.
-    """
-    sentinel = exc.LibTmuxException("simulated list-sessions failure")
-
-    def _boom(**_: object) -> list[dict[str, str]]:
-        raise sentinel
-
-    monkeypatch.setattr("libtmux.server.fetch_objs", _boom)
-    assert list(server.sessions) == []
 
 
 def test_server_sessions_missing_socket_returns_empty(tmp_path: pathlib.Path) -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import functools
 import logging
-import os
 import pathlib
 import shutil
 import subprocess
@@ -209,7 +208,7 @@ def test_new_session_shell(server: Server) -> None:
 def test_new_session_shell_env(server: Server) -> None:
     """Verify ``Server.new_session`` creates valid session running w/ command (#553)."""
     cmd = "sleep 1m"
-    env = dict(os.environ)
+    env = {"LIBTMUX_TEST_ENV": "present"}
     mysession = server.new_session(
         "test_new_session_env",
         window_command=cmd,
@@ -220,6 +219,7 @@ def test_new_session_shell_env(server: Server) -> None:
     pane = window.panes[0]
     assert mysession.session_name == "test_new_session_env"
     assert server.has_session("test_new_session_env")
+    assert mysession.getenv("LIBTMUX_TEST_ENV") == "present"
 
     pane_start_command = pane.pane_start_command
     assert pane_start_command is not None

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1415,7 +1415,8 @@ def test_lenient_list_accessors_log_and_return_empty(
     list_cmd: str,
 ) -> None:
     """Lenient list accessors log once where they swallow a tmux failure."""
-    sentinel = exc.LibTmuxException("simulated list failure")
+    stderr = [f"simulated list failure {index}" for index in range(125)]
+    sentinel = exc.LibTmuxException("\n".join(stderr))
 
     def _boom(**_: object) -> list[dict[str, str]]:
         raise sentinel
@@ -1429,8 +1430,8 @@ def test_lenient_list_accessors_log_and_return_empty(
     record = t.cast(t.Any, records[0])
     assert record.tmux_subcommand == list_cmd
     assert record.tmux_socket == server.socket_name
-    assert record.tmux_stderr_len == 1
-    assert not hasattr(record, "tmux_stderr")
+    assert record.tmux_stderr_len == len(stderr)
+    assert record.tmux_stderr == stderr[:100]
     assert record.funcName == ("clients" if accessor == "clients" else "sessions")
 
 


### PR DESCRIPTION
Closes #744.

## Summary

- **Document** how applications enable libtmux logging, interpret levels, read structured `tmux_` fields, assert on records with `caplog`, and select emitted fields through standard-library handlers and formatters.
- **Standardize** command and object lifecycle context with consistent, optional socket, subcommand, target, session, window, and pane fields.
- **Define** failure ownership: propagated failures stay in exceptions, expected probes remain quiet, and lenient server-list accessors emit one `ERROR` when they return an empty result.
- **Normalize** missing, non-executable, and malformed tmux binaries to `TmuxCommandNotFound` while preserving operating-system diagnostics; unrelated launch failures remain native.
- **Aggregate** recoverable option-parsing warnings and add structured control-mode and hook diagnostics.

## Changes by area

### Command and lifecycle records

- **Command execution:** `tmux_cmd` produces dispatch and completion records with a complete one-line argv, best-effort subcommand and socket context, exit status, bounded output snapshots, and total line counts.
- **Object lifecycle:** Server, session, window, and pane operations use a shared string-valued schema for affected objects and targets.
- **Control characters:** Caller-provided identity and command values use escaped representations so they cannot create additional rendered log lines.
- **Control mode:** Client startup and forced termination carry the same command context as normal tmux subprocess records.

### Failure handling

- **Propagated failures:** Direct and translated failures remain exception data instead of being logged and re-raised.
- **Lenient accessors:** `Server.sessions`, `Server.attached_sessions`, and `Server.clients` retain their empty-result contract and emit one bounded diagnostic where the failure is swallowed.
- **Health checks:** `Server.is_alive()` remains quiet, while `Server.raise_if_dead()` retains loud failure semantics.
- **Executable launches:** `TmuxCommandNotFound` preserves the operating-system message and cause when execution was attempted; unrelated resource errors remain `OSError`.

### Recoverable diagnostics

- **Option parsing:** Malformed `terminal-features`, `terminal-overrides`, and `command-alias` entries produce one aggregate warning per option with the skipped-entry count.
- **Hooks and lookups:** Parse and lookup diagnostics use structured context without duplicate traceback output.
- **Session lifecycle:** `Server.kill_session()` emits the same lifecycle schema as object-level session operations.

### Documentation

- **Logging guide:** The new topic documents logger ownership, levels, structured fields, failure routing, payload policy, handler filtering, formatter defaults, and `caplog` assertions.
- **Executable examples:** Documentation examples run through the repository doctest environment, including the `caplog` fixture.
- **Changelog:** The unreleased notes describe the failure-channel and executable-exception changes, structured records, aggregate warnings, and logging guide.

## Design decisions

- **Applications own payload policy:** `DEBUG` records retain complete command operands and bounded output snapshots. libtmux does not guess which values are secrets; handlers and formatters decide which fields reach each destination.
- **Derived fields are best effort:** The complete command remains authoritative. Subcommand and socket extraction stops at unknown global options instead of inventing context.
- **Exceptions and logs have separate owners:** A failure is logged only where libtmux converts it to a fallback result. Callers own logging for failures they receive as exceptions.

## Verification

```console
$ uv run ruff format . --check
```

```console
$ uv run ruff check .
```

```console
$ uv run mypy
```

```console
$ uv run pytest --reruns=0
```

```console
$ just build-docs
```

## Test plan

- [x] Verify command dispatch and completion schemas, output bounds, Unicode, control-character escaping, unknown global options, and complete large operands.
- [x] Verify server, session, window, pane, floating-pane, replacement, and all-except lifecycle records against live tmux.
- [x] Verify swallowed list failures log once while propagated failures and health checks do not emit duplicate errors.
- [x] Verify missing, inaccessible, malformed, and resource-exhausted executable paths preserve the intended exception types and diagnostics.
- [x] Verify logging records remain isolated across threaded and async command execution.
- [x] Execute the logging guide as doctests and build the Sphinx documentation.
- [x] Show the output-bound regression test failing under a deliberate cap change and passing after restoration.
- [x] Exercise the logging suite across supported Python versions and the CI matrix across supported tmux releases.
- [ ] Add committed coverage for every aggregate-warning family, blank hook output, and forced control-mode termination.
